### PR TITLE
feat(mada): dodaj codzienne czyszczenie pustych produktow

### DIFF
--- a/src/apps/mada/management/commands/cleanup_empty_mada_products.py
+++ b/src/apps/mada/management/commands/cleanup_empty_mada_products.py
@@ -1,0 +1,58 @@
+"""
+Usuwa "puste" produkty Mada - rekordy bez NAME (a wiec bez PRICE/PRODUCER/
+CATEGORIES) w products.xml. Feed Mada zawiera takie wpisy trwale (nie jest
+to stan przejsciowy w trakcie parsowania - upsert_product zapisuje caly
+produkt jednym update_or_create) - prawdopodobnie produkty wycofane
+z oferty, ale nadal raportowane w feedzie ze wzgledu na EAN/stan.
+
+Bezpieczenstwo: filtrujemy dodatkowo po mapped_product_uid__isnull=True,
+zeby nigdy nie ruszyc produktu, ktory mimo pustej nazwy zdazyl zostac
+zmapowany do MPD. CASCADE kasuje tez powiazane warianty/zdjecia. Jesli
+produkt pojawi sie pozniej w feedzie z uzupelnionymi danymi, kolejny
+sync_mada_full po prostu go odtworzy (update_or_create po api_id).
+
+Uzycie:
+  python manage.py cleanup_empty_mada_products --dry-run
+  python manage.py cleanup_empty_mada_products
+"""
+from django.core.management.base import BaseCommand
+from django.db import router
+from django.db.models import Q
+
+from mada.models import MadaProduct
+
+
+class Command(BaseCommand):
+    help = 'Usuwa puste produkty Mada (bez NAME w feedzie, nigdy nie zmapowane do MPD).'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help='Tylko pokaz ile produktow zostaloby usunietych, bez usuwania.',
+        )
+
+    def handle(self, *args, **options):
+        db = router.db_for_write(MadaProduct)
+        qs = MadaProduct.objects.using(db).filter(
+            Q(name='') | Q(name__isnull=True),
+            mapped_product_uid__isnull=True,
+        )
+        count = qs.count()
+
+        if options['dry_run']:
+            self.stdout.write(self.style.WARNING(
+                f'[dry-run] Znaleziono {count} pustych produktow Mada do usuniecia.'
+            ))
+            return
+
+        if count == 0:
+            self.stdout.write(self.style.SUCCESS('Brak pustych produktow Mada do usuniecia.'))
+            return
+
+        deleted_total, details = qs.delete()
+        self.stdout.write(self.style.SUCCESS(
+            f'Usunieto {count} pustych produktow Mada '
+            f'(lacznie z powiazanymi rekordami: {deleted_total}).'
+        ))
+        for model_label, n in details.items():
+            self.stdout.write(f'  - {model_label}: {n}')

