### PR TITLE
fix(admin): kafelki na stronie głównej ignorowały szerokość ekranu

### DIFF
--- a/src/templates/admin/app_list.html
+++ b/src/templates/admin/app_list.html
@@ -1,5 +1,9 @@
 {% load i18n %}
 <style>
+  /* Django's admin/css/dashboard.css hardcodes `.dashboard #content { width: 600px; }`
+     on the index page — override it so the tile grid can use the full viewport.
+     The colMS/#content-related negative-margin sidebar layout is untouched. */
+  .dashboard #content { width: 100% !important; max-width: none !important; }
   :root {
     --tile-surface:   #fcfcfb;
     --tile-border:    rgba(11,11,11,0.10);

--- a/templates/admin/app_list.html
+++ b/templates/admin/app_list.html
@@ -1,5 +1,9 @@
 {% load i18n %}
 <style>
+  /* Django's admin/css/dashboard.css hardcodes `.dashboard #content { width: 600px; }`
+     on the index page — override it so the tile grid can use the full viewport.
+     The colMS/#content-related negative-margin sidebar layout is untouched. */
+  .dashboard #content { width: 100% !important; max-width: none !important; }
   :root {
     --tile-surface:   #fcfcfb;
     --tile-border:    rgba(11,11,11,0.10);


### PR DESCRIPTION
## Summary
Znaleziony na screenshocie: strona główna admina (i widoki per-aplikacja) ściskała siatkę kafelków do wąskiej kolumny z ogromnym pustym obszarem po prawej, mimo że mój grid nie miał żadnego max-width.

Przyczyna: Django ładuje dedykowany `admin/css/dashboard.css` tylko na stronie index (body dostaje klasę `dashboard`), a ten plik zawiera `.dashboard #content { width: 600px; }` — twardo ograniczający całą treść (kafelki + sidebar "Ostatnie działania") do 600px niezależnie od szerokości monitora.

Nadpisuję tę jedną regułę na `width: 100%` w `app_list.html`. Mechanizm układu sidebaru (`colMS` na `#content` + `#content-related` z ujemnym marginesem -300px) zostaje nietknięty — działa poprawnie przy dowolnej szerokości, to tylko `width: 600px` było problemem.

## Test plan
- [x] Zweryfikowane testowym klientem — `/admin/` i `/admin/matterhorn1/` zwracają 200, reguła nadpisania obecna w HTML
- [ ] Wizualna weryfikacja w przeglądarce na szerokim monitorze (screenshot użytkownika pokazał problem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)