### PR TITLE
feat(mpd-app): toasty, wspólny hook błędów i przełącznik widoku listy

### DIFF
--- a/frontend/mpd/src/App.tsx
+++ b/frontend/mpd/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { AuthProvider } from './hooks/useAuth';
+import { ToastProvider } from './hooks/useToast';
 import { LoginPage } from './pages/LoginPage';
 import { ProductDetailPage } from './pages/ProductDetailPage';
 import { ProductsPage } from './pages/ProductsPage';
@@ -10,18 +11,20 @@ const routerBasename = import.meta.env.BASE_URL.replace(/\/$/, '') || undefined;
 
 export default function App() {
   return (
-    <AuthProvider>
-      <BrowserRouter basename={routerBasename}>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route element={<ProtectedRoute />}>
-            <Route element={<Layout />}>
-              <Route index element={<ProductsPage />} />
-              <Route path="products/:id" element={<ProductDetailPage />} />
+    <ToastProvider>
+      <AuthProvider>
+        <BrowserRouter basename={routerBasename}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route element={<ProtectedRoute />}>
+              <Route element={<Layout />}>
+                <Route index element={<ProductsPage />} />
+                <Route path="products/:id" element={<ProductDetailPage />} />
+              </Route>
             </Route>
-          </Route>
-        </Routes>
-      </BrowserRouter>
-    </AuthProvider>
+          </Routes>
+        </BrowserRouter>
+      </AuthProvider>
+    </ToastProvider>
   );
 }

--- a/frontend/mpd/src/components/Layout.css
+++ b/frontend/mpd/src/components/Layout.css
@@ -269,7 +269,9 @@
   text-decoration: none;
   color: inherit;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
-  transition: box-shadow 0.15s, transform 0.15s;
+  transition:
+    box-shadow 0.15s,
+    transform 0.15s;
 }
 
 .product-card:hover {

--- a/frontend/mpd/src/components/Layout.css
+++ b/frontend/mpd/src/components/Layout.css
@@ -24,9 +24,9 @@
 }
 
 .app-main {
-  max-width: 1400px;
+  width: 100%;
   margin: 0 auto;
-  padding: 1.5rem;
+  padding: 1.5rem 2rem;
 }
 
 .page-card {
@@ -152,6 +152,36 @@
   border: 1px solid #c3e6cb;
 }
 
