### PR TITLE
fix(admin): usuń masowe pobieranie wierszy w filtrach marki/kategorii

### DIFF
--- a/src/apps/matterhorn1/admin.py
+++ b/src/apps/matterhorn1/admin.py
@@ -82,7 +82,10 @@ class BrandFilter(SimpleListFilter):
                 pass
 
         # Pobierz unikalne marki z przefiltrowanego querysetu (używamy ID obiektu Brand)
-        brand_pks = list(qs.exclude(brand__isnull=True).values_list(
+        # .order_by() czyści odziedziczone sortowanie (-product_uid z ProductAdmin) —
+        # inaczej Postgres musi dołączyć product_uid do DISTINCT (bo jest w ORDER BY),
+        # co zamiast ~190 wierszy zwraca ~108k (po jednym na produkt).
+        brand_pks = list(qs.exclude(brand__isnull=True).order_by().values_list(
             'brand_id', flat=True).distinct())
         if not brand_pks:
             return []
@@ -121,7 +124,8 @@ class CategoryFilter(SimpleListFilter):
                 pass
 
         # Pobierz unikalne kategorie z przefiltrowanego querysetu (używamy ID obiektu Category)
-        category_pks = list(qs.exclude(category__isnull=True).values_list(
+        # .order_by() czyści odziedziczone sortowanie — patrz komentarz w BrandFilter.
+        category_pks = list(qs.exclude(category__isnull=True).order_by().values_list(
             'category_id', flat=True).distinct())
         if not category_pks:
             return []


### PR DESCRIPTION
BrandFilter i CategoryFilter budowały opcje sidebar przez values_list('brand_id', flat=True).distinct(), ale queryset dziedziczy domyślne sortowanie ProductAdmin (-product_uid). SQL wymaga, żeby kolumna z ORDER BY była w projekcji DISTINCT, więc Postgres liczył DISTINCT (brand_id, product_uid) zamiast DISTINCT brand_id — a że product_uid jest unikalny per produkt, dawało to ~108591 wierszy zamiast ~190 przy każdym wejściu na listę produktów (potwierdzone cProfile + logiem SQL na żywej bazie).

.order_by() przed .distinct() czyści odziedziczone sortowanie i przywraca właściwą deduplikację po samym brand_id/category_id.