### PR TITLE
fix: lock down unauthenticated legacy API endpoints

### DIFF
--- a/docs/K8S_PROD.md
+++ b/docs/K8S_PROD.md
@@ -87,6 +87,29 @@ echo 'export KUBECONFIG=$HOME/.kube/config' >> ~/.bashrc
 
 Kolejne wersje: tylko merge + tag — reszta robi CI.
 
+## Rotacja sekretów w `.env.prod` (np. DJANGO_SECRET_KEY)
+
+`deploy.sh` po deployu robi `kubectl rollout restart` **tylko** dla `nc-web`
+(`deployments/k8s/nc-prod/web.yaml` + `ingress.yaml` — patrz sekcja Workflow CI).
+`celery.yaml` (`celery-default`, `celery-import`, `celery-beat`) i `flower.yaml`
+(`flower`) czytają ten sam Secret `nc-env`, ale nie są aplikowane/restartowane
+automatycznie przy każdym tagu — po zmianie wartości w `.env.prod` (np. rotacji
+`DJANGO_SECRET_KEY`) trzeba je zrestartować ręcznie, inaczej dalej działają na
+starej wartości wczytanej przy starcie poda:
+
+```bash
+# 1. .env.prod na VPS ma już nową wartość (np. DJANGO_SECRET_KEY)
+./scripts/k8s-prod/create-secret.sh   # przebudowuje Secret nc-env
+kubectl rollout restart deployment/nc-web deployment/celery-default \
+  deployment/celery-import deployment/celery-beat deployment/flower -n nc-prod
+kubectl rollout status deployment/nc-web -n nc-prod
+```
+
+`nc-web` i tak dostanie restart automatycznie przy zwykłym tagowanym deployu —
+powyższe jest potrzebne głównie gdy zmieniasz `.env.prod` **bez** nowego tagu,
+albo chcesz mieć pewność, że wszystkie pody (w tym Celery/Flower) mają tę samą,
+aktualną wartość sekretu od razu.
+
 ## Flower (monitoring Celery)
 
 Manifest: `deployments/k8s/nc-prod/flower.yaml` (Deployment + Service + Ingress).

--- a/docs/env.sample.md
+++ b/docs/env.sample.md
@@ -1,3 +1,8 @@
+# WYMAGANE w core.settings.prod (i .test) — bez tego aplikacja nie wystartuje.
+# Wygeneruj osobny, losowy klucz dla KAŻDEGO środowiska (dev/test/prod), nigdy nie
+# współdziel z tym w repo/kodzie: .venv/Scripts/python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+DJANGO_SECRET_KEY=zmien-na-losowy-klucz
+
 # Bazy danych – dla lokalnego uruchomienia (manage.py na hoście) ustaw HOST=localhost, PORT=5434
 # Docker override w docker-compose.dev.yml ustawia postgres-ssh-tunnel dla kontenerów
 DEFAULT_DB_HOST=localhost

--- a/src/apps/MPD/admin.py
+++ b/src/apps/MPD/admin.py
@@ -113,9 +113,12 @@ def admin_update_producer_code(request):
 
 
 # Dodaj URL do admina
