### PR TITLE
fix(admin): dashboard bestsellerów na pełną szerokość ekranu

### DIFF
--- a/src/apps/matterhorn1/templates/admin/matterhorn1/stock_history/bestsellers.html
+++ b/src/apps/matterhorn1/templates/admin/matterhorn1/stock_history/bestsellers.html
@@ -56,7 +56,7 @@
     color: var(--text-primary);
     font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
     padding: 20px 0 48px;
-    max-width: 1180px;
+    width: 100%;
   }
   .page-head { margin-bottom: 24px; }
   .page-head p { color: var(--text-secondary); font-size: 14px; margin: 8px 0 0; max-width: 760px; line-height: 1.5; }

--- a/src/apps/tabu/templates/admin/tabu/stock_history/bestsellers.html
+++ b/src/apps/tabu/templates/admin/tabu/stock_history/bestsellers.html
@@ -56,7 +56,7 @@
     color: var(--text-primary);
     font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
     padding: 20px 0 48px;
-    max-width: 1180px;
+    width: 100%;
   }
   .page-head { margin-bottom: 24px; }
   .page-head p { color: var(--text-secondary); font-size: 14px; margin: 8px 0 0; max-width: 760px; line-height: 1.5; }


### PR DESCRIPTION
## Summary
- Usunięto `max-width: 1180px` na `.viz-root` w obu dashboardach bestsellerów (matterhorn1, tabu) — treść (wykresy, tabele) rozciąga się teraz na całą dostępną szerokość `#content` zamiast zostawiać puste marginesy po bokach na szerokich monitorach
- Kafelki (`app_list.html`) już wcześniej korzystały z pełnej szerokości — nie wymagały zmian

## Test plan
- [x] Zweryfikowane testowym klientem Django — obie strony bestsellerów zwracają 200
- [ ] Wizualna weryfikacja na szerokim monitorze

🤖 Generated with [Claude Code](https://claude.com/claude-code)