### PR TITLE
chore: mark blue-green docker-compose as deprecated

### DIFF
--- a/docker-compose/docker-compose.blue-green.ml.yml
+++ b/docker-compose/docker-compose.blue-green.ml.yml
@@ -1,3 +1,7 @@
+# DEPRECATED: produkcja działa teraz na k3s (deployments/k8s/nc-prod), nie na
+# blue-green przez docker-compose. Plik zostawiony do wglądu/awaryjnego
+# rollbacku, ale nie jest już częścią aktywnego procesu wdrożenia.
+#
 # docker-compose.blue-green.ml.yml - ML worker dla BLUE-GREEN (PROD)
 # Uruchamianie:
 #   docker-compose -f docker-compose.blue-green.yml -f docker-compose.blue-green.ml.yml up -d celery-ml

--- a/docker-compose/docker-compose.blue-green.yml
+++ b/docker-compose/docker-compose.blue-green.yml
@@ -1,3 +1,6 @@
+# DEPRECATED: produkcja działa teraz na k3s (deployments/k8s/nc-prod), nie na
+# blue-green przez docker-compose. Plik zostawiony do wglądu/awaryjnego
+# rollbacku, ale nie jest już częścią aktywnego procesu wdrożenia.
 version: '3.8'
 
 services:


### PR DESCRIPTION
## Summary
- Produkcja działa teraz na k3s (`deployments/k8s/nc-prod`), nie na blue-green przez docker-compose
- Dopisano komentarz DEPRECATED na górze `docker-compose.blue-green.yml` i `docker-compose.blue-green.ml.yml` wskazujący aktualny sposób wdrożenia
- Pliki zostawione (nie usunięte) na wypadek awaryjnego rollbacku/wglądu w starą konfigurację

## Test plan
- N/A - tylko komentarze, bez zmian funkcjonalnych

🤖 Generated with [Claude Code](https://claude.com/claude-code)