### PR TITLE
fix(deps): bump pillow, Mako, tornado, soupsieve for Dependabot

### DIFF
--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -54,7 +54,7 @@ jsonschema==4.24.0
 jsonschema-specifications==2025.4.1
 kombu==5.4.2
 lxml==6.0.0
-Mako==1.3.10
+Mako==1.3.12
 MarkupSafe==3.0.2
 mcp==1.10.1
 more-itertools==10.7.0
@@ -64,7 +64,7 @@ openai-agents==0.1.0
 outcome==1.3.0.post0
 packaging==24.2
 parso==0.8.4
-pillow==11.1.0
+pillow==12.3.0
 platformdirs==4.3.8
 prometheus_client==0.21.1
 prompt_toolkit==3.0.50
@@ -94,10 +94,10 @@ selenium==4.39.0
 six==1.17.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
-soupsieve==2.7
+soupsieve==2.8.4
 sqlparse==0.5.3
 text-unidecode==1.3
-tornado==6.4.2
+tornado==6.5.7
 tqdm==4.67.1
 traitlets==5.14.3
 trio==0.32.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -54,7 +54,7 @@ jsonschema==4.24.0
 jsonschema-specifications==2025.4.1
 kombu==5.4.2
 lxml==6.0.0
-Mako==1.3.10
+Mako==1.3.12
 MarkupSafe==3.0.2
 mcp==1.10.1
 more-itertools==10.7.0
@@ -64,7 +64,7 @@ openai-agents==0.1.0
 outcome==1.3.0.post0
 packaging==24.2
 parso==0.8.4
-pillow==11.1.0
+pillow==12.3.0
 platformdirs==4.3.8
 prometheus_client==0.21.1
 prompt_toolkit==3.0.50
@@ -94,10 +94,10 @@ selenium==4.39.0
 six==1.17.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
-soupsieve==2.7
+soupsieve==2.8.4
 sqlparse==0.5.3
 text-unidecode==1.3
-tornado==6.4.2
+tornado==6.5.7
 tqdm==4.67.1
 traitlets==5.14.3
 trio==0.32.0


### PR DESCRIPTION
Upgrade to patched versions addressing high-severity advisories in requirements.txt and requirements.ci.txt.