### PR TITLE
fix(deps): bump mcp and override fast-uri for Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3291,9 +3291,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "overrides": {
     "glob": "$glob",
+    "fast-uri": ">=3.1.1",
     "@semantic-release/npm": {
       "npm": "11.12.1"
     }

--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -56,7 +56,7 @@ kombu==5.4.2
 lxml==6.0.0
 Mako==1.3.12
 MarkupSafe==3.0.2
-mcp==1.10.1
+mcp==1.28.1
 more-itertools==10.7.0
 nest-asyncio==1.6.0
 openai==1.93.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -56,7 +56,7 @@ kombu==5.4.2
 lxml==6.0.0
 Mako==1.3.12
 MarkupSafe==3.0.2
-mcp==1.10.1
+mcp==1.28.1
 more-itertools==10.7.0
 nest-asyncio==1.6.0
 openai==1.93.0


### PR DESCRIPTION
Upgrade mcp to 1.28.1 (DNS rebinding protection) and force fast-uri >=3.1.1 via npm overrides. soupsieve/Mako already on patched versions from the previous bump.