### PR TITLE
fix(security): address CodeQL code scanning alerts

### DIFF
--- a/src/apps/MPD/admin.py
+++ b/src/apps/MPD/admin.py
@@ -109,7 +109,7 @@ def admin_update_producer_code(request):
         return JsonResponse({'status': 'error', 'message': 'Nieprawidłowy format JSON'}, status=400)
     except Exception as e:
         logger.error(f"Błąd podczas aktualizacji kodu producenta: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)
 
 
 # Dodaj URL do admina

--- a/src/apps/MPD/api_views.py
+++ b/src/apps/MPD/api_views.py
@@ -266,7 +266,7 @@ class MPDProductDetailAPI(APIView):
             return Response(
                 {
                     'status': 'error',
-                    'message': f'Nie udało się usunąć produktu: {exc}',
+                    'message': 'Nie udało się usunąć produktu.',
                 },
                 status=500,
             )

--- a/src/apps/MPD/views.py
+++ b/src/apps/MPD/views.py
@@ -104,7 +104,7 @@ def test_connection(request):
                 'permissions': permissions
             })
     except Exception as e:
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
 def test_table_structure(request):
@@ -138,7 +138,7 @@ def test_table_structure(request):
                 ]
             })
     except Exception as e:
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
 class ProductSetViewSet(viewsets.ModelViewSet):
@@ -200,9 +200,9 @@ def export_xml(request, source_name):
             return JsonResponse({'status': 'success', 'url': result['bucket_url']})
         return JsonResponse({'status': 'error', 'message': 'Nie udało się wygenerować pliku XML'}, status=500)
     except ValueError as e:
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=404)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=404)
     except Exception as e:
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
 def export_full_xml(request):
@@ -251,7 +251,7 @@ def get_xml_file(request, xml_type):
         else:
             return JsonResponse({'status': 'error', 'message': 'Nie znaleziono pliku XML'}, status=404)
     except Exception as e:
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
 def get_gateway_xml(request):
@@ -271,7 +271,7 @@ def get_gateway_xml(request):
         else:
             return JsonResponse({'status': 'error', 'message': 'Nie znaleziono pliku XML'}, status=404)
     except Exception as e:
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
 def update_all_gateways():
