### PR TITLE
test(MPD): napraw testy legacy widokow po lock-down endpointow

### DIFF
--- a/src/apps/MPD/tests_extended.py
+++ b/src/apps/MPD/tests_extended.py
@@ -832,6 +832,9 @@ class ManageProductPathsViewTest(TestCase):
 
     def setUp(self):
         self.client = Client()
+        admin_user = User.objects.create_user(
+            username='admin', password='adminpass123', is_staff=True)
+        self.client.force_login(admin_user)
         brand = Brands.objects.using('MPD').create(name='B')
         self.product = Products.objects.using('MPD').create(name='Produkt', brand=brand)
         self.path = Paths.objects.using('MPD').create(name='Kat', path='kat')
@@ -961,6 +964,9 @@ class ManageProductFabricViewTest(TestCase):
 
     def setUp(self):
         self.client = Client()
+        admin_user = User.objects.create_user(
+            username='admin', password='adminpass123', is_staff=True)
+        self.client.force_login(admin_user)
         brand = Brands.objects.using('MPD').create(name='B')
         self.product = Products.objects.using('MPD').create(name='Produkt', brand=brand)
         self.component = FabricComponent.objects.using('MPD').create(name='Bawełna')
@@ -1090,6 +1096,9 @@ class ManageProductAttributesViewTest(TestCase):
 
     def setUp(self):
         self.client = Client()
+        admin_user = User.objects.create_user(
+            username='admin', password='adminpass123', is_staff=True)
+        self.client.force_login(admin_user)
         brand = Brands.objects.using('MPD').create(name='B')
         self.product = Products.objects.using('MPD').create(name='Produkt', brand=brand)
         self.attr = Attributes.objects.using('MPD').create(name='Kolor')
@@ -1231,6 +1240,9 @@ class CreateProductViewTest(TestCase):
 
     def setUp(self):
         self.client = Client()
+        admin_user = User.objects.create_user(
+            username='admin', password='adminpass123', is_staff=True)
+        self.client.force_login(admin_user)
         self.brand = Brands.objects.using('MPD').create(name='Brand Testowy')
 
     def _post(self, data):


### PR DESCRIPTION
@admin_required (8b44f1e, 'lock down unauthenticated legacy API endpoints') zaczal wymagac zalogowanego admina na manage_product_paths, manage_product_fabric, manage_product_attributes i create_product, ale tests_extended.py nigdy nie zostal zaktualizowany - klient testowy w tych 4 klasach byl niezalogowany, wiec wszystkie asercje na 400/404/200 dostawaly 401.

Dodano force_login() zalogowanym adminem (is_staff=True) w setUp() kazdej z 4 klas: ManageProductPathsViewTest, ManageProductFabricViewTest, ManageProductAttributesViewTest, CreateProductViewTest.

Zweryfikowane: 49/49 testow w tych klasach + pelny regresyjny przebieg MPD/matterhorn1/tabu/mada/web_agent (387/387) - OK.