### PR TITLE
fix(MPD): pokaż w mpd-app wszystkie źródła (hurtownie) wariantu

### DIFF
--- a/frontend/mpd/src/pages/ProductDetailPage.css
+++ b/frontend/mpd/src/pages/ProductDetailPage.css
@@ -333,6 +333,18 @@
   color: #aaa;
 }
 
+.source-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.source-badge {
+  background: #e9ecef;
+  color: #495057;
+  white-space: nowrap;
+}
+
 .product-detail__variants .data-table td,
 .product-detail__variants .data-table th {
   font-size: 0.9rem;

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -446,6 +446,7 @@ export function ProductDetailPage() {
                   <th style={{ width: 110 }}>Cena detal.</th>
                   <th style={{ width: 130 }}>Kod prod.</th>
                   <th style={{ width: 80 }}>IAI</th>
+                  <th style={{ width: 200 }}>Źródła</th>
                 </tr>
               </thead>
               <tbody>
@@ -489,6 +490,25 @@ export function ProductDetailPage() {
                       >
                         {variant.exported_to_iai ? 'Tak' : 'Nie'}
                       </span>
+                    </td>
+                    <td>
+                      {variant.sources.length > 0 ? (
+                        <div className="source-badges">
+                          {variant.sources.map(source => (
+                            <span
+                              key={source.source_id}
+                              className="badge source-badge"
+                              title={`EAN: ${source.ean || '—'}`}
+                            >
+                              {source.source_short_name || source.source_name || `#${source.source_id}`}
+                              {source.stock != null ? `: ${source.stock}szt` : ''}
+                              {source.price != null ? ` / ${source.price} ${source.currency || 'PLN'}` : ''}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="muted">—</span>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/frontend/mpd/src/types/mpd.ts
+++ b/frontend/mpd/src/types/mpd.ts
@@ -31,6 +31,17 @@ export interface MpdVariantPrice {
   net_price: number | null;
 }
 
+export interface MpdVariantSource {
+  source_id: number;
+  source_name: string | null;
+  source_short_name: string | null;
+  ean: string;
+  producer_code: string;
+  stock: number | null;
+  price: number | null;
+  currency: string | null;
+}
+
 export interface MpdProductVariant {
   variant_id: number;
   color_id: number | null;
@@ -46,6 +57,7 @@ export interface MpdProductVariant {
   stock: number | null;
   warehouse_price: number | null;
   price: MpdVariantPrice | null;
+  sources: MpdVariantSource[];
 }
 
 export interface MpdProductImage {

--- a/src/apps/MPD/views.py
+++ b/src/apps/MPD/views.py
@@ -1075,20 +1075,49 @@ def get_product(request, product_id):
         ).select_related('color', 'size', 'producer_color').order_by('size__name', 'color__name')
 
         variant_ids = [v.variant_id for v in variants_qs]
+
+        # Stan/cena ze WSZYSTKICH źródeł (hurtowni) na wariant, nie tylko jednego
+        # zahardkodowanego source_id — wariant może mieć ofertę z kilku hurtowni
+        # naraz po zlinkowaniu po EAN (patrz MPD/source_adapters/linking.py).
         stock_by_variant = {}
         if variant_ids:
-            for stock in StockAndPrices.objects.using('MPD').filter(
+            for sp in StockAndPrices.objects.using('MPD').filter(
                 variant_id__in=variant_ids,
-                source_id=2,
-            ):
-                stock_by_variant[stock.variant_id] = stock
+            ).select_related('source'):
+                stock_by_variant.setdefault(sp.variant_id, {})[sp.source_id] = sp
+
+        pvs_by_variant = {}
+        if variant_ids:
+            for pvs in ProductvariantsSources.objects.using('MPD').filter(
+                variant_id__in=variant_ids,
+            ).select_related('source').order_by('source_id'):
+                pvs_by_variant.setdefault(pvs.variant_id, []).append(pvs)
 
         variants = []
         for variant in variants_qs:
-            first_pvs = ProductvariantsSources.objects.using('MPD').filter(
-                variant_id=variant.variant_id,
-            ).values('producer_code', 'ean').first()
-            stock = stock_by_variant.get(variant.variant_id)
+            pvs_list = pvs_by_variant.get(variant.variant_id, [])
+            variant_stock = stock_by_variant.get(variant.variant_id, {})
+
+            variant_sources = []
+            for pvs in pvs_list:
+                sp = variant_stock.get(pvs.source_id)
+                variant_sources.append({
+                    'source_id': pvs.source_id,
+                    'source_name': pvs.source.name if pvs.source else None,
+                    'source_short_name': pvs.source.short_name if pvs.source else None,
+                    'ean': pvs.ean or '',
+                    'producer_code': pvs.producer_code or '',
+                    'stock': sp.stock if sp else None,
+                    'price': float(sp.price) if sp else None,
+                    'currency': sp.currency if sp else None,
+                })
+
+            stocks = [s['stock'] for s in variant_sources if s['stock'] is not None]
+            total_stock = sum(stocks) if stocks else None
+            priced_sources = [s for s in variant_sources if s['price'] is not None]
+            cheapest = min(priced_sources, key=lambda s: s['price']) if priced_sources else None
+            first_pvs = pvs_list[0] if pvs_list else None
+
             variant_data = {
                 'variant_id': variant.variant_id,
                 'color_id': variant.color_id,
@@ -1100,11 +1129,12 @@ def get_product(request, product_id):
                 ),
                 'size_id': variant.size_id,
                 'size_name': variant.size.name if variant.size else None,
-                'producer_code': (first_pvs or {}).get('producer_code') or '',
-                'ean': (first_pvs or {}).get('ean') or '',
+                'producer_code': (first_pvs.producer_code if first_pvs else '') or '',
+                'ean': (first_pvs.ean if first_pvs else '') or '',
                 'exported_to_iai': variant.exported_to_iai,
-                'stock': stock.stock if stock else None,
-                'warehouse_price': float(stock.price) if stock else None,
+                'stock': total_stock,
+                'warehouse_price': cheapest['price'] if cheapest else None,
+                'sources': variant_sources,
             }
 
             try:


### PR DESCRIPTION
get_product zwracał stan/cenę tylko z zahardkodowanego source_id=2 (Matterhorn) i tylko jeden, dowolny wiersz ProductvariantsSources na wariant (.first() bez sortowania, bez source_id) - mimo że po zlinkowaniu po EAN wariant ma wpisy z kilku hurtowni naraz. Efekt: mpd-app pokazywał tylko jedno źródło, a produkt sprzedawany wyłącznie przez Tabu wyglądał jakby miał stan 0.

get_product zwraca teraz pełną listę źródeł na wariant (nazwa, EAN, stan, cena), stock to suma ze wszystkich źródeł, warehouse_price to cena najtańszej oferty. mpd-app (React) dostaje nową kolumnę "Źródła" w tabeli wariantów z osobnym badge'em na hurtownię.