@@ -932,7 +932,7 @@ def create_product(request):
         return JsonResponse({'status': 'error', 'message': 'Nieprawidłowy format JSON'}, status=400)
     except Exception as e:
         logger.error(f"Błąd podczas tworzenia produktu MPD: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)
 
 
 @csrf_exempt
@@ -1051,7 +1051,7 @@ def update_product(request, product_id):
         return JsonResponse({'status': 'error', 'message': 'Nieprawidłowy format JSON'}, status=400)
     except Exception as e:
         logger.error(f"Błąd podczas aktualizacji produktu MPD: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)
 
 
 @csrf_exempt
@@ -1255,7 +1255,7 @@ def get_product(request, product_id):
 
     except Exception as e:
         logger.error(f"Błąd podczas pobierania produktu MPD: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)
 
 
 @csrf_exempt
@@ -1361,7 +1361,7 @@ def update_product_retail_prices(request, product_id):
     except Exception as e:
         logger.error('Błąd zapisu cen detalicznych: %s', e)
         return JsonResponse(
-            {'status': 'error', 'message': f'Błąd serwera: {str(e)}'},
+            {'status': 'error', 'message': 'Błąd serwera'},
             status=500,
         )
 
@@ -1466,7 +1466,13 @@ def bulk_create_products(request):
 
             except Exception as e:
                 errors.append(
-                    f"Błąd tworzenia produktu {product_data.get('name', 'Unknown')}: {str(e)}")
+                    f"Błąd tworzenia produktu {product_data.get('name', 'Unknown')}"
+                )
+                logger.error(
+                    "Błąd tworzenia produktu %s: %s",
+                    product_data.get('name', 'Unknown'),
+                    str(e),
+                )
                 continue
 
         logger.info("🏁 MPD bulk_create_products: Zakończono przetwarzanie")
@@ -1486,7 +1492,7 @@ def bulk_create_products(request):
 
     except Exception as e:
         logger.error(f"❌ MPD bulk_create_products: Błąd: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
 def bulk_map_from_matterhorn1(request):
@@ -1622,7 +1628,7 @@ def bulk_map_from_matterhorn1(request):
 
                 except Exception as e:
                     errors.append({
-                        'error': f'Błąd podczas tworzenia produktu: {str(e)}',
+                        'error': 'Błąd podczas tworzenia produktu',
                         'data': product_data
                     })
                     logger.error(f"Błąd podczas mapowania produktu: {str(e)}")
@@ -1644,7 +1650,7 @@ def bulk_map_from_matterhorn1(request):
         return JsonResponse({'status': 'error', 'message': 'Nieprawidłowy format JSON'}, status=400)
     except Exception as e:
         logger.error(f"Błąd podczas bulk mapowania produktów: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)
 
 
 @csrf_exempt
@@ -1739,7 +1745,7 @@ def get_matterhorn1_products(request):
     except Exception as e:
         logger.error(
             f"Błąd podczas pobierania produktów matterhorn1: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)
 
 
 @csrf_exempt
@@ -1783,4 +1789,4 @@ def update_producer_code(request):
         return JsonResponse({'status': 'error', 'message': 'Nieprawidłowy format JSON'}, status=400)
     except Exception as e:
         logger.error(f"Błąd podczas aktualizacji kodu producenta: {str(e)}")
-        return JsonResponse({'status': 'error', 'message': f'Błąd serwera: {str(e)}'}, status=500)
+        return JsonResponse({'status': 'error', 'message': 'Błąd serwera'}, status=500)

--- a/src/apps/MPD/views_secure.py
+++ b/src/apps/MPD/views_secure.py
@@ -35,7 +35,7 @@ class GenerateFullXMLSecure(APIView):
             return Response(
                 {
                     'status': 'error',
-                    'message': f'Błąd podczas generowania pełnego XML: {exc}',
+                    'message': 'Błąd podczas generowania pełnego XML',
                 },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )

--- a/src/apps/matterhorn1/admin.py
+++ b/src/apps/matterhorn1/admin.py
@@ -10,6 +10,7 @@ from django.urls import path
 from django.utils.html import format_html
 import json
 import logging
+from urllib.parse import urlparse
 import requests
 from rapidfuzz import fuzz
 from .models import (
@@ -264,12 +265,16 @@ class ProductAdmin(admin.ModelAdmin):
             display_url = normalized_url
         elif normalized_url.startswith('//'):
             display_url = f"https:{normalized_url}"
-        elif normalized_url.startswith('matterhorn-wholesale.com/'):
-            display_url = f"https://{normalized_url}"
         elif normalized_url.startswith(storage_prefixes):
             display_url = resolve_image_url(normalized_url) or normalized_url
         else:
-            display_url = f"https://matterhorn-wholesale.com/{normalized_url.lstrip('/')}"
+            # Hostname przez urlparse (nie substring) — py/incomplete-url-substring-sanitization
+            candidate = normalized_url if '://' in normalized_url else f'https://{normalized_url.lstrip("/")}'
+            host = (urlparse(candidate).hostname or '').lower()
+            if host == 'matterhorn-wholesale.com' or host.endswith('.matterhorn-wholesale.com'):
+                display_url = candidate if candidate.startswith('http') else f'https://{normalized_url.lstrip("/")}'
+            else:
+                display_url = f"https://matterhorn-wholesale.com/{normalized_url.lstrip('/')}"
 
         return format_html(
             '<a href="{}" target="_blank" title="{}">'
@@ -770,7 +775,7 @@ class ProductAdmin(admin.ModelAdmin):
 
             except Exception as e:
                 logger.error("Błąd podczas tworzenia produktu MPD: %s", e)
-                return JsonResponse({'success': False, 'error': str(e)})
+                return JsonResponse({'success': False, 'error': 'Wystąpił błąd'})
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
 
@@ -882,7 +887,7 @@ class ProductAdmin(admin.ModelAdmin):
 
             except Exception as e:
                 logger.error("Błąd podczas aktualizacji produktu MPD: %s", e)
-                return JsonResponse({'success': False, 'error': str(e)})
+                return JsonResponse({'success': False, 'error': 'Wystąpił błąd'})
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
 
@@ -980,7 +985,7 @@ class ProductAdmin(admin.ModelAdmin):
 
             except Exception as e:
                 logger.error("Błąd podczas przypisywania mapowania: %s", e)
-                return JsonResponse({'success': False, 'error': str(e)})
+                return JsonResponse({'success': False, 'error': 'Wystąpił błąd'})
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
 
@@ -1023,7 +1028,7 @@ class ProductAdmin(admin.ModelAdmin):
 
             except Exception as e:
                 logger.error("Błąd podczas aktualizacji pola MPD: %s", e)
-                return JsonResponse({'success': False, 'error': str(e)})
+                return JsonResponse({'success': False, 'error': 'Wystąpił błąd'})
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
 
@@ -1153,7 +1158,7 @@ class ProductAdmin(admin.ModelAdmin):
             except Exception as e:
                 return JsonResponse({
                     'success': False,
-                    'error': str(e)
+                    'error': 'Wystąpił błąd'
                 })
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
@@ -1208,7 +1213,7 @@ class ProductAdmin(admin.ModelAdmin):
             except Exception as e:
                 return JsonResponse({
                     'success': False,
-                    'error': str(e)
+                    'error': 'Wystąpił błąd'
                 })
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
@@ -1256,7 +1261,7 @@ class ProductAdmin(admin.ModelAdmin):
             except Exception as e:
                 return JsonResponse({
                     'success': False,
-                    'error': str(e)
+                    'error': 'Wystąpił błąd'
                 })
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
@@ -1284,7 +1289,7 @@ class ProductAdmin(admin.ModelAdmin):
             except Exception as e:
                 return JsonResponse({
                     'success': False,
-                    'error': str(e)
+                    'error': 'Wystąpił błąd'
                 })
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
@@ -1323,7 +1328,7 @@ class ProductAdmin(admin.ModelAdmin):
             except Exception as e:
                 return JsonResponse({
                     'success': False,
-                    'error': str(e)
+                    'error': 'Wystąpił błąd'
                 })
 
         return JsonResponse({'success': False, 'error': 'Nieprawidłowa metoda'})
@@ -1775,7 +1780,7 @@ class ProductAdmin(admin.ModelAdmin):
         except Exception as e:
             logger.error(
                 f"Błąd dodawania wariantów dla produktu {product_id}: {e}")
-            return JsonResponse({'success': False, 'error': str(e)})
+            return JsonResponse({'success': False, 'error': 'Wystąpił błąd'})
 
 
 @admin.register(ProductDetails)

--- a/src/apps/matterhorn1/views.py
+++ b/src/apps/matterhorn1/views.py
@@ -221,7 +221,7 @@ class ProductBulkCreateView(ProductBulkView):
             logger.error(f"Błąd w ProductBulkCreateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -340,7 +340,7 @@ class ProductBulkUpdateView(ProductBulkView):
             logger.error(f"Błąd w ProductBulkUpdateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -457,7 +457,7 @@ class VariantBulkCreateView(View):
             logger.error(f"Błąd w VariantBulkCreateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -566,7 +566,7 @@ class VariantBulkUpdateView(View):
             logger.error(f"Błąd w VariantBulkUpdateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -663,7 +663,7 @@ class BrandBulkCreateView(View):
             logger.error(f"Błąd w BrandBulkCreateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -760,7 +760,7 @@ class CategoryBulkCreateView(View):
             logger.error(f"Błąd w CategoryBulkCreateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -875,7 +875,7 @@ class ImageBulkCreateView(View):
             logger.error(f"Błąd w ImageBulkCreateView: {str(e)}")
             return JsonResponse({
                 'success': False,
-                'error': f'Błąd serwera: {str(e)}'
+                'error': 'Błąd serwera'
             }, status=500)
 
 
@@ -1039,5 +1039,5 @@ def get_product_details(request, product_id):
         logger.error(f"Błąd podczas pobierania produktu: {str(e)}")
         return JsonResponse({
             'success': False,
-            'error': f'Błąd serwera: {str(e)}'
+            'error': 'Błąd serwera'
         }, status=500)

--- a/src/apps/matterhorn1/views_secure.py
+++ b/src/apps/matterhorn1/views_secure.py
@@ -96,7 +96,7 @@ class ProductBulkCreateAPI(BulkThrottleMixin, APIView):
                     errors.append(
                         {
                             'product_id': product_data.get('product_id', 'unknown'),
-                            'errors': [str(exc)],
+                            'errors': ['Błąd przetwarzania rekordu'],
                         }
                     )
 
@@ -196,7 +196,7 @@ class ProductBulkUpdateAPI(BulkThrottleMixin, APIView):
                     errors.append(
                         {
                             'product_id': product_id,
-                            'errors': [str(exc)],
+                            'errors': ['Błąd przetwarzania rekordu'],
                         }
                     )
 
@@ -295,7 +295,7 @@ class VariantBulkCreateAPI(BulkThrottleMixin, APIView):
                     errors.append(
                         {
                             'variant_uid': variant_data.get('variant_uid', 'unknown'),
-                            'errors': [str(exc)],
+                            'errors': ['Błąd przetwarzania rekordu'],
                         }
                     )
 
@@ -392,7 +392,7 @@ class VariantBulkUpdateAPI(BulkThrottleMixin, APIView):
                     errors.append(
                         {
                             'variant_uid': variant_uid,
-                            'errors': [str(exc)],
+                            'errors': ['Błąd przetwarzania rekordu'],
                         }
                     )
 
@@ -619,7 +619,7 @@ class ImageBulkCreateAPI(BulkThrottleMixin, APIView):
                     errors.append(
                         {
                             'image_url': resolve_image_url(image_data.get('image_url')) or image_data.get('image_url', 'unknown'),
-                            'errors': [str(exc)],
+                            'errors': ['Błąd przetwarzania rekordu'],
                         }
                     )
 

--- a/src/apps/tabu/admin.py
+++ b/src/apps/tabu/admin.py
@@ -415,7 +415,7 @@ class TabuProductAdmin(admin.ModelAdmin):
                     logger.info("Wynik dodawania wariantów Tabu→MPD: %s", mapping_info)
                 except Exception as e:
                     logger.exception("Błąd podczas dodawania wariantów Tabu→MPD: %s", e)
-                    mapping_info = {'error': str(e)}
+                    mapping_info = {'error': 'Wystąpił błąd'}
 
             # Upload zdjęć do bucketa i MPD (jak w Matterhorn1)
             try:
@@ -443,7 +443,7 @@ class TabuProductAdmin(admin.ModelAdmin):
             })
         except Exception as e:
             logger.exception("Błąd assign_mapping Tabu: %s", e)
-            return JsonResponse({'success': False, 'error': str(e)}, status=500)
+            return JsonResponse({'success': False, 'error': 'Wystąpił błąd'}, status=500)
 
     def image_preview(self, obj):
         if obj and obj.image_url:

--- a/src/apps/web_agent/automation/browser_automation.py
+++ b/src/apps/web_agent/automation/browser_automation.py
@@ -3864,7 +3864,8 @@ class BrowserAutomation:
             # Wzorzec 2: Materiał XX % (bez HTML tagów)
             # Najpierw usuń tagi HTML
             text_content = re.sub(r'<[^>]+>', ' ', html_content)
-            pattern2 = r'([A-ZĄĆĘŁŃÓŚŹŻ][a-ząćęłńóśźż]+(?:[a-ząćęłńóśźż]+)*)\s+(\d+)\s*%'
+            # Bez zagnieżdżonego kwantyfikatora (ReDoS / py/redos)
+            pattern2 = r'([A-ZĄĆĘŁŃÓŚŹŻ][a-ząćęłńóśźż]+)\s+(\d+)\s*%'
             matches2 = re.findall(pattern2, text_content)
 
             # Słowa do pominięcia (nie są materiałami)

--- a/src/apps/web_agent/views.py
+++ b/src/apps/web_agent/views.py
@@ -110,7 +110,7 @@ class AutomationRunViewSet(viewsets.ModelViewSet):
             logger.error(f"Błąd podczas uruchamiania automatyzacji: {e}")
             return Response({
                 'status': 'error',
-                'message': str(e)
+                'message': 'Wystąpił błąd'
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     
     @action(detail=True, methods=['get'], url_path='logs')

--- a/src/core/mpd_spa.py
+++ b/src/core/mpd_spa.py
@@ -6,7 +6,9 @@ import mimetypes
 from pathlib import Path
 
 from django.conf import settings
+from django.core.exceptions import SuspiciousFileOperation
 from django.http import FileResponse, Http404, HttpResponse
+from django.utils._os import safe_join
 
 
 def mpd_spa(request, path: str = ''):
@@ -21,15 +23,15 @@ def mpd_spa(request, path: str = ''):
     relative = (path or '').lstrip('/')
 
     if relative:
-        candidate = (root / relative).resolve()
         try:
-            candidate.relative_to(root_resolved)
-        except ValueError as exc:
+            # safe_join blokuje path traversal (.., absolutne ścieżki)
+            filepath = Path(safe_join(str(root_resolved), relative))
+        except SuspiciousFileOperation as exc:
             raise Http404 from exc
-        if candidate.is_file():
-            content_type, _ = mimetypes.guess_type(str(candidate))
+        if filepath.is_file():
+            content_type, _ = mimetypes.guess_type(str(filepath))
             return FileResponse(
-                candidate.open('rb'),
+                filepath.open('rb'),
                 content_type=content_type or 'application/octet-stream',
             )
 


### PR DESCRIPTION
## Summary
- **high** `py/path-injection` — `safe_join` w `mpd_spa.py`
- **high** `py/redos` — uproszczenie regex w `browser_automation.py`
- **high** `py/incomplete-url-substring-sanitization` — `urlparse` hostname w admin matterhorn1
- **medium** `py/stack-trace-exposure` — generyczne komunikaty w JSON (logi zostaja ze szczegolami)

Pozostaje: `actions/missing-workflow-permissions` (9) — osobny PR do workflow.

## Test plan
- [ ] SPA /mpd-app serwuje pliki, path traversal 404
- [ ] Miniatury matterhorn w adminie
- [ ] Po rescan CodeQL high alerts znikaja

Made with [Cursor](https://cursor.com)