### PR TITLE
fix(settings): import _strip_env_value in prod.py

### DIFF
--- a/src/core/settings/prod.py
+++ b/src/core/settings/prod.py
@@ -1,5 +1,6 @@
 import os
 from .base import *
+from .base import _strip_env_value
 
 # Produkcja używa baz bez przedrostka zzz_ (zdefiniowanych w base.py)
 # Development (dev.py) nadpisuje je na wersje z zzz_


### PR DESCRIPTION
## Summary
- `from .base import *` nie importuje nazw z podkreślnikiem
- Explicit import naprawia NameError przy collectstatic w Docker/prod

## Test plan
- [ ] Import core.settings.prod OK
- [ ] Deploy VPS collectstatic przechodzi

Made with [Cursor](https://cursor.com)