### PR TITLE
fix(mada): show banner on the app-index page too, not just changelists

### DIFF
--- a/src/apps/mada/templates/admin/mada/_banner.html
+++ b/src/apps/mada/templates/admin/mada/_banner.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{# Shared MADA wordmark, included from both change_list.html and app_index.html
+   overrides (the two entry points into the mada app) so the style lives in one place. #}
+<style>
+  .mada-app-banner {
+    margin: 0 0 20px;
+    padding: 18px 0 16px;
+    border-bottom: 1px solid rgba(11,11,11,0.12);
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 34px;
+    font-weight: 400;
+    letter-spacing: 0.22em;
+    color: #55534e;
+  }
+  @media (prefers-color-scheme: dark) {
+    .mada-app-banner {
+      border-bottom-color: rgba(255,255,255,0.14);
+      color: #d8d6cd;
+    }
+  }
+</style>
+<div class="mada-app-banner">MADA</div>

--- a/src/apps/mada/templates/admin/mada/app_index.html
+++ b/src/apps/mada/templates/admin/mada/app_index.html
@@ -1,0 +1,11 @@
+{% extends "admin/app_index.html" %}
+{% load i18n %}
+
+{# This is the page you actually land on right after clicking "Mada" from the
+   admin dashboard (before picking a model) - the change_list.html banner
+   never covers it, so it needs the same wordmark too. #}
+
+{% block content_title %}
+  {% include "admin/mada/_banner.html" %}
+  {{ block.super }}
+{% endblock %}

--- a/src/apps/mada/templates/admin/mada/change_list.html
+++ b/src/apps/mada/templates/admin/mada/change_list.html
@@ -7,29 +7,7 @@
    banner so it's obvious at a glance you're in Mada and not tabu/matterhorn1/MPD -
    those look almost identical otherwise. #}
 
-{% block extrastyle %}
-  {{ block.super }}
-  <style>
-    .mada-app-banner {
-      margin: 0 0 20px;
-      padding: 18px 0 16px;
-      border-bottom: 1px solid rgba(11,11,11,0.12);
-      font-family: Georgia, 'Times New Roman', serif;
-      font-size: 34px;
-      font-weight: 400;
-      letter-spacing: 0.22em;
-      color: #55534e;
-    }
-    @media (prefers-color-scheme: dark) {
-      .mada-app-banner {
-        border-bottom-color: rgba(255,255,255,0.14);
-        color: #d8d6cd;
-      }
-    }
-  </style>
-{% endblock %}
-
 {% block content_title %}
-  <div class="mada-app-banner">MADA</div>
+  {% include "admin/mada/_banner.html" %}
   {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
/admin/mada/ (app_index.html) is the page you land on right after clicking into "Mada" from the dashboard, before picking a model - it's a different template than change_list.html, so the wordmark added in 019c243 never covered it. Add the same banner there, factored into a shared admin/mada/_banner.html include so the two templates don't duplicate the CSS.