### PR TITLE
fix(mpd): przywróć linki do karty produktu na liście admina

### DIFF
--- a/src/apps/MPD/admin.py
+++ b/src/apps/MPD/admin.py
@@ -193,6 +193,7 @@ class ProductsAdmin(admin.ModelAdmin):
         'product_image_thumbnail', 'id', 'name', 'description',
         'brand', 'collection', 'season', 'updated_at', 'visibility', 'open_in_react',
     ]
+    list_display_links = ['id', 'name']
     list_filter = [
         'brand',
         'collection',


### PR DESCRIPTION
Miniatura była pierwszą kolumną list_display, więc Django robił z niej link do change — klik otwierał zdjęcie zamiast produktu.