### PR TITLE
style(mpd-app): popraw formatowanie Prettier w ProductDetailPage.tsx

### DIFF
--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -500,9 +500,13 @@ export function ProductDetailPage() {
                               className="badge source-badge"
                               title={`EAN: ${source.ean || '—'}`}
                             >
-                              {source.source_short_name || source.source_name || `#${source.source_id}`}
+                              {source.source_short_name ||
+                                source.source_name ||
+                                `#${source.source_id}`}
                               {source.stock != null ? `: ${source.stock}szt` : ''}
-                              {source.price != null ? ` / ${source.price} ${source.currency || 'PLN'}` : ''}
+                              {source.price != null
+                                ? ` / ${source.price} ${source.currency || 'PLN'}`
+                                : ''}
                             </span>
                           ))}
                         </div>


### PR DESCRIPTION
## Summary
- PR #87 dodał kolumnę "Źródła" w tabeli wariantów (`ProductDetailPage.tsx`), ale dwie nowe linie przekraczały print-width i CI (`Sprawdź formatowanie Prettier`) się na tym wywalił po zmergowaniu do `main`.
- Poprawka: `npx prettier --write` na dotkniętym pliku — czysto formatowanie, zero zmian logiki.

## Test plan
- [x] `npx prettier --check` na `ProductDetailPage.tsx` (i pozostałych plikach z #87) — przechodzi
- [x] Zweryfikowane bezpośrednio na treści `origin/main` (przed tą poprawką) że faktycznie nie przechodzi check — po zaaplikowaniu poprawki przechodzi
- [x] `npm run build` (tsc + vite) — bez błędów

🤖 Generated with [Claude Code](https://claude.com/claude-code)