### PR TITLE
feat(mada): add visible MADA wordmark banner to admin changelists

### DIFF
--- a/src/apps/mada/templates/admin/mada/change_list.html
+++ b/src/apps/mada/templates/admin/mada/change_list.html
@@ -1,0 +1,35 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{# App-level override (admin/mada/change_list.html) - Django's template lookup
+   applies this to every model's changelist under the mada app (madaproduct,
+   apisynclog, stockhistory, ...), not just one model. Purpose: a big, hard-to-miss
+   banner so it's obvious at a glance you're in Mada and not tabu/matterhorn1/MPD -
+   those look almost identical otherwise. #}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <style>
+    .mada-app-banner {
+      margin: 0 0 20px;
+      padding: 18px 0 16px;
+      border-bottom: 1px solid rgba(11,11,11,0.12);
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 34px;
+      font-weight: 400;
+      letter-spacing: 0.22em;
+      color: #55534e;
+    }
+    @media (prefers-color-scheme: dark) {
+      .mada-app-banner {
+        border-bottom-color: rgba(255,255,255,0.14);
+        color: #d8d6cd;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block content_title %}
+  <div class="mada-app-banner">MADA</div>
+  {{ block.super }}
+{% endblock %}

--- a/src/templates/admin/app_list.html
+++ b/src/templates/admin/app_list.html
@@ -123,6 +123,7 @@
             {% elif app.app_label == 'tabu' %}🧦
             {% elif app.app_label == 'MPD' %}🗂️
             {% elif app.app_label == 'web_agent' %}🤖
+            {% elif app.app_label == 'mada' %}🧵
             {% elif app.app_label == 'auth' %}🔐
             {% elif app.app_label == 'django_celery_beat' %}⏱️
             {% elif app.app_label == 'django_celery_results' %}📋


### PR DESCRIPTION
Mada's admin changelists (madaproduct, apisynclog, stockhistory, ...) look nearly identical to tabu/matterhorn1/MPD's, making it easy to lose track of which wholesaler's data you're looking at. Add an app-level change_list.html override (admin/mada/change_list.html - applies to every model in the app per Django's template lookup order) with a large serif "MADA" wordmark above the page title.

Also fill in the missing dashboard tile icon for mada in app_list.html (was falling through to the generic 📦 fallback).