+# WAŻNE: owinięcie przez admin.site.admin_view() jest konieczne — bez niego
+# widok nie przechodzi przez standardową kontrolę logowania/uprawnień admina
+# i byłby dostępny publicznie mimo rejestracji pod /admin/.
 original_get_urls = admin.site.get_urls
 admin.site.get_urls = lambda: original_get_urls() + [
-    path('mpd/update-producer-code/', admin_update_producer_code,
+    path('mpd/update-producer-code/', admin.site.admin_view(admin_update_producer_code),
          name='admin_update_producer_code'),
 ]
 

--- a/src/apps/MPD/views.py
+++ b/src/apps/MPD/views.py
@@ -19,6 +19,7 @@ from matterhorn1.defs_db import BUCKET_PUBLIC_BASE_URL, resolve_image_url
 from django.urls import reverse
 
 from django.views.decorators.csrf import csrf_exempt
+from core.legacy_auth import admin_required
 import decimal
 import json
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 # Create your views here.
 
 
+@admin_required
 def products(request):
     products = list(Products.objects.all())
     product_ids = [p.id for p in products]
@@ -69,6 +71,7 @@ def products(request):
     return render(request, 'MPD/mpd.html', {'products': products})
 
 
+@admin_required
 def product_mapping(request):
     """
     Widok do mapowania produktów z matterhorn1 do MPD
@@ -76,6 +79,7 @@ def product_mapping(request):
     return render(request, 'MPD/product_mapping.html')
 
 
+@admin_required
 def test_connection(request):
     try:
         with connections['MPD'].cursor() as cursor:
@@ -107,6 +111,7 @@ def test_connection(request):
         return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
+@admin_required
 def test_table_structure(request):
     try:
         with connections['MPD'].cursor() as cursor:
@@ -285,6 +290,7 @@ def update_all_gateways():
 
 
 @csrf_exempt
+@admin_required
 def generate_full_xml(request):
     exporter = FullXMLExporter()
     # Używa metody z zapisem rekordu do bazy - eksport przyrostowy (tylko nowe produkty)
@@ -311,6 +317,7 @@ def generate_full_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_full_change_xml(request):
     exporter = FullChangeXMLExporter()
     exporter_result = exporter.export()
@@ -344,6 +351,7 @@ def generate_full_change_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_gateway_xml(request, source_name):
     try:
         # Zawsze używa Matterhorn (id=2), ignoruje source_name
@@ -358,6 +366,7 @@ def generate_gateway_xml(request, source_name):
 
 
 @csrf_exempt
+@admin_required
 def generate_light_xml(request):
     exporter = LightXMLExporter()
     exporter_result = exporter.export()
@@ -371,6 +380,7 @@ def generate_light_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_producers_xml(request):
     exporter = ProducersXMLExporter()
     exporter_result = exporter.export()
@@ -384,6 +394,7 @@ def generate_producers_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_stocks_xml(request):
     exporter = StocksXMLExporter()
     exporter_result = exporter.export()
@@ -397,6 +408,7 @@ def generate_stocks_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_units_xml(request):
     exporter = UnitsXMLExporter()
     exporter_result = exporter.export()
@@ -415,6 +427,7 @@ def empty_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_categories_xml(request):
     """Generuje XML z kategoriami zgodnie ze schematem categories.xsd"""
     exporter = CategoriesXMLExporter()
@@ -429,6 +442,7 @@ def generate_categories_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_sizes_xml(request):
     """Generuje XML z rozmiarami zgodnie ze schematem sizes.xsd"""
     exporter = SizesXMLExporter()
@@ -443,30 +457,35 @@ def generate_sizes_xml(request):
 
 
 @csrf_exempt
+@admin_required
 def generate_parameters_xml(request):
     """Generuje XML z parametrami - tymczasowo puste"""
     return HttpResponse('<parameters file_format="IOF" version="3.0" generated_by="nc" language="pol"><!-- Puste parametry --></parameters>', content_type='application/xml')
 
 
 @csrf_exempt
+@admin_required
 def generate_series_xml(request):
     """Generuje XML z seriami - tymczasowo puste"""
     return HttpResponse('<series file_format="IOF" version="3.0" generated_by="nc" language="pol"><!-- Puste serie --></series>', content_type='application/xml')
 
 
 @csrf_exempt
+@admin_required
 def generate_warranties_xml(request):
     """Generuje XML z gwarancjami - tymczasowo puste"""
     return HttpResponse('<warranties file_format="IOF" version="3.0" generated_by="nc" language="pol"><!-- Puste gwarancje --></warranties>', content_type='application/xml')
 
 
 @csrf_exempt
+@admin_required
 def generate_preset_xml(request):
     """Generuje XML z presetami - tymczasowo puste"""
     return HttpResponse('<preset file_format="IOF" version="3.0" generated_by="nc" language="pol"><!-- Puste presety --></preset>', content_type='application/xml')
 
 
 @csrf_exempt
+@admin_required
 def generate_gateway_xml_api(request):
     """Generuje gateway.xml z endpointami API"""
     try:
@@ -534,6 +553,7 @@ def xml_links(request):
 
 
 @csrf_exempt
+@admin_required
 def manage_product_paths(request):
     """
     Endpoint do zarządzania przypisaniami ścieżek do produktów
@@ -599,6 +619,7 @@ def manage_product_paths(request):
 
 
 @csrf_exempt
+@admin_required
 def manage_product_fabric(request):
     """
     Endpoint do zarządzania składem materiałowym produktów
@@ -713,6 +734,7 @@ def manage_product_fabric(request):
 
 
 @csrf_exempt
+@admin_required
 def manage_product_attributes(request):
     """
     Endpoint do zarządzania atrybutami produktów
@@ -824,6 +846,7 @@ def manage_product_attributes(request):
 
 
 @csrf_exempt
+@admin_required
 def create_product(request):
     """
     Endpoint do tworzenia nowego produktu w MPD
@@ -936,6 +959,7 @@ def create_product(request):
 
 
 @csrf_exempt
+@admin_required
 def update_product(request, product_id):
     """
     Endpoint do aktualizacji produktu w MPD
@@ -1055,6 +1079,7 @@ def update_product(request, product_id):
 
 
 @csrf_exempt
+@admin_required
 def get_product(request, product_id):
     """
     Endpoint do pobierania danych produktu z MPD
@@ -1397,6 +1422,7 @@ def update_product_retail_prices(request, product_id):
 
 
 @csrf_exempt
+@admin_required
 def bulk_create_products(request):
     """
     Endpoint do bulk tworzenia produktów w MPD
@@ -1525,6 +1551,7 @@ def bulk_create_products(request):
         return JsonResponse({'status': 'error', 'message': 'Wystąpił błąd'}, status=500)
 
 
+@admin_required
 def bulk_map_from_matterhorn1(request):
     """
     Endpoint do bulk mapowania produktów z matterhorn1 do MPD
@@ -1684,6 +1711,7 @@ def bulk_map_from_matterhorn1(request):
 
 
 @csrf_exempt
+@admin_required
 def get_matterhorn1_products(request):
     """
     Endpoint do pobierania produktów z matterhorn1 do mapowania
@@ -1779,6 +1807,7 @@ def get_matterhorn1_products(request):
 
 
 @csrf_exempt
+@admin_required
 def update_producer_code(request):
     """
     Endpoint do aktualizacji kodu producenta wariantu

--- a/src/apps/matterhorn1/views.py
+++ b/src/apps/matterhorn1/views.py
@@ -8,6 +8,8 @@ import json
 import logging
 from datetime import datetime
 
+from core.legacy_auth import admin_required, AdminRequiredMixin
+
 # Import drf_spectacular tylko jeśli jest dostępny
 try:
     from drf_spectacular.utils import extend_schema, OpenApiExample
@@ -37,7 +39,7 @@ from .serializers import (
 logger = logging.getLogger(__name__)
 
 
-class BaseBulkView(View):
+class BaseBulkView(AdminRequiredMixin, View):
     """Bazowa klasa dla bulk operations"""
 
     def get_model(self):
@@ -362,7 +364,7 @@ class VariantBulkView(BaseBulkView):
         500: {'description': 'Błąd serwera'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class VariantBulkCreateView(View):
+class VariantBulkCreateView(AdminRequiredMixin, View):
     """Bulk create dla wariantów"""
 
     @method_decorator(csrf_exempt)
@@ -461,7 +463,7 @@ class VariantBulkCreateView(View):
             }, status=500)
 
 
-class VariantBulkUpdateView(View):
+class VariantBulkUpdateView(AdminRequiredMixin, View):
     """Bulk update dla wariantów"""
 
     @method_decorator(csrf_exempt)
@@ -587,7 +589,7 @@ class BrandBulkView(BaseBulkView):
         500: {'description': 'Błąd serwera'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class BrandBulkCreateView(View):
+class BrandBulkCreateView(AdminRequiredMixin, View):
     """Bulk create dla marek"""
 
     @method_decorator(csrf_exempt)
@@ -684,7 +686,7 @@ class CategoryBulkView(BaseBulkView):
         500: {'description': 'Błąd serwera'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class CategoryBulkCreateView(View):
+class CategoryBulkCreateView(AdminRequiredMixin, View):
     """Bulk create dla kategorii"""
 
     @method_decorator(csrf_exempt)
@@ -781,7 +783,7 @@ class ImageBulkView(BaseBulkView):
         500: {'description': 'Błąd serwera'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class ImageBulkCreateView(View):
+class ImageBulkCreateView(AdminRequiredMixin, View):
     """Bulk create dla obrazów"""
 
     @method_decorator(csrf_exempt)
@@ -888,7 +890,7 @@ class ImageBulkCreateView(View):
         200: {'description': 'Synchronizacja została uruchomiona'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class APISyncView(View):
+class APISyncView(AdminRequiredMixin, View):
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
@@ -906,7 +908,7 @@ class APISyncView(View):
         200: {'description': 'Synchronizacja produktów została uruchomiona'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class ProductSyncView(View):
+class ProductSyncView(AdminRequiredMixin, View):
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
@@ -924,7 +926,7 @@ class ProductSyncView(View):
         200: {'description': 'Synchronizacja wariantów została uruchomiona'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class VariantSyncView(View):
+class VariantSyncView(AdminRequiredMixin, View):
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
@@ -942,7 +944,7 @@ class VariantSyncView(View):
         200: {'description': 'Status API został pobrany pomyślnie'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class APIStatusView(View):
+class APIStatusView(AdminRequiredMixin, View):
     def get(self, request):
         return JsonResponse({'message': 'APIStatusView - do implementacji'})
 
@@ -956,12 +958,13 @@ class APIStatusView(View):
         200: {'description': 'Logi zostały pobrane pomyślnie'}
     }
 ) if DRF_SPECTACULAR_AVAILABLE else extend_schema()
-class APILogsView(View):
+class APILogsView(AdminRequiredMixin, View):
     def get(self, request):
         return JsonResponse({'message': 'APILogsView - do implementacji'})
 
 
 @csrf_exempt
+@admin_required
 def get_product_details(request, product_id):
     """
     API endpoint do pobierania szczegółów produktu z matterhorn1

--- a/src/core/legacy_auth.py
+++ b/src/core/legacy_auth.py
@@ -1,0 +1,59 @@
+"""
+Wspólne zabezpieczenie dla "legacy" widoków (sprzed wprowadzenia DRF APIView
+z permission_classes), które mimo to muszą pozostać dostępne tylko dla adminów.
+
+Akceptuje albo zalogowaną sesję (Django admin), albo nagłówek
+``Authorization: Token <key>`` (ten sam mechanizm co reszta API), żeby nie
+zrywać ewentualnych integracji serwer-serwer używających tokenu.
+"""
+from functools import wraps
+
+from django.http import JsonResponse
+from rest_framework.authtoken.models import Token
+
+
+def _resolve_staff_user(request):
+    """Zwraca zalogowanego użytkownika (sesja lub Token), albo None."""
+    user = getattr(request, 'user', None)
+    if user is not None and user.is_authenticated:
+        return user
+
+    auth_header = request.headers.get('Authorization', '')
+    if auth_header.startswith('Token '):
+        key = auth_header.split(' ', 1)[1].strip()
+        try:
+            return Token.objects.select_related('user').get(key=key).user
+        except Token.DoesNotExist:
+            return None
+
+    return None
+
+
+def _forbidden_response(request):
+    user = _resolve_staff_user(request)
+    if user is None:
+        return JsonResponse({'detail': 'Wymagane uwierzytelnienie.'}, status=401)
+    if not user.is_staff:
+        return JsonResponse({'detail': 'Brak uprawnień.'}, status=403)
+    return None
+
+
+def admin_required(view_func):
+    """Dekorator dla widoków funkcyjnych: wymaga zalogowanego admina."""
+    @wraps(view_func)
+    def wrapped(request, *args, **kwargs):
+        denied = _forbidden_response(request)
+        if denied is not None:
+            return denied
+        return view_func(request, *args, **kwargs)
+    return wrapped
+
+
+class AdminRequiredMixin:
+    """Mixin dla widoków klasowych (django.views.View): wymaga zalogowanego admina."""
+
+    def dispatch(self, request, *args, **kwargs):
+        denied = _forbidden_response(request)
+        if denied is not None:
+            return denied
+        return super().dispatch(request, *args, **kwargs)

--- a/src/core/settings/prod.py
+++ b/src/core/settings/prod.py
@@ -1,4 +1,5 @@
 import os
+from django.core.exceptions import ImproperlyConfigured
 from .base import *
 from .base import _strip_env_value
 
@@ -25,8 +26,13 @@ GUNICORN_KEEPALIVE = 5  # 5 sekund
 GUNICORN_MAX_REQUESTS = 500  # Restart workera po 500 requestach
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv(
-    'DJANGO_SECRET_KEY', 'django-insecure-zlntqh&x6vv%$+87ycj-)=#isuos^f_h4w%e#9+&w%xd5mph)!')
+# Brak fallbacku: jeśli DJANGO_SECRET_KEY nie jest ustawione w środowisku,
+# aplikacja ma się nie uruchomić, zamiast po cichu użyć klucza zapisanego w repo.
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+if not SECRET_KEY:
+    raise ImproperlyConfigured(
+        'Zmienna środowiskowa DJANGO_SECRET_KEY musi być ustawiona w produkcji.'
+    )
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -200,7 +206,10 @@ CSRF_COOKIE_HTTPONLY = False
 CSRF_USE_SESSIONS = False
 
 # CORS Configuration
-CORS_ALLOW_ALL_ORIGINS = True
+# CORS_ALLOW_ALL_ORIGINS=True razem z CORS_ALLOW_CREDENTIALS=True pozwalało
+# dowolnej stronie wysyłać żądania z ciasteczkami sesji zalogowanego użytkownika
+# i odczytywać odpowiedzi — wyłączone na rzecz jawnej listy dozwolonych originów.
+CORS_ALLOW_ALL_ORIGINS = False
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
@@ -209,7 +218,14 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:8000",
     "http://212.127.93.27:8001",
     "http://192.168.50.31:8001",
+    "https://nc.sowa.ch",
+    "https://sowa.ch",
 ]
