### PR TITLE
feat(mpd): grupuj zdjęcia według koloru w mpd-app

### DIFF
--- a/frontend/mpd/src/pages/ProductDetailPage.css
+++ b/frontend/mpd/src/pages/ProductDetailPage.css
@@ -254,6 +254,32 @@
   gap: 0.75rem;
 }
 
+.image-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.image-group__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0 0 0.65rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.image-group__badge {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #667eea;
+  background: #eef0ff;
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+}
+
 .image-gallery__item {
   display: block;
   border: 1px solid #eee;

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -465,9 +465,7 @@ export function ProductDetailPage() {
                         <span className="muted">—</span>
                       )}
                     </td>
-                    <td>
-                      {variant.producer_color_name || <span className="muted">—</span>}
-                    </td>
+                    <td>{variant.producer_color_name || <span className="muted">—</span>}</td>
                     <td>{variant.size_name || <span className="muted">—</span>}</td>
                     <td>{variant.stock ?? <span className="muted">0</span>}</td>
                     <td>

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { deleteProduct, fetchProduct, updateProduct } from '../api/mpd';
 import { ProductExtrasPanels } from '../components/ProductExtrasPanels';
 import type { MpdProductDetail, MpdProductUpdatePayload } from '../types/mpd';
+import { groupImagesByColor } from '../utils/groupImagesByColor';
 import '../components/Layout.css';
 import './ProductDetailPage.css';
 
@@ -118,6 +119,14 @@ export function ProductDetailPage() {
       setSaveError('Nie udało się usunąć produktu.');
     },
   });
