### PR TITLE
feat(mpd-app): kafelki na stronie produktu w układzie masonry

### DIFF
--- a/frontend/mpd/src/components/Layout.css
+++ b/frontend/mpd/src/components/Layout.css
@@ -253,15 +253,18 @@
 }
 
 .products-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
 }
 
 .product-card {
   position: relative;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
+  width: fit-content;
+  max-width: 280px;
   background: #fff;
   border: 1px solid #eee;
   border-radius: 10px;

--- a/frontend/mpd/src/components/ProductExtrasPanels.tsx
+++ b/frontend/mpd/src/components/ProductExtrasPanels.tsx
@@ -168,164 +168,162 @@ export function ProductExtrasPanels({
 
   return (
     <>
-      <div className="product-detail__grid product-detail__grid--pair">
-        <div className="page-card">
-          <h3 className="section-title">Atrybuty</h3>
-          <div className="inline-add">
-            <select
-              className="search-input"
-              value={attrToAdd}
-              onChange={e => setAttrToAdd(e.target.value)}
-            >
-              <option value="">Wybierz atrybut…</option>
-              {availableAttributes.map(a => (
-                <option key={a.id} value={a.id}>
-                  {a.name}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!attrToAdd || attrMutation.isPending}
-              onClick={() => {
-                setSectionOk(null);
-                attrMutation.mutate({
-                  product_id: productId,
-                  action: 'add',
-                  attribute_ids: [Number(attrToAdd)],
-                });
-              }}
-            >
-              Dodaj
-            </button>
-          </div>
-          {(product.attributes || []).length === 0 ? (
-            <div className="empty-state">Brak atrybutów.</div>
-          ) : (
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th style={{ width: 80 }}>ID</th>
-                  <th>Nazwa</th>
-                  <th style={{ width: 100 }}>Akcje</th>
-                </tr>
-              </thead>
-              <tbody>
-                {product.attributes.map(attr => (
-                  <tr key={attr.id}>
-                    <td>{attr.id}</td>
-                    <td>{attr.name || '—'}</td>
-                    <td>
-                      <button
-                        type="button"
-                        className="btn btn-danger-sm"
-                        disabled={attrMutation.isPending}
-                        onClick={() => {
-                          setSectionOk(null);
-                          attrMutation.mutate({
-                            product_id: productId,
-                            action: 'remove',
-                            attribute_id: attr.id,
-                          });
-                        }}
-                      >
-                        Usuń
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+      <div className="page-card">
+        <h3 className="section-title">Atrybuty</h3>
+        <div className="inline-add">
+          <select
+            className="search-input"
+            value={attrToAdd}
+            onChange={e => setAttrToAdd(e.target.value)}
+          >
+            <option value="">Wybierz atrybut…</option>
+            {availableAttributes.map(a => (
+              <option key={a.id} value={a.id}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={!attrToAdd || attrMutation.isPending}
+            onClick={() => {
+              setSectionOk(null);
+              attrMutation.mutate({
+                product_id: productId,
+                action: 'add',
+                attribute_ids: [Number(attrToAdd)],
+              });
+            }}
+          >
+            Dodaj
+          </button>
         </div>
+        {(product.attributes || []).length === 0 ? (
+          <div className="empty-state">Brak atrybutów.</div>
+        ) : (
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th style={{ width: 80 }}>ID</th>
+                <th>Nazwa</th>
+                <th style={{ width: 100 }}>Akcje</th>
+              </tr>
+            </thead>
+            <tbody>
+              {product.attributes.map(attr => (
+                <tr key={attr.id}>
+                  <td>{attr.id}</td>
+                  <td>{attr.name || '—'}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn btn-danger-sm"
+                      disabled={attrMutation.isPending}
+                      onClick={() => {
+                        setSectionOk(null);
+                        attrMutation.mutate({
+                          product_id: productId,
+                          action: 'remove',
+                          attribute_id: attr.id,
+                        });
+                      }}
+                    >
+                      Usuń
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
 
-        <div className="page-card">
-          <h3 className="section-title">
-            Skład materiałowy
-            <span className={`section-count ${fabricTotal === 100 ? '' : 'section-count--warn'}`}>
-              {fabricTotal}%
-            </span>
-          </h3>
-          <div className="inline-add">
-            <select
-              className="search-input"
-              value={fabricToAdd}
-              onChange={e => setFabricToAdd(e.target.value)}
-            >
-              <option value="">Wybierz komponent…</option>
-              {availableFabric.map(f => (
-                <option key={f.id} value={f.id}>
-                  {f.name}
-                </option>
-              ))}
-            </select>
-            <input
-              className="search-input"
-              style={{ maxWidth: 100 }}
-              type="number"
-              min={1}
-              max={100}
-              value={fabricPct}
-              onChange={e => setFabricPct(e.target.value)}
-              placeholder="%"
-            />
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={!fabricToAdd || fabricMutation.isPending}
-              onClick={() => {
-                setSectionOk(null);
-                fabricMutation.mutate({
-                  product_id: productId,
-                  action: 'add',
-                  component_id: Number(fabricToAdd),
-                  percentage: Number(fabricPct) || 1,
-                });
-              }}
-            >
-              Dodaj
-            </button>
-          </div>
-          {(product.fabric || []).length === 0 ? (
-            <div className="empty-state">Brak składu materiałowego.</div>
-          ) : (
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>Komponent</th>
-                  <th style={{ width: 100 }}>%</th>
-                  <th style={{ width: 100 }}>Akcje</th>
-                </tr>
-              </thead>
-              <tbody>
-                {product.fabric.map(item => (
-                  <tr key={item.component_id}>
-                    <td>{item.component_name || item.component_id}</td>
-                    <td>{item.percentage}%</td>
-                    <td>
-                      <button
-                        type="button"
-                        className="btn btn-danger-sm"
-                        disabled={fabricMutation.isPending}
-                        onClick={() => {
-                          setSectionOk(null);
-                          fabricMutation.mutate({
-                            product_id: productId,
-                            action: 'remove',
-                            component_id: item.component_id,
-                          });
-                        }}
-                      >
-                        Usuń
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+      <div className="page-card">
+        <h3 className="section-title">
+          Skład materiałowy
+          <span className={`section-count ${fabricTotal === 100 ? '' : 'section-count--warn'}`}>
+            {fabricTotal}%
+          </span>
+        </h3>
+        <div className="inline-add">
+          <select
+            className="search-input"
+            value={fabricToAdd}
+            onChange={e => setFabricToAdd(e.target.value)}
+          >
+            <option value="">Wybierz komponent…</option>
+            {availableFabric.map(f => (
+              <option key={f.id} value={f.id}>
+                {f.name}
+              </option>
+            ))}
+          </select>
+          <input
+            className="search-input"
+            style={{ maxWidth: 100 }}
+            type="number"
+            min={1}
+            max={100}
+            value={fabricPct}
+            onChange={e => setFabricPct(e.target.value)}
+            placeholder="%"
+          />
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={!fabricToAdd || fabricMutation.isPending}
+            onClick={() => {
+              setSectionOk(null);
+              fabricMutation.mutate({
+                product_id: productId,
+                action: 'add',
+                component_id: Number(fabricToAdd),
+                percentage: Number(fabricPct) || 1,
+              });
+            }}
+          >
+            Dodaj
+          </button>
         </div>
+        {(product.fabric || []).length === 0 ? (
+          <div className="empty-state">Brak składu materiałowego.</div>
+        ) : (
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Komponent</th>
+                <th style={{ width: 100 }}>%</th>
+                <th style={{ width: 100 }}>Akcje</th>
+              </tr>
+            </thead>
+            <tbody>
+              {product.fabric.map(item => (
+                <tr key={item.component_id}>
+                  <td>{item.component_name || item.component_id}</td>
+                  <td>{item.percentage}%</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn btn-danger-sm"
+                      disabled={fabricMutation.isPending}
+                      onClick={() => {
+                        setSectionOk(null);
+                        fabricMutation.mutate({
+                          product_id: productId,
+                          action: 'remove',
+                          component_id: item.component_id,
+                        });
+                      }}
+                    >
+                      Usuń
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
       <div className="page-card">
         <h3 className="section-title">Ścieżki</h3>
@@ -413,7 +411,7 @@ export function ProductExtrasPanels({
         )}
       </div>
 
-      <div className="page-card">
+      <div className="page-card product-detail__wide">
         <h3 className="section-title">Ceny detaliczne</h3>
         <div className="inline-add">
           <input
@@ -463,93 +461,95 @@ export function ProductExtrasPanels({
         {product.variants.length === 0 ? (
           <div className="empty-state">Brak wariantów.</div>
         ) : (
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>Kolor</th>
-                <th>Rozmiar</th>
-                <th>EAN</th>
-                <th>Cena detal.</th>
-                <th>VAT</th>
-                <th>Waluta</th>
-              </tr>
-            </thead>
-            <tbody>
-              {product.variants.map(variant => {
-                const draft = retailDraft[variant.variant_id] || {
-                  variant_id: variant.variant_id,
-                  retail_price: '',
-                  vat: defaultVatId,
-                  vat_id: defaultVatId,
-                  currency: 'PLN',
-                };
-                return (
-                  <tr key={variant.variant_id}>
-                    <td>{variant.color_name || '—'}</td>
-                    <td>{variant.size_name || '—'}</td>
-                    <td>{variant.ean || '—'}</td>
-                    <td>
-                      <input
-                        className="search-input"
-                        style={{ minWidth: 90 }}
-                        type="number"
-                        step="0.01"
-                        value={draft.retail_price ?? ''}
-                        onChange={e =>
-                          setRetailDraft(prev => ({
-                            ...prev,
-                            [variant.variant_id]: {
-                              ...draft,
-                              retail_price: e.target.value,
-                            },
-                          }))
-                        }
-                      />
-                    </td>
-                    <td>
-                      <select
-                        className="search-input"
-                        style={{ minWidth: 110 }}
-                        value={String(draft.vat_id ?? draft.vat ?? defaultVatId)}
-                        onChange={e =>
-                          setRetailDraft(prev => ({
-                            ...prev,
-                            [variant.variant_id]: {
-                              ...draft,
-                              vat: Number(e.target.value),
-                              vat_id: Number(e.target.value),
-                            },
-                          }))
-                        }
-                      >
-                        {(vatsCatalog.data || []).map(vat => (
-                          <option key={vat.id} value={vat.id}>
-                            {vat.vat_rate != null ? `${vat.vat_rate}%` : `ID ${vat.id}`}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td>
-                      <input
-                        className="search-input"
-                        style={{ minWidth: 70 }}
-                        value={draft.currency ?? 'PLN'}
-                        onChange={e =>
-                          setRetailDraft(prev => ({
-                            ...prev,
-                            [variant.variant_id]: {
-                              ...draft,
-                              currency: e.target.value,
-                            },
-                          }))
-                        }
-                      />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <div className="table-scroll">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Kolor</th>
+                  <th>Rozmiar</th>
+                  <th>EAN</th>
+                  <th>Cena detal.</th>
+                  <th>VAT</th>
+                  <th>Waluta</th>
+                </tr>
+              </thead>
+              <tbody>
+                {product.variants.map(variant => {
+                  const draft = retailDraft[variant.variant_id] || {
+                    variant_id: variant.variant_id,
+                    retail_price: '',
+                    vat: defaultVatId,
+                    vat_id: defaultVatId,
+                    currency: 'PLN',
+                  };
+                  return (
+                    <tr key={variant.variant_id}>
+                      <td>{variant.color_name || '—'}</td>
+                      <td>{variant.size_name || '—'}</td>
+                      <td>{variant.ean || '—'}</td>
+                      <td>
+                        <input
+                          className="search-input"
+                          style={{ minWidth: 90 }}
+                          type="number"
+                          step="0.01"
+                          value={draft.retail_price ?? ''}
+                          onChange={e =>
+                            setRetailDraft(prev => ({
+                              ...prev,
+                              [variant.variant_id]: {
+                                ...draft,
+                                retail_price: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </td>
+                      <td>
+                        <select
+                          className="search-input"
+                          style={{ minWidth: 110 }}
+                          value={String(draft.vat_id ?? draft.vat ?? defaultVatId)}
+                          onChange={e =>
+                            setRetailDraft(prev => ({
+                              ...prev,
+                              [variant.variant_id]: {
+                                ...draft,
+                                vat: Number(e.target.value),
+                                vat_id: Number(e.target.value),
+                              },
+                            }))
+                          }
+                        >
+                          {(vatsCatalog.data || []).map(vat => (
+                            <option key={vat.id} value={vat.id}>
+                              {vat.vat_rate != null ? `${vat.vat_rate}%` : `ID ${vat.id}`}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td>
+                        <input
+                          className="search-input"
+                          style={{ minWidth: 70 }}
+                          value={draft.currency ?? 'PLN'}
+                          onChange={e =>
+                            setRetailDraft(prev => ({
+                              ...prev,
+                              [variant.variant_id]: {
+                                ...draft,
+                                currency: e.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </>

--- a/frontend/mpd/src/pages/ProductDetailPage.css
+++ b/frontend/mpd/src/pages/ProductDetailPage.css
@@ -206,29 +206,45 @@
   color: #333;
 }
 
+/* Kafelki "płyną" w kolumnach (jak masonry) i same wypełniają wolne miejsca — */
+/* stała liczba kolumn (nie column-width), bo przy krótkiej treści przeglądarka */
+/* potrafi zostawić większość szerokości pustą zamiast rozciągnąć kolumny.      */
 .product-detail__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 1rem;
+  column-count: 4;
+  column-gap: 1rem;
 }
 
-/* Para paneli obok siebie (np. atrybuty + skład) — tabele nie powinny łamać layoutu */
-.product-detail__grid--pair {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  align-items: start;
-}
-
-.product-detail__grid--pair > .page-card {
-  min-width: 0;
-  overflow-x: auto;
-}
-
-@media (max-width: 900px) {
-  .product-detail__grid--pair {
-    grid-template-columns: 1fr;
+@media (max-width: 1600px) {
+  .product-detail__grid {
+    column-count: 3;
   }
+}
+
+@media (max-width: 1100px) {
+  .product-detail__grid {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 640px) {
+  .product-detail__grid {
+    column-count: 1;
+  }
+}
+
+.product-detail__grid > .page-card {
+  break-inside: avoid;
+  margin-bottom: 1rem;
+}
+
+/* Kafelek, dla którego jedna kolumna to za mało (np. szeroka tabela) —      */
+/* zajmuje pełną szerokość i przerywa w tym miejscu przepływ kolumn.        */
+.product-detail__grid > .page-card.product-detail__wide {
+  column-span: all;
+}
+
+.table-scroll {
+  overflow-x: auto;
 }
 
 .section-title {

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -409,9 +409,9 @@ export function ProductDetailPage() {
             }}
           />
         </div>
-      </div>
 
-      <ProductExtrasPanels productId={productId} product={product} />
+        <ProductExtrasPanels productId={productId} product={product} />
+      </div>
 
       <div className="page-card product-detail__variants">
         <h3 className="section-title">


### PR DESCRIPTION
## Summary
- Sekcja Zdjęcia/Opis/Atrybuty/Skład materiałowy/Ścieżki/Powiązane produkty/Ceny detaliczne na stronie produktu ułożona teraz w stałych kolumnach (CSS `columns`), zamiast sztywnego podziału 50/50 — krótsze kafelki wypełniają wolne miejsce zostawione przez wyższe.
- Kafelek „Ceny detaliczne" (szeroka tabela) zajmuje pełną szerokość (`column-span: all`), żeby nie trzeba było przewijać w poziomie.
- Liczba kolumn responsywna (4 → 3 → 2 → 1 w zależności od szerokości ekranu).

## Test plan
- [x] `npx tsc -b --noEmit` — czysto
- [x] `npx oxlint` — bez nowych ostrzeżeń
- [x] Ręcznie sprawdzone w przeglądarce na stronie produktu

🤖 Generated with [Claude Code](https://claude.com/claude-code)