+.toast-stack {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 360px;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.toast__close {
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+}
+
 .loading {
   text-align: center;
   padding: 2rem;
@@ -195,6 +225,104 @@
 .badge-hidden {
   background: #f8d7da;
   color: #721c24;
+}
+
+.view-toggle {
+  display: inline-flex;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.view-toggle__btn {
+  padding: 0.55rem 0.9rem;
+  border: none;
+  background: #fff;
+  color: #555;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.view-toggle__btn + .view-toggle__btn {
+  border-left: 1px solid #ddd;
+}
+
+.view-toggle__btn--active {
+  background: #667eea;
+  color: #fff;
+}
+
+.products-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.product-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+
+.product-card:hover {
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.product-card__image {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.product-card__image .product-thumb {
+  width: 160px;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.product-card__name {
+  margin: 0 0 0.15rem;
+  font-weight: 600;
+  color: #222;
+}
+
+.product-card__brand {
+  margin: 0 0 0.5rem;
+  color: #777;
+  font-size: 0.9rem;
+}
+
+.product-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.product-card__id {
+  color: #999;
+  font-size: 0.8rem;
+}
+
+.product-card__delete {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.product-card:hover .product-card__delete {
+  opacity: 1;
 }
 
 .pagination {

--- a/frontend/mpd/src/components/ProductCard.tsx
+++ b/frontend/mpd/src/components/ProductCard.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+import type { MpdProduct } from '../types/mpd';
+import { ProductThumbnail } from './ProductThumbnail';
+
+interface ProductCardProps {
+  product: MpdProduct;
+  onDelete: (productId: number, productName: string) => void;
+  deleteDisabled: boolean;
+}
+
+export function ProductCard({ product, onDelete, deleteDisabled }: ProductCardProps) {
+  return (
+    <Link to={`/products/${product.id}`} className="product-card">
+      <div className="product-card__image">
+        <ProductThumbnail
+          src={product.thumbnail_url}
+          alt={product.name || `Produkt ${product.id}`}
+          size={160}
+        />
+      </div>
+      <div className="product-card__body">
+        <p className="product-card__name">{product.name}</p>
+        <p className="product-card__brand">{product.brand_name || '—'}</p>
+        <div className="product-card__meta">
+          <span className={`badge ${product.visibility ? 'badge-visible' : 'badge-hidden'}`}>
+            {product.visibility ? 'Widoczny' : 'Ukryty'}
+          </span>
+          <span className="product-card__id">#{product.id}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="btn btn-danger-sm product-card__delete"
+        disabled={deleteDisabled}
+        onClick={e => {
+          e.preventDefault();
+          e.stopPropagation();
+          onDelete(product.id, product.name);
+        }}
+      >
+        Usuń
+      </button>
+    </Link>
+  );
+}

--- a/frontend/mpd/src/components/ProductExtrasPanels.tsx
+++ b/frontend/mpd/src/components/ProductExtrasPanels.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -12,15 +11,8 @@ import {
   manageProductPaths,
   updateRetailPrices,
 } from '../api/mpd';
+import { useActionMessages } from '../hooks/useActionMessages';
 import type { MpdProductDetail, MpdRetailPriceItem } from '../types/mpd';
-
-function errorMessage(err: unknown, fallback: string): string {
-  if (axios.isAxiosError(err)) {
-    const data = err.response?.data as { message?: string; detail?: string } | undefined;
-    return data?.message || data?.detail || err.message || fallback;
-  }
-  return fallback;
-}
 
 export function ProductExtrasPanels({
   productId,
@@ -30,8 +22,11 @@ export function ProductExtrasPanels({
   product: MpdProductDetail;
 }) {
   const queryClient = useQueryClient();
-  const [sectionError, setSectionError] = useState<string | null>(null);
-  const [sectionOk, setSectionOk] = useState<string | null>(null);
+  const {
+    setError: setSectionError,
+    setSuccess: setSectionOk,
+    reportError: reportSectionError,
+  } = useActionMessages();
 
   const [attrToAdd, setAttrToAdd] = useState('');
   const [fabricToAdd, setFabricToAdd] = useState('');
@@ -125,7 +120,7 @@ export function ProductExtrasPanels({
       setAttrToAdd('');
       await invalidateProduct();
     },
-    onError: err => setSectionError(errorMessage(err, 'Błąd atrybutów')),
+    onError: err => reportSectionError(err, 'Błąd atrybutów'),
   });
 
   const fabricMutation = useMutation({
@@ -140,7 +135,7 @@ export function ProductExtrasPanels({
       setFabricToAdd('');
       await invalidateProduct();
     },
-    onError: err => setSectionError(errorMessage(err, 'Błąd składu')),
+    onError: err => reportSectionError(err, 'Błąd składu'),
   });
 
   const pathMutation = useMutation({
@@ -154,7 +149,7 @@ export function ProductExtrasPanels({
       setSectionOk(res.message || 'Ścieżki zaktualizowane');
       await invalidateProduct();
     },
-    onError: err => setSectionError(errorMessage(err, 'Błąd ścieżek')),
+    onError: err => reportSectionError(err, 'Błąd ścieżek'),
   });
 
   const retailMutation = useMutation({
@@ -168,13 +163,11 @@ export function ProductExtrasPanels({
       setSectionOk(res.message || 'Ceny zapisane');
       await invalidateProduct();
     },
-    onError: err => setSectionError(errorMessage(err, 'Błąd cen')),
+    onError: err => reportSectionError(err, 'Błąd cen'),
   });
 
   return (
     <>
-      {sectionError && <div className="alert alert-error">{sectionError}</div>}
-      {sectionOk && <div className="alert alert-success">{sectionOk}</div>}
       <div className="product-detail__grid product-detail__grid--pair">
         <div className="page-card">
           <h3 className="section-title">Atrybuty</h3>

--- a/frontend/mpd/src/components/Toast.tsx
+++ b/frontend/mpd/src/components/Toast.tsx
@@ -1,0 +1,18 @@
+export type ToastKind = 'error' | 'success';
+
+interface ToastProps {
+  message: string;
+  kind: ToastKind;
+  onClose: () => void;
+}
+
+export function Toast({ message, kind, onClose }: ToastProps) {
+  return (
+    <div className={`toast alert alert-${kind}`}>
+      <span>{message}</span>
+      <button type="button" className="toast__close" onClick={onClose} aria-label="Zamknij">
+        ×
+      </button>
+    </div>
+  );
+}

--- a/frontend/mpd/src/hooks/useActionMessages.ts
+++ b/frontend/mpd/src/hooks/useActionMessages.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { getErrorMessage } from '../utils/errors';
+import { useToast } from './useToast';
+
+export function useActionMessages() {
+  const { showToast } = useToast();
+
+  const setError = useCallback(
+    (message: string | null) => {
+      if (message) {
+        showToast('error', message);
+      }
+    },
+    [showToast]
+  );
+
+  const setSuccess = useCallback(
+    (message: string | null) => {
+      if (message) {
+        showToast('success', message);
+      }
+    },
+    [showToast]
+  );
+
+  const reportError = useCallback(
+    (err: unknown, fallback: string) => {
+      showToast('error', getErrorMessage(err, fallback));
+    },
+    [showToast]
+  );
+
+  return { setError, setSuccess, reportError };
+}

--- a/frontend/mpd/src/hooks/useLocalStorage.ts
+++ b/frontend/mpd/src/hooks/useLocalStorage.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = window.localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  function setStoredValue(next: T | ((prev: T) => T)) {
+    setValue(prev => {
+      const resolved = typeof next === 'function' ? (next as (prev: T) => T)(prev) : next;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(resolved));
+      } catch {
+        // localStorage może być niedostępny (tryb prywatny, pełny limit) — stan i tak działa w pamięci
+      }
+      return resolved;
+    });
+  }
+
+  return [value, setStoredValue] as const;
+}

--- a/frontend/mpd/src/hooks/useToast.tsx
+++ b/frontend/mpd/src/hooks/useToast.tsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react';
+import { Toast, type ToastKind } from '../components/Toast';
+
+interface ToastItem {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+interface ToastContextValue {
+  showToast: (kind: ToastKind, message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const TOAST_DURATION_MS = 4000;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const nextId = useRef(0);
+
+  const removeToast = useCallback((id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    (kind: ToastKind, message: string) => {
+      const id = nextId.current++;
+      setToasts(prev => [...prev, { id, kind, message }]);
+      window.setTimeout(() => removeToast(id), TOAST_DURATION_MS);
+    },
+    [removeToast]
+  );
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="toast-stack">
+        {toasts.map(t => (
+          <Toast key={t.id} message={t.message} kind={t.kind} onClose={() => removeToast(t.id)} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast musi być używany wewnątrz ToastProvider');
+  }
+  return context;
+}

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -56,8 +56,11 @@ export function ProductDetailPage() {
     visibility: true,
   }));
   const [baseline, setBaseline] = useState<FormState | null>(null);
-  const { setError: setSaveError, setSuccess: setSaveOk, reportError: reportSaveError } =
-    useActionMessages();
+  const {
+    setError: setSaveError,
+    setSuccess: setSaveOk,
+    reportError: reportSaveError,
+  } = useActionMessages();
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['mpd-product', productId],

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { deleteProduct, fetchProduct, updateProduct } from '../api/mpd';
 import { ProductExtrasPanels } from '../components/ProductExtrasPanels';
+import { useActionMessages } from '../hooks/useActionMessages';
 import type { MpdProductDetail, MpdProductUpdatePayload } from '../types/mpd';
 import { groupImagesByColor } from '../utils/groupImagesByColor';
 import { groupVariantsForDisplay } from '../utils/groupVariantsForDisplay';
@@ -56,8 +56,8 @@ export function ProductDetailPage() {
     visibility: true,
   }));
   const [baseline, setBaseline] = useState<FormState | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [saveOk, setSaveOk] = useState<string | null>(null);
+  const { setError: setSaveError, setSuccess: setSaveOk, reportError: reportSaveError } =
+    useActionMessages();
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['mpd-product', productId],
@@ -85,17 +85,7 @@ export function ProductDetailPage() {
       await queryClient.invalidateQueries({ queryKey: ['mpd-product', productId] });
       await queryClient.invalidateQueries({ queryKey: ['mpd-products'] });
     },
-    onError: err => {
-      if (axios.isAxiosError(err)) {
-        const message =
-          (err.response?.data as { message?: string; detail?: string } | undefined)?.message ||
-          (err.response?.data as { detail?: string } | undefined)?.detail ||
-          err.message;
-        setSaveError(message || 'Nie udało się zapisać produktu.');
-        return;
-      }
-      setSaveError('Nie udało się zapisać produktu.');
-    },
+    onError: err => reportSaveError(err, 'Nie udało się zapisać produktu.'),
   });
 
   const deleteMutation = useMutation({
@@ -108,17 +98,7 @@ export function ProductDetailPage() {
       await queryClient.invalidateQueries({ queryKey: ['mpd-products'] });
       navigate('/');
     },
-    onError: err => {
-      if (axios.isAxiosError(err)) {
-        const message =
-          (err.response?.data as { message?: string; detail?: string } | undefined)?.message ||
-          (err.response?.data as { detail?: string } | undefined)?.detail ||
-          err.message;
-        setSaveError(message || 'Nie udało się usunąć produktu.');
-        return;
-      }
-      setSaveError('Nie udało się usunąć produktu.');
-    },
+    onError: err => reportSaveError(err, 'Nie udało się usunąć produktu.'),
   });
 
   const imageGroups = useMemo(() => {
@@ -240,9 +220,6 @@ export function ProductDetailPage() {
           </button>
         </div>
       </div>
-
-      {saveError && <div className="alert alert-error">{saveError}</div>}
-      {saveOk && <div className="alert alert-success">{saveOk}</div>}
 
       <div className="product-detail__header page-card">
         <div className="product-detail__title-row">

--- a/frontend/mpd/src/pages/ProductsPage.tsx
+++ b/frontend/mpd/src/pages/ProductsPage.tsx
@@ -1,9 +1,11 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { deleteProduct, fetchCatalogBrands, fetchCatalogPaths, fetchProducts } from '../api/mpd';
+import { ProductCard } from '../components/ProductCard';
 import { ProductThumbnail } from '../components/ProductThumbnail';
+import { useActionMessages } from '../hooks/useActionMessages';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 import '../components/Layout.css';
 import './ProductDetailPage.css';
 
@@ -11,6 +13,7 @@ const PAGE_SIZE = 50;
 
 type SortField = 'id' | 'name' | 'brand_name' | 'visibility' | 'updated_at';
 type VisibilityFilter = '' | 'true' | 'false';
+type ViewMode = 'table' | 'grid';
 
 const SORTABLE_COLUMNS: { field: SortField; label: string; width?: number }[] = [
   { field: 'id', label: 'ID', width: 70 },
@@ -42,7 +45,8 @@ export function ProductsPage() {
   const [pathId, setPathId] = useState('');
   const [sortField, setSortField] = useState<SortField>('id');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
-  const [listError, setListError] = useState<string | null>(null);
+  const { setError: setListError, reportError: reportListError } = useActionMessages();
+  const [viewMode, setViewMode] = useLocalStorage<ViewMode>('mpd-products-view', 'table');
   const searchTimerRef = useRef<number | undefined>(undefined);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
@@ -100,17 +104,7 @@ export function ProductsPage() {
       setListError(null);
       await queryClient.invalidateQueries({ queryKey: ['mpd-products'] });
     },
-    onError: err => {
-      if (axios.isAxiosError(err)) {
-        const message =
-          (err.response?.data as { message?: string; detail?: string } | undefined)?.message ||
-          (err.response?.data as { detail?: string } | undefined)?.detail ||
-          err.message;
-        setListError(message || 'Nie udało się usunąć produktu.');
-        return;
-      }
-      setListError('Nie udało się usunąć produktu.');
-    },
+    onError: err => reportListError(err, 'Nie udało się usunąć produktu.'),
   });
 
   useEffect(() => {
@@ -224,6 +218,22 @@ export function ProductsPage() {
             Wyczyść filtry
           </button>
         )}
+        <div className="view-toggle" role="group" aria-label="Widok listy">
+          <button
+            type="button"
+            className={`view-toggle__btn${viewMode === 'table' ? ' view-toggle__btn--active' : ''}`}
+            onClick={() => setViewMode('table')}
+          >
+            ☰ Tabela
+          </button>
+          <button
+            type="button"
+            className={`view-toggle__btn${viewMode === 'grid' ? ' view-toggle__btn--active' : ''}`}
+            onClick={() => setViewMode('grid')}
+          >
+            ▦ Siatka
+          </button>
+        </div>
       </div>
 
       {isLoading && <div className="loading">Ładowanie produktów…</div>}
@@ -234,101 +244,114 @@ export function ProductsPage() {
         </div>
       )}
 
-      {listError && <div className="alert alert-error">{listError}</div>}
-
       {data && (
         <>
           <p style={{ color: '#666', marginBottom: '0.75rem' }}>
             Wyświetlono: <strong>{products.length}</strong> z <strong>{totalCount}</strong>{' '}
             produktów
           </p>
-          <table className="data-table products-table">
-            <thead>
-              <tr>
-                <th style={{ width: 72 }}>Zdjęcie</th>
-                {SORTABLE_COLUMNS.map(col => {
-                  const active = sortField === col.field;
-                  const ariaSort = active
-                    ? sortDir === 'asc'
-                      ? 'ascending'
-                      : 'descending'
-                    : 'none';
-                  return (
-                    <th
-                      key={col.field}
-                      style={col.width ? { width: col.width } : undefined}
-                      className={`sortable-th${active ? ' sortable-th--active' : ''}`}
-                      aria-sort={ariaSort}
-                    >
-                      <button
-                        type="button"
-                        className="sortable-th__btn"
-                        onClick={() => handleSort(col.field)}
-                      >
-                        <span>{col.label}</span>
-                        <span className="sortable-th__indicator" aria-hidden>
-                          {active ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
-                        </span>
-                      </button>
-                    </th>
-                  );
-                })}
-                <th style={{ width: 90 }}>Akcje</th>
-              </tr>
-            </thead>
-            <tbody>
-              {products.length === 0 ? (
+          {viewMode === 'table' ? (
+            <table className="data-table products-table">
+              <thead>
                 <tr>
-                  <td colSpan={7} className="empty-state">
-                    Brak produktów spełniających kryteria.
-                  </td>
+                  <th style={{ width: 72 }}>Zdjęcie</th>
+                  {SORTABLE_COLUMNS.map(col => {
+                    const active = sortField === col.field;
+                    const ariaSort = active
+                      ? sortDir === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none';
+                    return (
+                      <th
+                        key={col.field}
+                        style={col.width ? { width: col.width } : undefined}
+                        className={`sortable-th${active ? ' sortable-th--active' : ''}`}
+                        aria-sort={ariaSort}
+                      >
+                        <button
+                          type="button"
+                          className="sortable-th__btn"
+                          onClick={() => handleSort(col.field)}
+                        >
+                          <span>{col.label}</span>
+                          <span className="sortable-th__indicator" aria-hidden>
+                            {active ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
+                          </span>
+                        </button>
+                      </th>
+                    );
+                  })}
+                  <th style={{ width: 90 }}>Akcje</th>
                 </tr>
-              ) : (
-                products.map(product => (
-                  <tr key={product.id} onClick={() => navigate(`/products/${product.id}`)}>
-                    <td className="products-table__thumb-cell">
-                      <ProductThumbnail
-                        src={product.thumbnail_url}
-                        alt={product.name || `Produkt ${product.id}`}
-                      />
-                    </td>
-                    <td>{product.id}</td>
-                    <td>
-                      <Link
-                        to={`/products/${product.id}`}
-                        className="products-table__link"
-                        onClick={e => e.stopPropagation()}
-                      >
-                        {product.name}
-                      </Link>
-                    </td>
-                    <td>{product.brand_name || '—'}</td>
-                    <td>
-                      <span
-                        className={`badge ${product.visibility ? 'badge-visible' : 'badge-hidden'}`}
-                      >
-                        {product.visibility ? 'Tak' : 'Nie'}
-                      </span>
-                    </td>
-                    <td>{new Date(product.updated_at).toLocaleString('pl-PL')}</td>
-                    <td>
-                      <button
-                        type="button"
-                        className="btn btn-danger-sm"
-                        disabled={deleteMutation.isPending}
-                        onClick={e => {
-                          e.stopPropagation();
-                          handleDelete(product.id, product.name);
-                        }}
-                      >
-                        Usuń
-                      </button>
+              </thead>
+              <tbody>
+                {products.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="empty-state">
+                      Brak produktów spełniających kryteria.
                     </td>
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
+                ) : (
+                  products.map(product => (
+                    <tr key={product.id} onClick={() => navigate(`/products/${product.id}`)}>
+                      <td className="products-table__thumb-cell">
+                        <ProductThumbnail
+                          src={product.thumbnail_url}
+                          alt={product.name || `Produkt ${product.id}`}
+                        />
+                      </td>
+                      <td>{product.id}</td>
+                      <td>
+                        <Link
+                          to={`/products/${product.id}`}
+                          className="products-table__link"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          {product.name}
+                        </Link>
+                      </td>
+                      <td>{product.brand_name || '—'}</td>
+                      <td>
+                        <span
+                          className={`badge ${product.visibility ? 'badge-visible' : 'badge-hidden'}`}
+                        >
+                          {product.visibility ? 'Tak' : 'Nie'}
+                        </span>
+                      </td>
+                      <td>{new Date(product.updated_at).toLocaleString('pl-PL')}</td>
+                      <td>
+                        <button
+                          type="button"
+                          className="btn btn-danger-sm"
+                          disabled={deleteMutation.isPending}
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleDelete(product.id, product.name);
+                          }}
+                        >
+                          Usuń
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          ) : products.length === 0 ? (
+            <div className="empty-state">Brak produktów spełniających kryteria.</div>
+          ) : (
+            <div className="products-grid">
+              {products.map(product => (
+                <ProductCard
+                  key={product.id}
+                  product={product}
+                  onDelete={handleDelete}
+                  deleteDisabled={deleteMutation.isPending}
+                />
+              ))}
+            </div>
+          )}
 
           <div ref={loadMoreRef} className="infinite-scroll-sentinel" aria-hidden={!hasNextPage}>
             {isFetchingNextPage && <div className="loading">Ładowanie kolejnych…</div>}

--- a/frontend/mpd/src/utils/errors.ts
+++ b/frontend/mpd/src/utils/errors.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export function getErrorMessage(err: unknown, fallback: string): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data as { message?: string; detail?: string } | undefined;
+    return data?.message || data?.detail || err.message || fallback;
+  }
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- Wydzielono powtarzającą się logikę parsowania błędów axios do `utils/errors.ts` i hooka `useActionMessages` (usunięto 7 kopii tego samego kodu z ProductsPage, ProductDetailPage, ProductExtrasPanels).
- Dodano system powiadomień toast (`hooks/useToast.tsx` + `components/Toast.tsx`) zastępujący stałe alerty na stronach — komunikaty wyskakują w rogu ekranu i same znikają.
- Dodano przełącznik widoku listy produktów: tabela / siatka kart (`components/ProductCard.tsx`), zapamiętywany w localStorage (`hooks/useLocalStorage.ts`).
- `.app-main` rozciągnięty na pełną szerokość ekranu (usunięty `max-width: 1400px`).

## Test plan
- [x] `npx tsc -b --noEmit` — czysto
- [x] `npx oxlint` — bez nowych ostrzeżeń
- [x] Ręcznie przetestowane w przeglądarce: usuwanie/zapis produktu, toasty, przełącznik tabela/siatka

🤖 Generated with [Claude Code](https://claude.com/claude-code)