### PR TITLE
fix(prod): na k3s tylko nc-web, Celery i Redis wracają na Docker

### DIFF
--- a/deployments/k8s/nc-prod/ingress.yaml
+++ b/deployments/k8s/nc-prod/ingress.yaml
@@ -20,3 +20,21 @@ spec:
                 name: nc-web
                 port:
                   number: 8000
+---
+# IngressRoute — pewny routing Traefik (entrypoint web = NodePort 30080)
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nc-web
+  namespace: nc-prod
+  labels:
+    app: nc-web
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`nc.sowa.ch`)
+      kind: Rule
+      services:
+        - name: nc-web
+          port: 8000

--- a/deployments/k8s/nc-prod/web.yaml
+++ b/deployments/k8s/nc-prod/web.yaml
@@ -45,7 +45,7 @@ spec:
             - name: DJANGO_ENV
               value: prod
             - name: REDIS_HOST
-              value: redis
+              value: "172.17.0.1"
             - name: CELERY_BROKER_URL
               value: ""
             - name: CELERY_RESULT_BACKEND

--- a/docker-compose/docker-compose.blue-green.yml
+++ b/docker-compose/docker-compose.blue-green.yml
@@ -51,7 +51,7 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "8000:8000"  # Port dla blue (można zmienić na inny jeśli potrzebny)
+      - "127.0.0.1:8000:8000"  # Port dla blue (można zmienić na inny jeśli potrzebny)
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"]
       interval: 10s
@@ -109,7 +109,7 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "8001:8000"  # Port dla green (aktywny)
+      - "127.0.0.1:8001:8000"  # Port dla green (aktywny)
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"]
       interval: 10s
@@ -187,7 +187,7 @@ services:
       retries: 5
       start_period: 10s
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - /mnt/data2tb/docker/volumes/nc_postgres_data:/var/lib/postgresql/data
       - ./deployments/docker/postgres/initdb.d:/docker-entrypoint-initdb.d:ro
@@ -202,9 +202,12 @@ services:
     image: redis:7.2-alpine
     container_name: nc-redis-1
     command: redis-server /usr/local/etc/redis/redis.conf --requirepass ${REDIS_PASSWORD:-prod_password}
+    ports:
+      - "127.0.0.1:6379:6379"
+      - "172.17.0.1:6379:6379"
     volumes:
       - /mnt/data2tb/docker/volumes/nc_redis_data:/data
-      - ./redis.conf:/usr/local/etc/redis/redis.conf:ro
+      - ../deployments/redis.conf:/usr/local/etc/redis/redis.conf:ro
     networks:
       - nc_network
     healthcheck:
@@ -329,7 +332,7 @@ services:
         flower --port=5555 --basic_auth=${FLOWER_USER:-admin}:${FLOWER_PASSWORD:-flower} --persistent=True
         --db=/var/lib/flower/flower.db --inspect_timeout=30
     ports:
-      - "5555:5555"
+      - "127.0.0.1:5555:5555"
     volumes:
       - ../src:/app
       - /mnt/data2tb/docker/volumes/nc_flower_data:/var/lib/flower

--- a/scripts/k8s-prod/deploy.sh
+++ b/scripts/k8s-prod/deploy.sh
@@ -37,10 +37,9 @@ if ! kubectl get secret nc-env -n nc-prod &>/dev/null; then
   fi
 fi
 
-echo "=== Apply redis (bez restartu aplikacji) ==="
-kubectl apply -f "$MANIFEST_DIR/redis.yaml"
+# Redis / Celery / Flower zostają na Dockerze — na k3s tylko nc-web.
 
-# Migracje PRZED apply web/celery — stary web nadal obsluguje ruch (brak 504)
+# Migracje PRZED apply web — stary web nadal obsluguje ruch (brak 504)
 if [[ "$RUN_MIGRATE" == true && "$SKIP_MIGRATE" != true ]]; then
   echo "=== Job migracji (przed rolloutem web) ==="
   kubectl delete job nc-migrate -n nc-prod --ignore-not-found
@@ -53,10 +52,8 @@ if [[ "$RUN_MIGRATE" == true && "$SKIP_MIGRATE" != true ]]; then
   kubectl logs job/nc-migrate -n nc-prod --tail=20
 fi
 
-echo "=== Apply manifestow aplikacji nc-prod ==="
+echo "=== Apply manifestow nc-web (k3s tylko web) ==="
 kubectl apply -f "$MANIFEST_DIR/web.yaml"
-kubectl apply -f "$MANIFEST_DIR/celery.yaml"
-kubectl apply -f "$MANIFEST_DIR/flower.yaml"
 kubectl apply -f "$MANIFEST_DIR/ingress.yaml"
 
 echo "=== Rollout nc-web ==="
@@ -67,7 +64,6 @@ else
   echo "Pierwszy deploy — czekam na utworzenie deployment nc-web..."
   kubectl rollout status deployment/nc-web -n nc-prod --timeout=600s
 fi
-kubectl rollout restart deployment/celery-default deployment/celery-import deployment/celery-beat deployment/flower -n nc-prod 2>/dev/null || true
 
 "$SCRIPT_DIR/expose-traefik.sh"
 


### PR DESCRIPTION
Web łączy się z Redisem na hoście (172.17.0.1), a Traefik dostaje IngressRoute, żeby routing nc.sowa.ch nie zniknął po restarcie.