### PR TITLE
fix(admin): popraw wyświetlanie stanu 0 w historii stanów magazynowych

### DIFF
--- a/src/apps/matterhorn1/templates/admin/matterhorn1/stock_history/product_detail.html
+++ b/src/apps/matterhorn1/templates/admin/matterhorn1/stock_history/product_detail.html
@@ -93,9 +93,9 @@
     <tr>
       <td>{{ r.timestamp }}</td>
       <td>{{ r.variant_name|default:r.variant_uid }}</td>
-      <td>{{ r.old_stock|default:'-' }}</td>
-      <td>{{ r.new_stock|default:'-' }}</td>
-      <td class="sh-change-{{ r.change_type }}">{{ r.stock_change|default:'-' }}</td>
+      <td>{{ r.old_stock|default_if_none:'-' }}</td>
+      <td>{{ r.new_stock|default_if_none:'-' }}</td>
+      <td class="sh-change-{{ r.change_type }}">{{ r.stock_change|default_if_none:'-' }}</td>
       <td>{{ r.change_type|default:'-' }}</td>
     </tr>
     {% endfor %}

--- a/src/apps/tabu/templates/admin/tabu/stock_history/product_detail.html
+++ b/src/apps/tabu/templates/admin/tabu/stock_history/product_detail.html
@@ -93,9 +93,9 @@
     <tr>
       <td>{{ r.timestamp }}</td>
       <td>{{ r.variant_symbol|default:r.variant_api_id }}</td>
-      <td>{{ r.old_stock|default:'-' }}</td>
-      <td>{{ r.new_stock|default:'-' }}</td>
-      <td class="sh-change-{{ r.change_type }}">{{ r.stock_change|default:'-' }}</td>
+      <td>{{ r.old_stock|default_if_none:'-' }}</td>
+      <td>{{ r.new_stock|default_if_none:'-' }}</td>
+      <td class="sh-change-{{ r.change_type }}">{{ r.stock_change|default_if_none:'-' }}</td>
       <td>{{ r.change_type|default:'-' }}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Filtr `default` traktuje 0 jako wartość fałszywą, więc realne zerowe stany (produkt wyprzedany) renderowały się jako "-", myląc to z brakiem danych. Zamiana na `default_if_none` naprawia old_stock/new_stock/ stock_change w tabeli historii (matterhorn1, tabu).