--- a/src/apps/mada/management/commands/setup_mada_cleanup_task.py
+++ b/src/apps/mada/management/commands/setup_mada_cleanup_task.py
@@ -1,0 +1,78 @@
+"""
+Konfiguruje periodic task (django-celery-beat) do codziennego czyszczenia
+pustych produktów Mada (bez NAME w feedzie).
+
+Domyślnie 01:00 - godzinę po pełnym imporcie (00:15, patrz
+setup_mada_sync_task), żeby nie kasować produktów, które tego samego dnia
+mogą jeszcze zostać uzupełnione przez feed.
+
+Użycie:
+  python manage.py setup_mada_cleanup_task --settings=core.settings.dev
+  python manage.py setup_mada_cleanup_task --hour 1 --minute 0 --settings=core.settings.dev
+  python manage.py setup_mada_cleanup_task --disable --settings=core.settings.dev
+  python manage.py setup_mada_cleanup_task --delete --settings=core.settings.dev
+"""
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
+
+TASK_NAME = 'Mada: czyszczenie pustych produktów (dziennie)'
+
+
+class Command(BaseCommand):
+    help = 'Konfiguruje periodic task czyszczący puste produkty Mada raz dziennie.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--hour', type=int, default=1,
+                             help='Godzina uruchomienia (domyślnie: 1, po pełnym imporcie o 00:15)')
+        parser.add_argument('--minute', type=int, default=0,
+                             help='Minuta uruchomienia (domyślnie: 0)')
+        parser.add_argument('--disable', action='store_true', help='Wyłącz task')
+        parser.add_argument('--delete', action='store_true', help='Usuń task')
+
+    def handle(self, *args, **options):
+        if options['delete']:
+            deleted, _ = PeriodicTask.objects.filter(name=TASK_NAME).delete()
+            if deleted:
+                self.stdout.write(self.style.SUCCESS(f'Usunięto periodic task: {TASK_NAME}'))
+            else:
+                self.stdout.write(self.style.WARNING(f'Task nie istniał: {TASK_NAME}'))
+            return
+
+        enabled = not options['disable']
+
+        crontab, _ = CrontabSchedule.objects.get_or_create(
+            minute=str(options['minute']),
+            hour=str(options['hour']),
+            day_of_week='*', day_of_month='*', month_of_year='*',
+        )
+        task, created = PeriodicTask.objects.update_or_create(
+            name=TASK_NAME,
+            defaults={
+                'crontab': crontab,
+                'interval': None,
+                'task': 'mada.tasks.cleanup_empty_products',
+                'queue': 'default',
+                'enabled': enabled,
+                'start_time': timezone.now(),
+                'description': (
+                    'Usuwa produkty Mada bez NAME w feedzie (nigdy nie zmapowane do MPD). '
+                    'CASCADE kasuje też ich warianty/zdjęcia. Jeśli produkt pojawi się '
+                    'później w feedzie z danymi, sync_mada_full go po prostu odtworzy.'
+                ),
+            },
+        )
+        verb = 'Utworzono' if created else 'Zaktualizowano'
+        status = 'włączony' if task.enabled else 'wyłączony'
+        self.stdout.write(self.style.SUCCESS(
+            f'{verb} periodic task: {task.name}\n'
+            f'   - Harmonogram: codziennie o {options["hour"]:02d}:{options["minute"]:02d}\n'
+            f'   - Status: {status}'
+        ))
+        self.stdout.write(self.style.HTTP_INFO(
+            '\nWskazówki:\n'
+            '  - Podgląd bez usuwania: python manage.py cleanup_empty_mada_products --dry-run\n'
+            '  - Ręczne uruchomienie: python manage.py cleanup_empty_mada_products\n'
+            '  - Wyłączenie: python manage.py setup_mada_cleanup_task --disable\n'
+            '  - Admin: /admin/django_celery_beat/periodictask/\n'
+        ))

--- a/src/apps/mada/tasks.py
+++ b/src/apps/mada/tasks.py
@@ -45,3 +45,24 @@ def sync_mada_partial(self):
         raise self.retry(exc=exc)
     finally:
         cache.delete(lock_key)
+
+
+@shared_task(bind=True, name='mada.tasks.cleanup_empty_products', max_retries=2, default_retry_delay=600)
+def cleanup_empty_products(self):
+    """
+    Usuwa puste produkty Mada (bez NAME w feedzie, nigdy nie zmapowane do MPD).
+    Wywoływany raz dziennie, po pełnym imporcie.
+    """
+    lock_key = 'mada:lock:cleanup_empty_products'
+    if not cache.add(lock_key, self.request.id, timeout=_LOCK_TTL_SECONDS):
+        logger.warning('Pomijam cleanup_empty_products: poprzedni task nadal trwa (lock aktywny).')
+        return {'status': 'skipped', 'reason': 'already_running'}
+
+    try:
+        call_command('cleanup_empty_mada_products')
+        return {'status': 'ok'}
+    except Exception as exc:
+        logger.exception('Błąd czyszczenia pustych produktów Mada: %s', exc)
+        raise self.retry(exc=exc)
+    finally:
+        cache.delete(lock_key)


### PR DESCRIPTION
Feed Mada trwale zawiera produkty bez NAME (a wiec bez PRICE/PRODUCER/ CATEGORIES) - ~30% katalogu (3709/12302 w dev). Wygladaja na wycofane z oferty, ale nadal raportowane w products.xml ze wzgledu na EAN/stan (czesc ma warianty z realnymi stanami magazynowymi). Zadny z nich nie jest zmapowany do MPD.

Dodano:
- cleanup_empty_mada_products: management command usuwajacy MadaProduct z name='' i mapped_product_uid__isnull=True (bezpieczne - CASCADE kasuje tez warianty/zdjecia; jesli feed pozniej uzupelni dane, sync_mada_full po prostu odtworzy produkt po api_id)
- mada.tasks.cleanup_empty_products: task z tym samym wzorcem locka co sync_mada_full/sync_mada_partial
- setup_mada_cleanup_task: rejestruje PeriodicTask na codziennie 01:00 (godzine po pelnym imporcie o 00:15)