### PR TITLE
fix(admin): przyspiesz listę produktów matterhorn1 i podnieś bufory n…

### DIFF
--- a/deployments/nginx/nginx.conf
+++ b/deployments/nginx/nginx.conf
@@ -70,12 +70,14 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         
-        # Buffering
+        # Buffering — admin (np. lista produktów, dashboard bestsellerów) potrafi
+        # zwrócić strony rzędu 200-300KB; przy 4k*8=32KB nginx przelewał każdą
+        # taką odpowiedź na dysk (proxy_temp), co dokładało realne opóźnienie.
         proxy_buffering on;
-        proxy_buffer_size 4k;
-        proxy_buffers 8 4k;
-        proxy_busy_buffers_size 8k;
-        
+        proxy_buffer_size 16k;
+        proxy_buffers 16 16k;
+        proxy_busy_buffers_size 32k;
+
         # Error handling
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
         proxy_next_upstream_tries 2;
@@ -164,12 +166,14 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         
-        # Buffering
+        # Buffering — admin (np. lista produktów, dashboard bestsellerów) potrafi
+        # zwrócić strony rzędu 200-300KB; przy 4k*8=32KB nginx przelewał każdą
+        # taką odpowiedź na dysk (proxy_temp), co dokładało realne opóźnienie.
         proxy_buffering on;
-        proxy_buffer_size 4k;
-        proxy_buffers 8 4k;
-        proxy_busy_buffers_size 8k;
-        
+        proxy_buffer_size 16k;
+        proxy_buffers 16 16k;
+        proxy_busy_buffers_size 32k;
+
         # Error handling
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
         proxy_next_upstream_tries 2;

--- a/src/apps/matterhorn1/admin.py
+++ b/src/apps/matterhorn1/admin.py
@@ -250,7 +250,9 @@ class ProductAdmin(admin.ModelAdmin):
         """Wyświetl całkowity stan magazynowy"""
         return obj.stock_total
     stock_total.short_description = 'Stan magazynowy'
-    stock_total.admin_order_field = 'productvariant__stock'
+    # Bez admin_order_field: sortowanie po sumie stanów wariantów wymagałoby
+    # agregacji po całej tabeli produktów przy każdym ładowaniu listy (zmierzone
+    # ~720ms na 108k produktów) zamiast szybkiego odczytu po indeksie product_uid.
 
     def stock_history_link(self, obj):
         """Link do widoku historii stanów magazynowych produktu"""


### PR DESCRIPTION
…ginx

Strona /admin/matterhorn1/product/ (~240KB) była zawsze przelewana przez nginx na dysk (proxy_buffer_size 4k * 8 = 32KB), co dokładało realne opóźnienie — potwierdzone w logach ("upstream response is buffered to a temporary file").

Przy okazji: stock_total.admin_order_field wskazywał na nieistniejącą relację ('productvariant__stock' zamiast related_name='variants'), więc sortowanie po kolumnie "Stan magazynowy" rzucało FieldError. Próba naprawy przez Sum('variants__stock') w get_queryset okazała się regresją — zmierzone EXPLAIN ANALYZE pokazało ~720ms (GroupAggregate po wszystkich 108k produktach) zamiast ~40ms z obecnym prefetch_related. Zamiast tego usunięto admin_order_field — kolumna zostaje widoczna, ale nie oferuje (nigdy nie działającego) sortowania.

- podnieś proxy_buffer_size/proxy_buffers w nginx.conf (oba server blocki)
- usuń błędny stock_total.admin_order_field w ProductAdmin