+# Dodatkowe dozwolone źródła z zmiennej środowiskowej (bez zmiany kodu przy deployu)
+cors_origins_env = os.getenv('CORS_ALLOWED_ORIGINS', '')
+if cors_origins_env:
+    CORS_ALLOWED_ORIGINS.extend([origin.strip()
+                                for origin in cors_origins_env.split(',') if origin.strip()])
 
 # Redis Configuration - wspólne dla Celery i Cache
 # W Dockerze nazwa serwisu Redis to 'redis' (w trybie blue-green: docker-compose.blue-green.yml)


### PR DESCRIPTION
- core.legacy_auth: nowy AdminRequiredMixin/@admin_required (sesja lub Authorization: Token) dla widoków spoza DRF, których nie da się objąć domyślnymi permission_classes.
- MPD/views.py, matterhorn1/views.py: zablokowane pod IsAdminUser wszystkie legacy write/debug endpointy (bulk create/update, generate-*-xml, manage_product_*, test_connection/test_table_structure, create/update product, itd.) dostępne wcześniej bez żadnej autoryzacji mimo @csrf_exempt. Publiczne zostają tylko endpointy serwujące już wygenerowany feed XML (export_xml, export_full_xml, get_xml_file, get_gateway_xml, xml_links, empty_xml).
- MPD/admin.py: admin_update_producer_code był podpięty pod /admin/ z pominięciem admin.site.admin_view() — jedyne takie miejsce w repo, przez co był publicznie dostępny mimo pozoru bycia częścią panelu admina.
- core/settings/prod.py: usunięty hardcodowany fallback SECRET_KEY (brak DJANGO_SECRET_KEY w env teraz zatrzymuje start zamiast po cichu użyć klucza z repo); CORS_ALLOW_ALL_ORIGINS=True + CORS_ALLOW_CREDENTIALS=True wyłączone na rzecz jawnej listy originów (uzupełnionej o realną domenę prod, która wcześniej na tej liście nie istniała).
- docs/env.sample.md, docs/K8S_PROD.md: dopisany brakujący DJANGO_SECRET_KEY w wzorcu .env oraz sekcja o rotacji sekretów w .env.prod na k3s (nc-web restartuje się automatycznie przy tagowanym deployu, celery-*/flower trzeba zrestartować ręcznie po zmianie Secret nc-env).