+
+  const imageGroups = useMemo(() => {
+    const product = data?.product;
+    if (!product?.images?.length) {
+      return [];
+    }
+    return groupImagesByColor(product.images, product.variants ?? []);
+  }, [data?.product]);
 
   if (!Number.isFinite(productId) || productId <= 0) {
     return (
@@ -353,34 +362,47 @@ export function ProductDetailPage() {
         {product.images.length > 0 && (
           <div className="page-card product-detail__images">
             <h3 className="section-title">Zdjęcia</h3>
-            <div className="image-gallery">
-              {product.images.map(img => (
-                <a
-                  key={img.id}
-                  href={img.image_url || undefined}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="image-gallery__item"
-                >
-                  {img.image_url ? (
-                    <img
-                      src={img.image_url}
-                      alt={`Produkt ${product.id}`}
-                      loading="lazy"
-                      decoding="async"
-                      width={120}
-                      height={120}
-                      onError={e => {
-                        const el = e.currentTarget;
-                        el.onerror = null;
-                        el.src =
-                          'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgZmlsbD0iI2VlZSIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTkiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIj5icmFrIHpkajwvdGV4dD48L3N2Zz4=';
-                      }}
-                    />
-                  ) : (
-                    <span className="image-gallery__fallback">Brak URL</span>
-                  )}
-                </a>
+            <div className="image-groups">
+              {imageGroups.map(group => (
+                <div key={group.key} className="image-group">
+                  <h4 className="image-group__title">
+                    {group.label}
+                    {group.kind === 'producer' && (
+                      <span className="image-group__badge">kolor producenta</span>
+                    )}
+                    <span className="section-count">{group.images.length}</span>
+                  </h4>
+                  <div className="image-gallery">
+                    {group.images.map(img => (
+                      <a
+                        key={img.id}
+                        href={img.image_url || undefined}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="image-gallery__item"
+                      >
+                        {img.image_url ? (
+                          <img
+                            src={img.image_url}
+                            alt={`${group.label} — produkt ${product.id}`}
+                            loading="lazy"
+                            decoding="async"
+                            width={120}
+                            height={120}
+                            onError={e => {
+                              const el = e.currentTarget;
+                              el.onerror = null;
+                              el.src =
+                                'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgZmlsbD0iI2VlZSIvPjx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTIiIGZpbGw9IiM5OTkiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGR5PSIuM2VtIj5icmFrIHpkajwvdGV4dD48L3N2Zz4=';
+                            }}
+                          />
+                        ) : (
+                          <span className="image-gallery__fallback">Brak URL</span>
+                        )}
+                      </a>
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
           </div>
@@ -417,6 +439,7 @@ export function ProductDetailPage() {
                 <tr>
                   <th style={{ width: 70 }}>ID</th>
                   <th>Kolor</th>
+                  <th>Kolor prod.</th>
                   <th style={{ width: 120 }}>Rozmiar</th>
                   <th style={{ width: 80 }}>Stan</th>
                   <th style={{ width: 110 }}>Cena mag.</th>
@@ -441,6 +464,9 @@ export function ProductDetailPage() {
                       ) : (
                         <span className="muted">—</span>
                       )}
+                    </td>
+                    <td>
+                      {variant.producer_color_name || <span className="muted">—</span>}
                     </td>
                     <td>{variant.size_name || <span className="muted">—</span>}</td>
                     <td>{variant.stock ?? <span className="muted">0</span>}</td>

--- a/frontend/mpd/src/utils/groupImagesByColor.ts
+++ b/frontend/mpd/src/utils/groupImagesByColor.ts
@@ -1,0 +1,118 @@
+import type { MpdProductImage, MpdProductVariant } from '../types/mpd';
+
+export type ImageColorGroup = {
+  key: string;
+  label: string;
+  kind: 'producer' | 'color' | 'other';
+  images: MpdProductImage[];
+};
+
+function normalizeColorKey(name: string): string {
+  return name.toLowerCase().replace(/\//g, '_').replace(/ /g, '_');
+}
+
+function basenameLower(filePath: string): string {
+  const parts = filePath.replace(/\\/g, '/').split('/');
+  return (parts[parts.length - 1] || filePath).toLowerCase();
+}
+
+/**
+ * Grupuje zdjęcia jak Django MPD admin: match nazwy koloru w basename file_path
+ * (najpierw kolor producenta, potem zwykły kolor; dłuższe nazwy pierwsze).
+ */
+export function groupImagesByColor(
+  images: MpdProductImage[],
+  variants: MpdProductVariant[],
+): ImageColorGroup[] {
+  const producerMap = new Map<string, string>();
+  const colorMap = new Map<string, string>();
+
+  for (const v of variants) {
+    if (v.producer_color_id != null && v.producer_color_name) {
+      producerMap.set(String(v.producer_color_id), v.producer_color_name);
+    }
+    if (v.color_id != null && v.color_name) {
+      colorMap.set(String(v.color_id), v.color_name);
+    }
+  }
+
+  const producerKeys = [...producerMap.entries()]
+    .map(([id, name]) => ({ id, name, key: normalizeColorKey(name) }))
+    .sort((a, b) => b.key.length - a.key.length);
+
+  const colorKeys = [...colorMap.entries()]
+    .map(([id, name]) => ({ id, name, key: normalizeColorKey(name) }))
+    .sort((a, b) => b.key.length - a.key.length);
+
+  const byProducer = new Map<string, MpdProductImage[]>(
+    [...producerMap.keys()].map(id => [id, []]),
+  );
+  const byColor = new Map<string, MpdProductImage[]>(
+    [...colorMap.keys()].map(id => [id, []]),
+  );
+  const other: MpdProductImage[] = [];
+
+  for (const img of images) {
+    const fileName = basenameLower(img.file_path);
+    let matched = false;
+
+    for (const { id, key } of producerKeys) {
+      if (key && fileName.includes(key)) {
+        byProducer.get(id)?.push(img);
+        matched = true;
+        break;
+      }
+    }
+
+    if (!matched) {
+      for (const { id, key } of colorKeys) {
+        if (key && fileName.includes(key)) {
+          byColor.get(id)?.push(img);
+          matched = true;
+          break;
+        }
+      }
+    }
+
+    if (!matched) {
+      other.push(img);
+    }
+  }
+
+  const groups: ImageColorGroup[] = [];
+
+  for (const [id, name] of producerMap) {
+    const imgs = byProducer.get(id) ?? [];
+    if (imgs.length > 0) {
+      groups.push({
+        key: `producer-${id}`,
+        label: name,
+        kind: 'producer',
+        images: imgs,
+      });
+    }
+  }
+
+  for (const [id, name] of colorMap) {
+    const imgs = byColor.get(id) ?? [];
+    if (imgs.length > 0) {
+      groups.push({
+        key: `color-${id}`,
+        label: name,
+        kind: 'color',
+        images: imgs,
+      });
+    }
+  }
+
+  if (other.length > 0) {
+    groups.push({
+      key: 'other',
+      label: 'Inne zdjęcia',
+      kind: 'other',
+      images: other,
+    });
+  }
+
+  return groups;
+}

--- a/frontend/mpd/src/utils/groupImagesByColor.ts
+++ b/frontend/mpd/src/utils/groupImagesByColor.ts
@@ -22,7 +22,7 @@ function basenameLower(filePath: string): string {
  */
 export function groupImagesByColor(
   images: MpdProductImage[],
-  variants: MpdProductVariant[],
+  variants: MpdProductVariant[]
 ): ImageColorGroup[] {
   const producerMap = new Map<string, string>();
   const colorMap = new Map<string, string>();
@@ -45,11 +45,9 @@ export function groupImagesByColor(
     .sort((a, b) => b.key.length - a.key.length);
 
   const byProducer = new Map<string, MpdProductImage[]>(
-    [...producerMap.keys()].map(id => [id, []]),
+    [...producerMap.keys()].map(id => [id, []])
   );
-  const byColor = new Map<string, MpdProductImage[]>(
-    [...colorMap.keys()].map(id => [id, []]),
-  );
+  const byColor = new Map<string, MpdProductImage[]>([...colorMap.keys()].map(id => [id, []]));
   const other: MpdProductImage[] = [];
 
   for (const img of images) {


### PR DESCRIPTION
## Summary
- Galeria pogrupowana jak w adminie MPD
- Match po file_path (bez zmian API)
- Kolumna Kolor prod. w wariantach

## Test plan
- [ ] Produkt z wieloma kolorami — osobne sekcje
- [ ] Pliki bez koloru → Inne zdjęcia
- [ ] Build frontend/mpd OK

Made with [Cursor](https://cursor.com)