### PR TITLE
fix(deps): bump openai to 2.46.0 for langchain-openai

### DIFF
--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -59,7 +59,7 @@ MarkupSafe==3.0.2
 mcp==1.28.1
 more-itertools==10.7.0
 nest-asyncio==1.6.0
-openai==1.93.0
+openai==2.46.0
 openai-agents==0.1.0
 outcome==1.3.0.post0
 packaging==24.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -59,7 +59,7 @@ MarkupSafe==3.0.2
 mcp==1.28.1
 more-itertools==10.7.0
 nest-asyncio==1.6.0
-openai==1.93.0
+openai==2.46.0
 openai-agents==0.1.0
 outcome==1.3.0.post0
 packaging==24.2


### PR DESCRIPTION
## Summary
- ``openai`` 1.93.0 → **2.46.0** — ``langchain-openai==1.1.14`` wymaga ``openai>=2.26,<3``
- Odblokowuje ``pip install -r requirements.txt`` na deploy VPS

## Test plan
- [ ] Docker/VPS ``pip install -r requirements.txt`` przechodzi
- [ ] CI requirements.ci.txt przechodzi