### PR TITLE
fix(security): clear remaining CodeQL alerts

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -10,6 +10,10 @@ concurrency:
   group: check-branch-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   changes:
     name: Wykryj zmienione ścieżki

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -11,6 +11,9 @@ on:
       - 'scripts/k8s-test/**'
       - 'src/**'
 
+permissions:
+  contents: read
+
 jobs:
   deploy-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -17,6 +17,9 @@ on:
         default: 'main'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
   #   branches: [ main ]
   workflow_dispatch:  # Tylko ręczne uruchomienie (jeśli potrzebne)
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/src/apps/matterhorn1/admin.py
+++ b/src/apps/matterhorn1/admin.py
@@ -957,7 +957,7 @@ class ProductAdmin(admin.ModelAdmin):
                             f"Wynik dodawania wariantów: {mapping_info}")
                     except Exception as e:
                         logger.error(f"Błąd podczas dodawania wariantów: {e}")
-                        mapping_info = {'error': f'Błąd wariantów: {str(e)}'}
+                        mapping_info = {'error': 'Błąd mapowania wariantów'}
 
                     # Upload zdjęć do bucketa
                     try:
@@ -970,7 +970,7 @@ class ProductAdmin(admin.ModelAdmin):
                             'uploaded_images', 0)
                     except Exception as e:
                         logger.error(f"Błąd podczas uploadu zdjęć: {e}")
-                        mapping_info['upload_error'] = str(e)
+                        mapping_info['upload_error'] = 'Błąd uploadu zdjęć'
 
                     # Task linkowania uruchamiany przez sygnał MPD (ProductvariantsSources post_save)
                 else:
@@ -1147,7 +1147,11 @@ class ProductAdmin(admin.ModelAdmin):
 
                         except Exception as e:
                             errors.append(
-                                f"Błąd mapowania produktu {product_id}: {str(e)}")
+                                f"Błąd mapowania produktu {product_id}"
+                            )
+                            logger.error(
+                                "Błąd mapowania produktu %s: %s", product_id, e
+                            )
 
                 return JsonResponse({
                     'success': True,

--- a/src/apps/tabu/admin.py
+++ b/src/apps/tabu/admin.py
@@ -361,7 +361,16 @@ class TabuProductAdmin(admin.ModelAdmin):
                 'mpd_product_id': result['mpd_product_id'],
             })
         status_code = 404 if (result.get('error_message') or '').find('nie istnieje') >= 0 else 400
-        return JsonResponse({'success': False, 'error': result['error_message']}, status=status_code)
+        # Tylko znane komunikaty biznesowe — bez surowych wyjątków (py/stack-trace-exposure)
+        err = result.get('error_message') or ''
+        safe = {
+            'Produkt Tabu nie istnieje',
+            'Produkt jest już zmapowany do MPD',
+            'Saga zakończona kompensacją',
+        }
+        if err not in safe:
+            err = 'Nie udało się utworzyć produktu w MPD'
+        return JsonResponse({'success': False, 'error': err}, status=status_code)
 
     @method_decorator(csrf_exempt)
     @method_decorator(require_http_methods(["POST"]))
@@ -428,7 +437,7 @@ class TabuProductAdmin(admin.ModelAdmin):
                 logger.info("Wynik uploadu zdjęć Tabu→MPD: %s", upload_result)
             except Exception as e:
                 logger.exception("Błąd podczas uploadu zdjęć Tabu→MPD: %s", e)
-                mapping_info['upload_error'] = str(e)
+                mapping_info['upload_error'] = 'Błąd uploadu zdjęć'
 
             if not size_category and not mapping_info.get('error'):
                 mapping_info['error'] = 'Brak kategorii rozmiarowej w MPD (produkt bez wariantów z rozmiarem?).'

--- a/src/apps/tabu/services.py
+++ b/src/apps/tabu/services.py
@@ -389,7 +389,7 @@ def create_mpd_product_from_tabu(
         return {
             'success': False,
             'mpd_product_id': None,
-            'error_message': str(e),
+            'error_message': 'Nie udało się utworzyć produktu w MPD',
         }
 
 


### PR DESCRIPTION
## Summary
- Domknięcie `py/stack-trace-exposure` (mapping_info / error_message)
- `permissions: contents: read` (+ pull-requests w check-branch) — 9 alertów Actions

## Test plan
- [ ] Po merge Code Scanning open ~0
- [ ] check-branch nadal działa (paths-filter)
- [ ] test_saga_compensation nadal OK (serwis zwraca result.error)

Made with [Cursor](https://cursor.com)