### PR TITLE
docs: mark blue-green deployment as deprecated in favor of k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NC (nc_project)
 
-Projekt Django + PostgreSQL + Celery/Redis. **Produkcja działa wyłącznie w trybie blue‑green** (`docker-compose.blue-green.yml`).
+Projekt Django + PostgreSQL + Celery/Redis. **Produkcja działa na k3s** (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`). Tryb blue‑green (`docker-compose.blue-green.yml`) jest **DEPRECATED** — zachowany tylko do wglądu/awaryjnego rollbacku.
 
 ## Wymagania
 - **Docker + Docker Compose** (w praktyce: Docker Desktop na Windows).
@@ -16,7 +16,7 @@ Projekt Django + PostgreSQL + Celery/Redis. **Produkcja działa wyłącznie w tr
 - `src/apps/` – aplikacje Django (poniżej opis)
 - **manage.py** – w katalogu `src/` (uruchomienie: `cd src && python manage.py ...` lub `python src/manage.py ...`)
 - `deployments/docker/` – Dockerfile dev/prod/ML + entrypoint
-- `docker-compose*.yml` – definicje usług (dev, dev+ML, blue‑green prod)
+- `docker-compose*.yml` – definicje usług (dev, dev+ML, blue‑green prod **[DEPRECATED]**)
 - `scripts/` – skrypty (build, deploy, migracje, security, monitoring)
 - `docs/` – dokumentacja (quick start, deploy, struktura, API itp.)
 
@@ -45,7 +45,7 @@ Projekt Django + PostgreSQL + Celery/Redis. **Produkcja działa wyłącznie w tr
 - **Inne elementy**
   - **Celery + Redis** – kolejki (`celery-default`, opcjonalnie ML worker), monitoring przez Flower.
   - **drf-spectacular** – dokumentacja REST API pod `/api/schema/`, `/api/docs/`, `/api/redoc/`.
-  - **Blue‑green deploy** – pełny pipeline deployu na VPS (`deployments/docker`, `scripts/deploy`, `.github/workflows/deploy-vps.yml`).
+  - **Deploy na k3s** – pełny pipeline deployu na VPS (`deployments/k8s/nc-prod`, `scripts/k8s-prod`, `.github/workflows/deploy-vps.yml`). Blue‑green (`scripts/deploy`) jest **DEPRECATED**.
 
 ## Konfiguracja środowiska (`.env.dev`)
 Plik **`.env.dev` nie jest wersjonowany** (jest ignorowany) – musisz go mieć lokalnie.
@@ -92,8 +92,10 @@ docker-compose -f docker-compose.dev.yml exec web bash
 docker-compose -f docker-compose.dev.yml down
 ```
 
-## Produkcja (tylko blue‑green)
-Deploy robimy przez GitHub Actions (`Release` → `deploy-vps.yml`) albo ręcznie na serwerze:
+## Produkcja (k3s)
+Deploy robimy przez GitHub Actions (`Release` → `deploy-vps.yml`), który uruchamia `scripts/k8s-prod/deploy.sh` na k3s. Szczegóły: `docs/K8S_PROD.md`.
+
+> ⚠️ **DEPRECATED**: poniższe skrypty blue‑green (`scripts/deploy/*`) nie są już używane na produkcji — zachowane do wglądu/awaryjnego rollbacku.
 
 ```bash
 export ENVIRONMENT=prod
@@ -102,12 +104,12 @@ export ENVIRONMENT=prod
 ./scripts/deploy/deploy-blue-green.sh rollback
 ```
 
-### Migracje na produkcji (blue/green)
+### Migracje na produkcji (blue/green, DEPRECATED)
 ```bash
 ./scripts/deploy/run-migrations.sh
 ```
 
-### ML worker na produkcji (opcjonalnie)
+### ML worker na produkcji (blue/green, DEPRECATED)
 ```bash
 docker-compose -f docker-compose.blue-green.yml -f docker-compose.blue-green.ml.yml up -d celery-ml
 ```
@@ -116,5 +118,6 @@ docker-compose -f docker-compose.blue-green.yml -f docker-compose.blue-green.ml.
 - `docs/QUICK_START.md`
 - `docs/DOCKER_QUICK_GUIDE.md`
 - `docs/SCRIPTS_GUIDE.md`
-- `docs/BLUE_GREEN_DEPLOYMENT.md`
+- `docs/K8S_PROD.md` (aktualny deploy produkcyjny)
+- `docs/BLUE_GREEN_DEPLOYMENT.md` (DEPRECATED)
 - **Zewnętrzne API:** `docs/IDOSELL_API.md` (linki do IdoSell: [Getting Started](https://idosell.readme.io/docs/getting-started), [developers](https://www.idosell.com/developers))

--- a/docs/BLUE_GREEN_DEPLOYMENT.md
+++ b/docs/BLUE_GREEN_DEPLOYMENT.md
@@ -1,5 +1,7 @@
 # 🔵🟢 Blue-Green Deployment - Zero Downtime
 
+> ⚠️ **DEPRECATED**: Blue-green (docker-compose) nie jest już mechanizmem produkcyjnym — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`). Ten dokument opisuje starą procedurę, zachowany do wglądu/awaryjnego rollbacku.
+
 ## Czym jest Blue-Green Deployment?
 
 Blue-Green deployment to strategia gdzie mamy **dwa identyczne środowiska produkcyjne**:

--- a/docs/BUILD_OPTIMIZATION.md
+++ b/docs/BUILD_OPTIMIZATION.md
@@ -1,5 +1,7 @@
 # Optymalizacja budowania obrazów Docker
 
+> ⚠️ **DEPRECATED (część blue-green)**: fragmenty dotyczące blue-green (docker-compose) opisują nieaktywny mechanizm — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`).
+
 ## 🚀 Problem
 Budowanie obrazów Docker trwało bardzo długo, ponieważ za każdym razem pobierane były pakiety systemowe (apt) i pakiety Python (pip).
 

--- a/docs/DEPLOYMENT_SCRIPTS.md
+++ b/docs/DEPLOYMENT_SCRIPTS.md
@@ -1,5 +1,7 @@
 # 🚀 Przewodnik po skryptach deployment
 
+> ⚠️ **DEPRECATED**: skrypty blue-green opisane tutaj nie są już mechanizmem produkcyjnym — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`). Dokument zachowany do wglądu/awaryjnego rollbacku.
+
 ## Szybki wybór - który skrypt użyć?
 
 ### 🎯 Chcę zero-downtime deployment (ZALECANE)

--- a/docs/DEPLOY_POSTGRES_FIX.md
+++ b/docs/DEPLOY_POSTGRES_FIX.md
@@ -1,5 +1,7 @@
 # ✅ Naprawa - PostgreSQL chroniony przed odtwarzaniem podczas deploy
 
+> ⚠️ **DEPRECATED (kontekst blue-green)**: opisuje naprawę w mechanizmie blue-green, który nie jest już używany na produkcji (obecnie k3s, patrz `docs/K8S_PROD.md`).
+
 ## Problem który był
 
 ```bash

--- a/docs/DOCKER_QUICK_GUIDE.md
+++ b/docs/DOCKER_QUICK_GUIDE.md
@@ -1,5 +1,7 @@
 # 🚀 Docker - Szybki przewodnik
 
+> ⚠️ **DEPRECATED (część blue-green)**: sekcje o blue-green (docker-compose) opisują nieaktywny mechanizm produkcyjny — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`). Sekcje o środowisku DEV pozostają aktualne.
+
 ## 📋 Wybór środowiska
 
 ```bash

--- a/docs/DOCKER_STRUCTURE.md
+++ b/docs/DOCKER_STRUCTURE.md
@@ -1,5 +1,7 @@
 # 🐳 Struktura plików Docker
 
+> ⚠️ **DEPRECATED (część blue-green)**: opisy plików `docker-compose.blue-green*.yml` dotyczą nieaktywnego mechanizmu produkcyjnego — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`).
+
 ## 📁 Uporządkowana struktura
 
 Projekt używa CZYTELNEJ struktury z osobnymi plikami dla dev i prod:

--- a/docs/GITHUB_AUTO_DEPLOY.md
+++ b/docs/GITHUB_AUTO_DEPLOY.md
@@ -1,5 +1,7 @@
 # 🤖 Deployment z GitHub Actions
 
+> ⚠️ **DEPRECATED (część blue-green)**: opisany tu przepływ blue-green nie jest już aktywny — aktualny deploy przez `deploy-vps.yml` używa k3s (patrz `docs/K8S_PROD.md`).
+
 ## 🎯 Jak to działa?
 
 **Deployment NIE uruchamia się automatycznie przy każdym commicie!**

--- a/docs/ML_CONTAINER_SETUP.md
+++ b/docs/ML_CONTAINER_SETUP.md
@@ -1,5 +1,7 @@
 # 🤖 ML Container - Dokumentacja
 
+> ⚠️ **DEPRECATED (część blue-green)**: fragmenty o deployu ML workera przez `docker-compose.blue-green.ml.yml` opisują nieaktywny mechanizm — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`).
+
 ## 📋 Cel i uzasadnienie
 
 Osobny kontener Docker dla tasków ML (embeddings, semantic search) z PyTorch, aby **NIE spowalniać** standardowych deploymentów.

--- a/docs/ML_CONTAINER_TODO.md
+++ b/docs/ML_CONTAINER_TODO.md
@@ -1,5 +1,7 @@
 # 🤖 ML Container - TODO List
 
+> ⚠️ **DEPRECATED (część blue-green)**: plan zakładał deploy ML workera przez blue-green (docker-compose), które nie jest już mechanizmem produkcyjnym (obecnie k3s, patrz `docs/K8S_PROD.md`).
+
 ## 📋 Plan implementacji osobnego kontenera ML
 
 ### Cel:

--- a/docs/NGINX_PROXY_MANAGER_SETUP.md
+++ b/docs/NGINX_PROXY_MANAGER_SETUP.md
@@ -1,5 +1,7 @@
 # Konfiguracja Nginx Proxy Manager dla produkcji
 
+> ⚠️ **DEPRECATED (część blue-green)**: fragmenty odnoszące się do routingu blue/green kontenerów opisują nieaktywny mechanizm — produkcja działa na k3s + Traefik (patrz `docs/K8S_PROD.md`).
+
 ## 🎯 Cel
 
 Skonfigurować Nginx Proxy Manager (NPM) do automatycznego zarządzania blue-green deployment bez ręcznego przełączania kontenerów przy każdym deploymencie.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,5 +1,7 @@
 # 🚀 Quick Start - NC Project
 
+> ⚠️ **DEPRECATED (część blue-green)**: sekcje o deployu produkcyjnym przez blue-green (docker-compose) opisują nieaktywny mechanizm — produkcja działa na k3s (patrz `docs/K8S_PROD.md`). Sekcje o środowisku DEV pozostają aktualne.
+
 ## Pierwsze uruchomienie (5 minut)
 
 ### 1️⃣ Sklonuj projekt (już masz ✅)

--- a/docs/SCRIPTS_GUIDE.md
+++ b/docs/SCRIPTS_GUIDE.md
@@ -1,5 +1,7 @@
 # 📜 Przewodnik po skryptach projektu
 
+> ⚠️ **DEPRECATED (część blue-green)**: skrypty `scripts/deploy/*blue-green*` i `scripts/ops/*blue-green*` nie są już mechanizmem produkcyjnym — produkcja działa na k3s (`scripts/k8s-prod/*`, patrz `docs/K8S_PROD.md`).
+
 ## 🎯 Główne skrypty deployment
 
 ### 🚀 Production (GitHub Actions)

--- a/docs/UPGRADE_NOTES.md
+++ b/docs/UPGRADE_NOTES.md
@@ -1,5 +1,7 @@
 # 🎉 Upgrade do Zero-Downtime Deployment
 
+> ⚠️ **DEPRECATED**: opisany tu upgrade dotyczył blue-green (docker-compose), które nie jest już mechanizmem produkcyjnym — produkcja działa na k3s (patrz `docs/K8S_PROD.md`).
+
 ## Co się zmieniło?
 
 ### PRZED (tradycyjny deploy):

--- a/docs/ZERO_DOWNTIME_DEPLOYMENT.md
+++ b/docs/ZERO_DOWNTIME_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Zero-Downtime Deployment - Orkiestracja
 
-> ⚠️ **HISTORYCZNE / NIEUŻYWANE (w części)**
+> ⚠️ **DEPRECATED**: cały mechanizm blue-green (docker-compose) opisany w tej dokumentacji nie jest już używany na produkcji — produkcja działa na k3s (`deployments/k8s/nc-prod`, patrz `docs/K8S_PROD.md`).
 >
 > Skrypty `deploy-zero-downtime.*` opisane w tej dokumentacji zostały wycofane z repo.
 > Produkcja działa **wyłącznie w trybie blue‑green**.

--- a/scripts/deploy/deploy-blue-green-nginx.sh
+++ b/scripts/deploy/deploy-blue-green-nginx.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# ⚠️ DEPRECATED: produkcja działa teraz na k3s (deployments/k8s/nc-prod),
+# nie na blue-green przez docker-compose. Zachowany do wglądu/awaryjnego
+# rollbacku (patrz docs/K8S_PROD.md).
+#
 # Skrypt do wdrożenia/restartu blue-green deployment z nginx
 # Użycie: ./scripts/deploy/deploy-blue-green-nginx.sh
 

--- a/scripts/deploy/deploy-blue-green.sh
+++ b/scripts/deploy/deploy-blue-green.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 ################################################################################
+# ⚠️ DEPRECATED: produkcja działa teraz na k3s (scripts/k8s-prod/deploy.sh,
+# deployments/k8s/nc-prod), nie na blue-green przez docker-compose.
+# Skrypt zachowany do wglądu/awaryjnego rollbacku, nie jest już częścią
+# aktywnego procesu wdrożenia (patrz docs/K8S_PROD.md).
+#
 # Blue-Green Deployment Script
-# 
+#
 # Ten skrypt wykonuje zero-downtime deployment używając strategii Blue-Green
 ################################################################################
 

--- a/scripts/deploy/fix-blue-green-nginx.sh
+++ b/scripts/deploy/fix-blue-green-nginx.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# ⚠️ DEPRECATED: produkcja działa teraz na k3s (deployments/k8s/nc-prod),
+# nie na blue-green przez docker-compose. Zachowany do wglądu/awaryjnego
+# rollbacku (patrz docs/K8S_PROD.md).
+#
 # Skrypt do diagnozy i naprawy blue-green deployment z nginx
 # Użycie: ./scripts/deploy/fix-blue-green-nginx.sh
 

--- a/scripts/ops/deploy-blue-green.sh
+++ b/scripts/ops/deploy-blue-green.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# ⚠️ DEPRECATED: produkcja działa teraz na k3s (deployments/k8s/nc-prod),
+# nie na blue-green przez docker-compose. Zachowany do wglądu/awaryjnego
+# rollbacku (patrz docs/K8S_PROD.md).
+#
 # Automatyczny deployment blue-green z przełączaniem
 
 set -e

--- a/scripts/ops/switch-blue-green.sh
+++ b/scripts/ops/switch-blue-green.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# ⚠️ DEPRECATED: produkcja działa teraz na k3s (deployments/k8s/nc-prod),
+# nie na blue-green przez docker-compose. Zachowany do wglądu/awaryjnego
+# rollbacku (patrz docs/K8S_PROD.md).
+#
 # Skrypt do automatycznego przełączania między blue/green deployment
 
 set -e


### PR DESCRIPTION
Blue-green (docker-compose) deployment is no longer the production mechanism - deploy-vps.yml deploys to k3s (deployments/k8s/nc-prod). Adds DEPRECATED banners to README.md, related docs/, and scripts/deploy|ops blue-green scripts pointing to docs/K8S_PROD.md. No functional changes - scripts and docker-compose files are kept for reference/emergency rollback.