### PR TITLE
fix(tests): usuń nieużywane importy w matterhorn1/tests_serializers.py

### DIFF
--- a/src/apps/matterhorn1/tests_serializers.py
+++ b/src/apps/matterhorn1/tests_serializers.py
@@ -4,7 +4,6 @@ pokrywają istniejące testy widoków API (tests.py).
 """
 from django.test import TestCase
 
-from .models import Brand, Category, Product
 from .serializers import (
     BrandSerializer,
     BulkBrandSerializer,


### PR DESCRIPTION
## Summary
- Ruff (kontener code-reviewer) zgłosił F401 dla `Brand`/`Category`/`Product` w `matterhorn1/tests_serializers.py` — importy modeli były niepotrzebne, testy korzystają wyłącznie z serializerów.

## Test plan
- [x] `ruff check` na zmienionym pliku — czysto
- [x] `manage.py test matterhorn1.tests_serializers` — 37/37 OK