### PR TITLE
fix(matterhorn1): napraw layout changelist admina (filtr + wyszukiwarka)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,11 +18,16 @@ PRETTIER_FILES="$(git diff --cached --name-only --diff-filter=ACMR -- '*.js' '*.
 if [ -n "$JS_TS_FILES" ]; then
   echo "husky: eslint (staged js/ts)"
   # Nie blokuj commita - tylko informacyjnie.
-  npx --no eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx $JS_TS_FILES || true
+  # UWAGA: bez "--no" - ta flaga nie jest rozpoznawana przez obecny npx/npm
+  # (npm >=10) i powoduje, ze npm "polyka" wywolanie zamiast przekazac je do
+  # eslinta (npm --version/EUNKNOWNCONFIG zamiast realnego checka). Lokalna
+  # devDependency (node_modules/.bin) jest wystarczajaca - npx i tak jej uzyje
+  # bez pytania o instalacje.
+  npx eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx $JS_TS_FILES || true
 fi
 
 if [ -n "$PRETTIER_FILES" ]; then
   echo "husky: prettier --check (staged)"
   # Nie blokuj commita - tylko informacyjnie.
-  npx --no prettier --check $PRETTIER_FILES || true
+  npx prettier --check $PRETTIER_FILES || true
 fi

--- a/src/apps/matterhorn1/static/matterhorn1/css/admin-changelist-django6-fix.css
+++ b/src/apps/matterhorn1/static/matterhorn1/css/admin-changelist-django6-fix.css
@@ -1,55 +1,41 @@
 /**
- * Django 6 + django-admin-interface: naprawa layoutu changelist.
+ * django-admin-interface: sticky filter panel na changelist.
  *
- * admin_interface (list-filter-sticky) ustawia na #changelist-filter
- * float:right i height:100%. W Django 6 filtr jest wewnątrz
- * .changelist-form-container (flex) — float wypycha tabelę pod filtr
- * i zostawia dużą pustą przestrzeń.
+ * UWAGA - historia tego pliku (Django 5.2.4, DOM sprawdzony na zywo):
+ * Django juz samo ustawia poprawny layout w core admin/css/changelists.css:
+ *   #changelist { display: flex; ... }
+ *   #changelist .changelist-form-container { flex: 1 1 auto; min-width: 0; }
+ *   #changelist-filter { flex: 0 0 240px; order: 1; ... }
+ * .changelist-form-container i #changelist-filter sa BEZPOSREDNIMI
+ * rodzenstwem #changelist (flex-item obok flex-item) - #changelist-filter
+ * nie jest zagniezdzone w .changelist-form-container.
+ *
+ * Poprzednia wersja tego pliku zakladala inny (blednie odgadniety pod
+ * kątem Django 6) uklad DOM i psula layout na dwa sposoby:
+ *   1. `.changelist-form-container { display: flex !important }` +
+ *      `#changelist { display: block }` na koncu pliku - nadpisywalo
+ *      poprawny flex z Django, filtr spadal w block-flow POD cala
+ *      tabele (setki wierszy w dol).
+ *   2. `.changelist-form-container > div { flex: 1 1 auto; min-width: 0 }`
+ *      lapalo #toolbar (div - pasek wyszukiwania) jako flex-item obok
+ *      form#changelist-form (NIE div, wiec regula go omijala) - #toolbar
+ *      zapadal sie do ~0px szerokosci, bo form z cala tabela mial
+ *      znacznie wiekszy flex-basis i wygrywal przy shrinkowaniu.
+ *
+ * Zostawiamy tu tylko dodatek UX (sticky panel filtrow przy scrollu),
+ * ktory nie zmienia display/flex-basis samego .changelist-form-container
+ * ani #toolbar, wiec nie koliduje z natywnym layoutem Django.
  */
 @media (min-width: 768px) {
-    .admin-interface #changelist .changelist-form-container {
-        display: flex !important;
-        align-items: flex-start !important;
-        flex-wrap: nowrap !important;
-        width: 100%;
-    }
-
-    .admin-interface #changelist .changelist-form-container > div {
-        flex: 1 1 auto;
-        min-width: 0;
-    }
-
-    .admin-interface #changelist .changelist-form-container:has(#changelist-filter) > div {
-        max-width: calc(100% - 270px);
-    }
-
-    .admin-interface.list-filter-sticky .module.filtered #changelist-filter,
-    .admin-interface .module.filtered #changelist-filter {
-        float: none !important;
+    .admin-interface.list-filter-sticky .module.filtered #changelist-filter {
         position: sticky;
         top: 30px;
         z-index: 30;
-        flex: 0 0 240px !important;
-        order: 1;
-        align-self: flex-start;
-        height: auto !important;
         max-height: calc(100vh - 60px);
         overflow-y: auto;
-        margin: 0 0 0 30px;
     }
 
     .admin-interface.list-filter-sticky.sticky-pagination .module.filtered #changelist-filter {
         max-height: calc(100vh - 125px);
     }
-
-    /* Stary selektor admin_interface nie pasuje do DOM Django 6 */
-    .admin-interface.list-filter-sticky .module.filtered #toolbar + #changelist-filter {
-        position: sticky !important;
-        top: 30px;
-    }
-}
-
-/* Unikaj podwójnego flexa gdy serwowany jest jeszcze CSS z Django 5.x */
-.admin-interface.change-list #changelist {
-    display: block;
 }

--- a/src/apps/matterhorn1/static/matterhorn1/css/admin-changelist-django6-fix.css
+++ b/src/apps/matterhorn1/static/matterhorn1/css/admin-changelist-django6-fix.css
@@ -27,15 +27,15 @@
  * ani #toolbar, wiec nie koliduje z natywnym layoutem Django.
  */
 @media (min-width: 768px) {
-    .admin-interface.list-filter-sticky .module.filtered #changelist-filter {
-        position: sticky;
-        top: 30px;
-        z-index: 30;
-        max-height: calc(100vh - 60px);
-        overflow-y: auto;
-    }
+  .admin-interface.list-filter-sticky .module.filtered #changelist-filter {
+    position: sticky;
+    top: 30px;
+    z-index: 30;
+    max-height: calc(100vh - 60px);
+    overflow-y: auto;
+  }
 
-    .admin-interface.list-filter-sticky.sticky-pagination .module.filtered #changelist-filter {
-        max-height: calc(100vh - 125px);
-    }
+  .admin-interface.list-filter-sticky.sticky-pagination .module.filtered #changelist-filter {
+    max-height: calc(100vh - 125px);
+  }
 }

--- a/src/apps/matterhorn1/static/matterhorn1/css/product-image-thumbnails.css
+++ b/src/apps/matterhorn1/static/matterhorn1/css/product-image-thumbnails.css
@@ -1,89 +1,88 @@
 /* Style dla miniatur obrazów produktów w adminie - skalowanie w locie */
 .product-image-thumbnail {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 5px;
-    padding: 5px;
-    max-width: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 5px;
+  max-width: 150px;
 }
 
 .thumbnail-link {
-    display: block;
-    text-decoration: none;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    padding: 3px;
-    background: #fff;
-    transition: all 0.2s ease;
-    overflow: hidden;
-    width: 120px;
-    height: 120px;
-    /* Kontener o stałym rozmiarze - obraz będzie skalowany w locie */
+  display: block;
+  text-decoration: none;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 3px;
+  background: #fff;
+  transition: all 0.2s ease;
+  overflow: hidden;
+  width: 120px;
+  height: 120px;
+  /* Kontener o stałym rozmiarze - obraz będzie skalowany w locie */
 }
 
 .thumbnail-link:hover {
-    border-color: #417690;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transform: scale(1.05);
+  border-color: #417690;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transform: scale(1.05);
 }
 
 .thumbnail-image {
-    display: block;
-    /* Skalowanie w locie - przeglądarka automatycznie przeskaluje obraz */
-    width: 120px !important;
-    height: 120px !important;
-    max-width: 120px !important;
-    max-height: 120px !important;
-    object-fit: contain;
-    background: #f5f5f5;
-    border-radius: 2px;
-    /* Wymuszenie skalowania w przeglądarce zamiast ładowania pełnego obrazu */
-    image-rendering: -webkit-optimize-contrast;
-    image-rendering: crisp-edges;
+  display: block;
+  /* Skalowanie w locie - przeglądarka automatycznie przeskaluje obraz */
+  width: 120px !important;
+  height: 120px !important;
+  max-width: 120px !important;
+  max-height: 120px !important;
+  object-fit: contain;
+  background: #f5f5f5;
+  border-radius: 2px;
+  /* Wymuszenie skalowania w przeglądarce zamiast ładowania pełnego obrazu */
+  image-rendering: -webkit-optimize-contrast;
+  image-rendering: crisp-edges;
 }
 
 .thumbnail-url {
-    font-size: 10px;
-    color: #666;
-    text-align: center;
-    word-break: break-all;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    line-height: 1.2;
+  font-size: 10px;
+  color: #666;
+  text-align: center;
+  word-break: break-all;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
 }
 
 /* Lazy loading placeholder */
-.thumbnail-image[loading="lazy"] {
-    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-    background-size: 200% 100%;
-    animation: loading 1.5s infinite;
+.thumbnail-image[loading='lazy'] {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
 }
 
 @keyframes loading {
-    0% {
-        background-position: 200% 0;
-    }
-    100% {
-        background-position: -200% 0;
-    }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 /* Responsywność dla mniejszych ekranów */
 @media (max-width: 768px) {
-    .product-image-thumbnail {
-        max-width: 100px;
-    }
-    
-    .thumbnail-image {
-        max-width: 80px;
-        max-height: 80px;
-    }
-    
-    .thumbnail-url {
-        font-size: 9px;
-    }
-}
+  .product-image-thumbnail {
+    max-width: 100px;
+  }
 
+  .thumbnail-image {
+    max-width: 80px;
+    max-height: 80px;
+  }
+
+  .thumbnail-url {
+    font-size: 9px;
+  }
+}

--- a/src/apps/matterhorn1/static/matterhorn1/js/app.js
+++ b/src/apps/matterhorn1/static/matterhorn1/js/app.js
@@ -5,21 +5,17 @@ import BulkMapping from './components/BulkMapping';
 import BulkCreate from './components/BulkCreate';
 
 // Inicjalizacja komponentów React
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   // ProductMapping - dla pojedynczego produktu
   const productMappingContainer = document.getElementById('product-mapping-container');
   if (productMappingContainer) {
     const productId = parseInt(productMappingContainer.dataset.productId);
     const isMapped = productMappingContainer.dataset.isMapped === 'true';
     const mappedProductId = productMappingContainer.dataset.mappedProductId;
-    
+
     const root = createRoot(productMappingContainer);
     root.render(
-      <ProductMapping 
-        productId={productId}
-        isMapped={isMapped}
-        mappedProductId={mappedProductId}
-      />
+      <ProductMapping productId={productId} isMapped={isMapped} mappedProductId={mappedProductId} />
     );
   }
 
@@ -27,12 +23,12 @@ document.addEventListener('DOMContentLoaded', function() {
   const bulkMappingContainer = document.getElementById('bulk-mapping-container');
   if (bulkMappingContainer) {
     const mappings = JSON.parse(bulkMappingContainer.dataset.mappings || '[]');
-    
+
     const root = createRoot(bulkMappingContainer);
     root.render(
-      <BulkMapping 
+      <BulkMapping
         mappings={mappings}
-        onComplete={() => window.location.href = '/admin/matterhorn1/product/'}
+        onComplete={() => (window.location.href = '/admin/matterhorn1/product/')}
       />
     );
   }
@@ -41,12 +37,12 @@ document.addEventListener('DOMContentLoaded', function() {
   const bulkCreateContainer = document.getElementById('bulk-create-container');
   if (bulkCreateContainer) {
     const productsData = JSON.parse(bulkCreateContainer.dataset.productsData || '[]');
-    
+
     const root = createRoot(bulkCreateContainer);
     root.render(
-      <BulkCreate 
+      <BulkCreate
         productsData={productsData}
-        onComplete={() => window.location.href = '/admin/matterhorn1/product/'}
+        onComplete={() => (window.location.href = '/admin/matterhorn1/product/')}
       />
     );
   }

--- a/src/apps/matterhorn1/static/matterhorn1/js/components-simple.js
+++ b/src/apps/matterhorn1/static/matterhorn1/js/components-simple.js
@@ -10,7 +10,7 @@ function SingleProductCreate({ productId, productData, onComplete }) {
     name: productData.name || '',
     description: productData.description || '',
     brand_name: productData.brand?.name || '',
-    variants: productData.variants || []
+    variants: productData.variants || [],
   });
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState('');
@@ -29,28 +29,31 @@ function SingleProductCreate({ productId, productData, onComplete }) {
   const updateVariant = (variantIndex, field, value) => {
     setEditedProduct(prev => ({
       ...prev,
-      variants: prev.variants.map((variant, j) => 
+      variants: prev.variants.map((variant, j) =>
         j === variantIndex ? { ...variant, [field]: value } : variant
-      )
+      ),
     }));
   };
 
   const addVariant = () => {
     setEditedProduct(prev => ({
       ...prev,
-      variants: [...prev.variants, {
-        size_name: '',
-        stock: 0,
-        ean: '',
-        producer_code: ''
-      }]
+      variants: [
+        ...prev.variants,
+        {
+          size_name: '',
+          stock: 0,
+          ean: '',
+          producer_code: '',
+        },
+      ],
     }));
   };
 
-  const removeVariant = (variantIndex) => {
+  const removeVariant = variantIndex => {
     setEditedProduct(prev => ({
       ...prev,
-      variants: prev.variants.filter((_, j) => j !== variantIndex)
+      variants: prev.variants.filter((_, j) => j !== variantIndex),
     }));
   };
 
@@ -61,13 +64,13 @@ function SingleProductCreate({ productId, productData, onComplete }) {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ products: [editedProduct] })
+        body: JSON.stringify({ products: [editedProduct] }),
       });
 
       const data = await response.json();
-      
+
       if (data.success) {
         showMessage(data.message, 'success');
         setTimeout(() => {
@@ -85,258 +88,348 @@ function SingleProductCreate({ productId, productData, onComplete }) {
     }
   };
 
-  return React.createElement('div', {
-    style: { marginTop: '20px', padding: '20px', border: '1px solid #ddd', borderRadius: '8px', backgroundColor: '#f9f9f9' }
-  }, [
-    message && React.createElement('div', {
-      key: 'message',
-      className: `status-message ${messageType}`,
+  return React.createElement(
+    'div',
+    {
       style: {
-        margin: '10px 0',
-        padding: '10px',
-        borderRadius: '4px',
-        backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-        color: messageType === 'success' ? '#155724' : '#721c24',
-        border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-      }
-    }, message),
-
-    React.createElement('div', { key: 'form' }, [
-      // Nazwa produktu
-      React.createElement('div', { key: 'name', style: { marginBottom: '15px' } }, [
-        React.createElement('label', {
-          key: 'label',
-          style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' }
-        }, 'Nazwa:'),
-        React.createElement('input', {
-          key: 'input',
-          type: 'text',
-          value: editedProduct.name,
-          onChange: (e) => updateProduct('name', e.target.value),
-          style: {
-            width: '100%',
-            padding: '8px',
-            border: '1px solid #ccc',
-            borderRadius: '4px'
-          }
-        })
-      ]),
-
-      // Opis produktu
-      React.createElement('div', { key: 'description', style: { marginBottom: '15px' } }, [
-        React.createElement('label', {
-          key: 'label',
-          style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' }
-        }, 'Opis:'),
-        React.createElement('textarea', {
-          key: 'textarea',
-          value: editedProduct.description,
-          onChange: (e) => updateProduct('description', e.target.value),
-          rows: 3,
-          style: {
-            width: '100%',
-            padding: '8px',
-            border: '1px solid #ccc',
-            borderRadius: '4px'
-          }
-        })
-      ]),
-
-      // Marka
-      React.createElement('div', { key: 'brand', style: { marginBottom: '15px' } }, [
-        React.createElement('label', {
-          key: 'label',
-          style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' }
-        }, 'Marka:'),
-        React.createElement('input', {
-          key: 'input',
-          type: 'text',
-          value: editedProduct.brand_name,
-          onChange: (e) => updateProduct('brand_name', e.target.value),
-          style: {
-            width: '100%',
-            padding: '8px',
-            border: '1px solid #ccc',
-            borderRadius: '4px'
-          }
-        })
-      ]),
-
-      // Warianty
-      React.createElement('div', { key: 'variants' }, [
-        React.createElement('div', {
-          key: 'header',
-          style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }
-        }, [
-          React.createElement('h4', { key: 'title' }, 'Warianty:'),
-          React.createElement('button', {
-            key: 'add',
-            onClick: addVariant,
+        marginTop: '20px',
+        padding: '20px',
+        border: '1px solid #ddd',
+        borderRadius: '8px',
+        backgroundColor: '#f9f9f9',
+      },
+    },
+    [
+      message &&
+        React.createElement(
+          'div',
+          {
+            key: 'message',
+            className: `status-message ${messageType}`,
             style: {
-              background: '#28a745',
-              color: 'white',
-              border: 'none',
-              padding: '5px 10px',
+              margin: '10px 0',
+              padding: '10px',
               borderRadius: '4px',
-              cursor: 'pointer'
-            }
-          }, '+ Dodaj wariant')
+              backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+              color: messageType === 'success' ? '#155724' : '#721c24',
+              border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+            },
+          },
+          message
+        ),
+
+      React.createElement('div', { key: 'form' }, [
+        // Nazwa produktu
+        React.createElement('div', { key: 'name', style: { marginBottom: '15px' } }, [
+          React.createElement(
+            'label',
+            {
+              key: 'label',
+              style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+            },
+            'Nazwa:'
+          ),
+          React.createElement('input', {
+            key: 'input',
+            type: 'text',
+            value: editedProduct.name,
+            onChange: e => updateProduct('name', e.target.value),
+            style: {
+              width: '100%',
+              padding: '8px',
+              border: '1px solid #ccc',
+              borderRadius: '4px',
+            },
+          }),
         ]),
 
-        editedProduct.variants.map((variant, variantIndex) =>
-          React.createElement('div', {
-            key: variantIndex,
+        // Opis produktu
+        React.createElement('div', { key: 'description', style: { marginBottom: '15px' } }, [
+          React.createElement(
+            'label',
+            {
+              key: 'label',
+              style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+            },
+            'Opis:'
+          ),
+          React.createElement('textarea', {
+            key: 'textarea',
+            value: editedProduct.description,
+            onChange: e => updateProduct('description', e.target.value),
+            rows: 3,
             style: {
-              border: '1px solid #e0e0e0',
+              width: '100%',
+              padding: '8px',
+              border: '1px solid #ccc',
               borderRadius: '4px',
-              padding: '15px',
-              marginBottom: '10px',
-              backgroundColor: 'white'
-            }
-          }, [
-            React.createElement('div', {
+            },
+          }),
+        ]),
+
+        // Marka
+        React.createElement('div', { key: 'brand', style: { marginBottom: '15px' } }, [
+          React.createElement(
+            'label',
+            {
+              key: 'label',
+              style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+            },
+            'Marka:'
+          ),
+          React.createElement('input', {
+            key: 'input',
+            type: 'text',
+            value: editedProduct.brand_name,
+            onChange: e => updateProduct('brand_name', e.target.value),
+            style: {
+              width: '100%',
+              padding: '8px',
+              border: '1px solid #ccc',
+              borderRadius: '4px',
+            },
+          }),
+        ]),
+
+        // Warianty
+        React.createElement('div', { key: 'variants' }, [
+          React.createElement(
+            'div',
+            {
               key: 'header',
-              style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }
-            }, [
-              React.createElement('h5', { key: 'title' }, `Wariant ${variantIndex + 1}`),
-              React.createElement('button', {
-                key: 'remove',
-                onClick: () => removeVariant(variantIndex),
+              style: {
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '10px',
+              },
+            },
+            [
+              React.createElement('h4', { key: 'title' }, 'Warianty:'),
+              React.createElement(
+                'button',
+                {
+                  key: 'add',
+                  onClick: addVariant,
+                  style: {
+                    background: '#28a745',
+                    color: 'white',
+                    border: 'none',
+                    padding: '5px 10px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                  },
+                },
+                '+ Dodaj wariant'
+              ),
+            ]
+          ),
+
+          editedProduct.variants.map((variant, variantIndex) =>
+            React.createElement(
+              'div',
+              {
+                key: variantIndex,
                 style: {
-                  background: '#dc3545',
-                  color: 'white',
-                  border: 'none',
-                  padding: '3px 8px',
+                  border: '1px solid #e0e0e0',
                   borderRadius: '4px',
-                  cursor: 'pointer'
-                }
-              }, 'Usuń')
-            ]),
+                  padding: '15px',
+                  marginBottom: '10px',
+                  backgroundColor: 'white',
+                },
+              },
+              [
+                React.createElement(
+                  'div',
+                  {
+                    key: 'header',
+                    style: {
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '10px',
+                    },
+                  },
+                  [
+                    React.createElement('h5', { key: 'title' }, `Wariant ${variantIndex + 1}`),
+                    React.createElement(
+                      'button',
+                      {
+                        key: 'remove',
+                        onClick: () => removeVariant(variantIndex),
+                        style: {
+                          background: '#dc3545',
+                          color: 'white',
+                          border: 'none',
+                          padding: '3px 8px',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                        },
+                      },
+                      'Usuń'
+                    ),
+                  ]
+                ),
 
-            React.createElement('div', {
-              key: 'fields',
-              style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' }
-            }, [
-              React.createElement('div', { key: 'size' }, [
-                React.createElement('label', {
-                  key: 'label',
-                  style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                }, 'Rozmiar:'),
-                React.createElement('input', {
-                  key: 'input',
-                  type: 'text',
-                  value: variant.size_name,
-                  onChange: (e) => updateVariant(variantIndex, 'size_name', e.target.value),
-                  style: {
-                    width: '100%',
-                    padding: '6px',
-                    border: '1px solid #ccc',
-                    borderRadius: '4px'
-                  }
-                })
-              ]),
+                React.createElement(
+                  'div',
+                  {
+                    key: 'fields',
+                    style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' },
+                  },
+                  [
+                    React.createElement('div', { key: 'size' }, [
+                      React.createElement(
+                        'label',
+                        {
+                          key: 'label',
+                          style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                        },
+                        'Rozmiar:'
+                      ),
+                      React.createElement('input', {
+                        key: 'input',
+                        type: 'text',
+                        value: variant.size_name,
+                        onChange: e => updateVariant(variantIndex, 'size_name', e.target.value),
+                        style: {
+                          width: '100%',
+                          padding: '6px',
+                          border: '1px solid #ccc',
+                          borderRadius: '4px',
+                        },
+                      }),
+                    ]),
 
-              React.createElement('div', { key: 'stock' }, [
-                React.createElement('label', {
-                  key: 'label',
-                  style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                }, 'Stan magazynowy:'),
-                React.createElement('input', {
-                  key: 'input',
-                  type: 'number',
-                  value: variant.stock,
-                  onChange: (e) => updateVariant(variantIndex, 'stock', parseInt(e.target.value) || 0),
-                  style: {
-                    width: '100%',
-                    padding: '6px',
-                    border: '1px solid #ccc',
-                    borderRadius: '4px'
-                  }
-                })
-              ]),
+                    React.createElement('div', { key: 'stock' }, [
+                      React.createElement(
+                        'label',
+                        {
+                          key: 'label',
+                          style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                        },
+                        'Stan magazynowy:'
+                      ),
+                      React.createElement('input', {
+                        key: 'input',
+                        type: 'number',
+                        value: variant.stock,
+                        onChange: e =>
+                          updateVariant(variantIndex, 'stock', parseInt(e.target.value) || 0),
+                        style: {
+                          width: '100%',
+                          padding: '6px',
+                          border: '1px solid #ccc',
+                          borderRadius: '4px',
+                        },
+                      }),
+                    ]),
 
-              React.createElement('div', { key: 'ean' }, [
-                React.createElement('label', {
-                  key: 'label',
-                  style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                }, 'EAN:'),
-                React.createElement('input', {
-                  key: 'input',
-                  type: 'text',
-                  value: variant.ean,
-                  onChange: (e) => updateVariant(variantIndex, 'ean', e.target.value),
-                  style: {
-                    width: '100%',
-                    padding: '6px',
-                    border: '1px solid #ccc',
-                    borderRadius: '4px'
-                  }
-                })
-              ]),
+                    React.createElement('div', { key: 'ean' }, [
+                      React.createElement(
+                        'label',
+                        {
+                          key: 'label',
+                          style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                        },
+                        'EAN:'
+                      ),
+                      React.createElement('input', {
+                        key: 'input',
+                        type: 'text',
+                        value: variant.ean,
+                        onChange: e => updateVariant(variantIndex, 'ean', e.target.value),
+                        style: {
+                          width: '100%',
+                          padding: '6px',
+                          border: '1px solid #ccc',
+                          borderRadius: '4px',
+                        },
+                      }),
+                    ]),
 
-              React.createElement('div', { key: 'producer' }, [
-                React.createElement('label', {
-                  key: 'label',
-                  style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                }, 'Kod producenta:'),
-                React.createElement('input', {
-                  key: 'input',
-                  type: 'text',
-                  value: variant.producer_code,
-                  onChange: (e) => updateVariant(variantIndex, 'producer_code', e.target.value),
-                  style: {
-                    width: '100%',
-                    padding: '6px',
-                    border: '1px solid #ccc',
-                    borderRadius: '4px'
-                  }
-                })
-              ])
-            ])
-          ])
-        )
-      ])
-    ]),
+                    React.createElement('div', { key: 'producer' }, [
+                      React.createElement(
+                        'label',
+                        {
+                          key: 'label',
+                          style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                        },
+                        'Kod producenta:'
+                      ),
+                      React.createElement('input', {
+                        key: 'input',
+                        type: 'text',
+                        value: variant.producer_code,
+                        onChange: e => updateVariant(variantIndex, 'producer_code', e.target.value),
+                        style: {
+                          width: '100%',
+                          padding: '6px',
+                          border: '1px solid #ccc',
+                          borderRadius: '4px',
+                        },
+                      }),
+                    ]),
+                  ]
+                ),
+              ]
+            )
+          ),
+        ]),
+      ]),
 
-    // Przyciski
-    React.createElement('div', {
-      key: 'actions',
-      style: { marginTop: '15px' }
-    }, [
-      React.createElement('button', {
-        key: 'submit',
-        onClick: submitProduct,
-        disabled: isLoading,
-        style: {
-          background: '#28a745',
-          color: 'white',
-          border: 'none',
-          padding: '10px 20px',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          marginRight: '10px',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Tworzenie...' : 'Utwórz w MPD'),
-      
-      React.createElement('button', {
-        key: 'cancel',
-        onClick: () => {
-          const container = document.getElementById('bulk-create-single-container');
-          if (container) container.style.display = 'none';
+      // Przyciski
+      React.createElement(
+        'div',
+        {
+          key: 'actions',
+          style: { marginTop: '15px' },
         },
-        disabled: isLoading,
-        style: {
-          background: '#6c757d',
-          color: 'white',
-          border: 'none',
-          padding: '10px 20px',
-          borderRadius: '4px',
-          cursor: 'pointer'
-        }
-      }, 'Anuluj')
-    ])
-  ]);
+        [
+          React.createElement(
+            'button',
+            {
+              key: 'submit',
+              onClick: submitProduct,
+              disabled: isLoading,
+              style: {
+                background: '#28a745',
+                color: 'white',
+                border: 'none',
+                padding: '10px 20px',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                marginRight: '10px',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Tworzenie...' : 'Utwórz w MPD'
+          ),
+
+          React.createElement(
+            'button',
+            {
+              key: 'cancel',
+              onClick: () => {
+                const container = document.getElementById('bulk-create-single-container');
+                if (container) container.style.display = 'none';
+              },
+              disabled: isLoading,
+              style: {
+                background: '#6c757d',
+                color: 'white',
+                border: 'none',
+                padding: '10px 20px',
+                borderRadius: '4px',
+                cursor: 'pointer',
+              },
+            },
+            'Anuluj'
+          ),
+        ]
+      ),
+    ]
+  );
 }
 
 // ProductMapping Component
@@ -358,12 +451,15 @@ function ProductMapping({ productId, isMapped, mappedProductId }) {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
     } catch (error) {
       console.error('Error:', error);
       showMessage('Wystąpił błąd podczas uploadowania obrazów', 'error');
@@ -379,13 +475,16 @@ function ProductMapping({ productId, isMapped, mappedProductId }) {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
-      
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
+
       if (data.success) {
         setTimeout(() => window.location.reload(), 1500);
       }
@@ -404,13 +503,16 @@ function ProductMapping({ productId, isMapped, mappedProductId }) {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
-      
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
+
       if (data.success) {
         setTimeout(() => window.location.reload(), 1500);
       }
@@ -430,16 +532,22 @@ function ProductMapping({ productId, isMapped, mappedProductId }) {
     try {
       const formData = new FormData();
       formData.append('size_category', sizeCategory);
-      formData.append('csrfmiddlewaretoken', document.querySelector('[name=csrfmiddlewaretoken]').value);
+      formData.append(
+        'csrfmiddlewaretoken',
+        document.querySelector('[name=csrfmiddlewaretoken]').value
+      );
 
       const response = await fetch(`/admin/matterhorn1/product/add-variants/${productId}/`, {
         method: 'POST',
-        body: formData
+        body: formData,
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
-      
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
+
       if (data.success) {
         setTimeout(() => window.location.reload(), 1500);
       }
@@ -455,89 +563,118 @@ function ProductMapping({ productId, isMapped, mappedProductId }) {
     return null;
   }
 
-  return React.createElement('div', {
-    style: { marginTop: '20px', borderTop: '1px solid #ccc', paddingTop: '20px' }
-  }, [
-    React.createElement('h3', { key: 'title' }, 'Zaawansowane funkcje'),
-    
-    message && React.createElement('div', {
-      key: 'message',
-      className: `status-message ${messageType}`,
-      style: {
-        margin: '10px 0',
-        padding: '10px',
-        borderRadius: '4px',
-        backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-        color: messageType === 'success' ? '#155724' : '#721c24',
-        border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-      }
-    }, message),
-    
-    React.createElement('div', {
-      key: 'buttons',
-      style: { display: 'flex', gap: '10px', flexWrap: 'wrap' }
-    }, [
-      React.createElement('button', {
-        key: 'upload',
-        onClick: uploadImages,
-        disabled: isLoading,
-        style: {
-          background: '#28a745',
-          color: 'white',
-          border: 'none',
-          padding: '8px 16px',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Przetwarzanie...' : 'Upload obrazów'),
-      
-      React.createElement('button', {
-        key: 'variants',
-        onClick: autoMapVariants,
-        disabled: isLoading,
-        style: {
-          background: '#17a2b8',
-          color: 'white',
-          border: 'none',
-          padding: '8px 16px',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Przetwarzanie...' : 'Auto-mapuj warianty'),
-      
-      React.createElement('button', {
-        key: 'add-variants',
-        onClick: addVariants,
-        disabled: isLoading,
-        style: {
-          background: '#6f42c1',
-          color: 'white',
-          border: 'none',
-          padding: '8px 16px',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Przetwarzanie...' : 'Dodaj warianty'),
-      
-      React.createElement('button', {
-        key: 'sync',
-        onClick: syncWithMpd,
-        disabled: isLoading,
-        style: {
-          background: '#ffc107',
-          color: 'black',
-          border: 'none',
-          padding: '8px 16px',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Przetwarzanie...' : 'Synchronizuj z MPD')
-    ])
-  ]);
+  return React.createElement(
+    'div',
+    {
+      style: { marginTop: '20px', borderTop: '1px solid #ccc', paddingTop: '20px' },
+    },
+    [
+      React.createElement('h3', { key: 'title' }, 'Zaawansowane funkcje'),
+
+      message &&
+        React.createElement(
+          'div',
+          {
+            key: 'message',
+            className: `status-message ${messageType}`,
+            style: {
+              margin: '10px 0',
+              padding: '10px',
+              borderRadius: '4px',
+              backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+              color: messageType === 'success' ? '#155724' : '#721c24',
+              border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+            },
+          },
+          message
+        ),
+
+      React.createElement(
+        'div',
+        {
+          key: 'buttons',
+          style: { display: 'flex', gap: '10px', flexWrap: 'wrap' },
+        },
+        [
+          React.createElement(
+            'button',
+            {
+              key: 'upload',
+              onClick: uploadImages,
+              disabled: isLoading,
+              style: {
+                background: '#28a745',
+                color: 'white',
+                border: 'none',
+                padding: '8px 16px',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Przetwarzanie...' : 'Upload obrazów'
+          ),
+
+          React.createElement(
+            'button',
+            {
+              key: 'variants',
+              onClick: autoMapVariants,
+              disabled: isLoading,
+              style: {
+                background: '#17a2b8',
+                color: 'white',
+                border: 'none',
+                padding: '8px 16px',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Przetwarzanie...' : 'Auto-mapuj warianty'
+          ),
+
+          React.createElement(
+            'button',
+            {
+              key: 'add-variants',
+              onClick: addVariants,
+              disabled: isLoading,
+              style: {
+                background: '#6f42c1',
+                color: 'white',
+                border: 'none',
+                padding: '8px 16px',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Przetwarzanie...' : 'Dodaj warianty'
+          ),
+
+          React.createElement(
+            'button',
+            {
+              key: 'sync',
+              onClick: syncWithMpd,
+              disabled: isLoading,
+              style: {
+                background: '#ffc107',
+                color: 'black',
+                border: 'none',
+                padding: '8px 16px',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Przetwarzanie...' : 'Synchronizuj z MPD'
+          ),
+        ]
+      ),
+    ]
+  );
 }
 
 // BulkMapping Component
@@ -556,14 +693,14 @@ function BulkMapping({ mappings, onComplete }) {
   const handleSuggestionClick = (productId, mpdId) => {
     setSelectedMappings(prev => ({
       ...prev,
-      [productId]: mpdId
+      [productId]: mpdId,
     }));
   };
 
   const submitMappings = async () => {
     const mappingsData = Object.entries(selectedMappings).map(([productId, mpdId]) => ({
       product_id: parseInt(productId),
-      mpd_product_id: parseInt(mpdId)
+      mpd_product_id: parseInt(mpdId),
     }));
 
     if (mappingsData.length === 0) {
@@ -577,13 +714,13 @@ function BulkMapping({ mappings, onComplete }) {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ mappings: mappingsData })
+        body: JSON.stringify({ mappings: mappingsData }),
       });
 
       const data = await response.json();
-      
+
       if (data.success) {
         showMessage(data.message, 'success');
         setTimeout(() => {
@@ -601,165 +738,228 @@ function BulkMapping({ mappings, onComplete }) {
     }
   };
 
-  return React.createElement('div', {
-    style: { maxWidth: '1200px', margin: '20px auto', padding: '20px' }
-  }, [
-    React.createElement('h1', { key: 'title' }, 'Mapowanie produktów do MPD'),
-    React.createElement('p', { key: 'subtitle' }, 'Wybierz mapowania dla wybranych produktów:'),
-    
-    message && React.createElement('div', {
-      key: 'message',
-      className: `status-message ${messageType}`,
-      style: {
-        margin: '20px 0',
-        padding: '15px',
-        borderRadius: '4px',
-        backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-        color: messageType === 'success' ? '#155724' : '#721c24',
-        border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-      }
-    }, message),
+  return React.createElement(
+    'div',
+    {
+      style: { maxWidth: '1200px', margin: '20px auto', padding: '20px' },
+    },
+    [
+      React.createElement('h1', { key: 'title' }, 'Mapowanie produktów do MPD'),
+      React.createElement('p', { key: 'subtitle' }, 'Wybierz mapowania dla wybranych produktów:'),
 
-    React.createElement('div', { key: 'mappings' }, mappings.map((mapping) =>
-      React.createElement('div', {
-        key: mapping.product.id,
-        style: {
-          border: '1px solid #ddd',
-          borderRadius: '8px',
-          marginBottom: '20px',
-          padding: '20px',
-          backgroundColor: '#f9f9f9'
-        }
-      }, [
-        React.createElement('div', {
-          key: 'info',
-          style: {
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: '15px'
-          }
-        }, [
-          React.createElement('div', { key: 'details', style: { flex: 1 } }, [
-            React.createElement('div', {
-              key: 'name',
+      message &&
+        React.createElement(
+          'div',
+          {
+            key: 'message',
+            className: `status-message ${messageType}`,
+            style: {
+              margin: '20px 0',
+              padding: '15px',
+              borderRadius: '4px',
+              backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+              color: messageType === 'success' ? '#155724' : '#721c24',
+              border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+            },
+          },
+          message
+        ),
+
+      React.createElement(
+        'div',
+        { key: 'mappings' },
+        mappings.map(mapping =>
+          React.createElement(
+            'div',
+            {
+              key: mapping.product.id,
               style: {
-                fontWeight: 'bold',
-                fontSize: '1.1em',
-                color: '#333'
-              }
-            }, mapping.product.name),
-            React.createElement('div', {
-              key: 'meta',
-              style: {
-                color: '#666',
-                fontSize: '0.9em',
-                marginTop: '5px'
-              }
-            }, `ID: ${mapping.product.product_uid} | Marka: ${mapping.product.brand?.name || 'Brak'} | Kategoria: ${mapping.product.category?.name || 'Brak'}`)
-          ])
-        ]),
-        
-        React.createElement('div', { key: 'suggestions', style: { marginTop: '15px' } }, [
-          React.createElement('h4', { key: 'title' }, 'Sugerowane mapowania:'),
-          mapping.suggestions && mapping.suggestions.length > 0 
-            ? mapping.suggestions.map((suggestion) =>
-                React.createElement('div', {
-                  key: suggestion.id,
-                  onClick: () => handleSuggestionClick(mapping.product.id, suggestion.id),
+                border: '1px solid #ddd',
+                borderRadius: '8px',
+                marginBottom: '20px',
+                padding: '20px',
+                backgroundColor: '#f9f9f9',
+              },
+            },
+            [
+              React.createElement(
+                'div',
+                {
+                  key: 'info',
                   style: {
                     display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'center',
-                    padding: '10px',
-                    border: selectedMappings[mapping.product.id] === suggestion.id 
-                      ? '2px solid #28a745' 
-                      : '1px solid #e0e0e0',
-                    borderRadius: '4px',
-                    marginBottom: '8px',
-                    backgroundColor: selectedMappings[mapping.product.id] === suggestion.id 
-                      ? '#f8fff9' 
-                      : 'white',
-                    cursor: 'pointer',
-                    transition: 'all 0.3s'
-                  }
-                }, [
+                    marginBottom: '15px',
+                  },
+                },
+                [
                   React.createElement('div', { key: 'details', style: { flex: 1 } }, [
-                    React.createElement('div', {
-                      key: 'name',
-                      style: { fontWeight: 500, color: '#333' }
-                    }, suggestion.name),
-                    React.createElement('div', {
-                      key: 'brand',
-                      style: { color: '#666', fontSize: '0.9em' }
-                    }, suggestion.brand)
+                    React.createElement(
+                      'div',
+                      {
+                        key: 'name',
+                        style: {
+                          fontWeight: 'bold',
+                          fontSize: '1.1em',
+                          color: '#333',
+                        },
+                      },
+                      mapping.product.name
+                    ),
+                    React.createElement(
+                      'div',
+                      {
+                        key: 'meta',
+                        style: {
+                          color: '#666',
+                          fontSize: '0.9em',
+                          marginTop: '5px',
+                        },
+                      },
+                      `ID: ${mapping.product.product_uid} | Marka: ${mapping.product.brand?.name || 'Brak'} | Kategoria: ${mapping.product.category?.name || 'Brak'}`
+                    ),
                   ]),
-                  React.createElement('div', {
-                    key: 'similarity',
-                    style: {
-                      color: '#28a745',
-                      fontWeight: 'bold',
-                      marginLeft: '10px'
-                    }
-                  }, `${suggestion.similarity}%`)
-                ])
-              )
-            : React.createElement('div', {
-                key: 'no-suggestions',
-                style: {
-                  color: '#666',
-                  fontStyle: 'italic',
-                  textAlign: 'center',
-                  padding: '20px'
-                }
-              }, 'Brak sugerowanych mapowań')
-        ])
-      ])
-    )),
-    
-    React.createElement('div', {
-      key: 'actions',
-      style: {
-        marginTop: '30px',
-        textAlign: 'center',
-        padding: '20px',
-        borderTop: '1px solid #ddd'
-      }
-    }, [
-      React.createElement('button', {
-        key: 'submit',
-        onClick: submitMappings,
-        disabled: isLoading,
-        style: {
-          padding: '10px 20px',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          fontSize: '14px',
-          margin: '0 10px',
-          backgroundColor: '#417690',
-          color: 'white',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Zapisywanie...' : 'Zapisz mapowania'),
-      
-      React.createElement('button', {
-        key: 'cancel',
-        onClick: () => window.history.back(),
-        disabled: isLoading,
-        style: {
-          padding: '10px 20px',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: '14px',
-          margin: '0 10px',
-          backgroundColor: '#6c757d',
-          color: 'white'
-        }
-      }, 'Anuluj')
-    ])
-  ]);
+                ]
+              ),
+
+              React.createElement('div', { key: 'suggestions', style: { marginTop: '15px' } }, [
+                React.createElement('h4', { key: 'title' }, 'Sugerowane mapowania:'),
+                mapping.suggestions && mapping.suggestions.length > 0
+                  ? mapping.suggestions.map(suggestion =>
+                      React.createElement(
+                        'div',
+                        {
+                          key: suggestion.id,
+                          onClick: () => handleSuggestionClick(mapping.product.id, suggestion.id),
+                          style: {
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: '10px',
+                            border:
+                              selectedMappings[mapping.product.id] === suggestion.id
+                                ? '2px solid #28a745'
+                                : '1px solid #e0e0e0',
+                            borderRadius: '4px',
+                            marginBottom: '8px',
+                            backgroundColor:
+                              selectedMappings[mapping.product.id] === suggestion.id
+                                ? '#f8fff9'
+                                : 'white',
+                            cursor: 'pointer',
+                            transition: 'all 0.3s',
+                          },
+                        },
+                        [
+                          React.createElement('div', { key: 'details', style: { flex: 1 } }, [
+                            React.createElement(
+                              'div',
+                              {
+                                key: 'name',
+                                style: { fontWeight: 500, color: '#333' },
+                              },
+                              suggestion.name
+                            ),
+                            React.createElement(
+                              'div',
+                              {
+                                key: 'brand',
+                                style: { color: '#666', fontSize: '0.9em' },
+                              },
+                              suggestion.brand
+                            ),
+                          ]),
+                          React.createElement(
+                            'div',
+                            {
+                              key: 'similarity',
+                              style: {
+                                color: '#28a745',
+                                fontWeight: 'bold',
+                                marginLeft: '10px',
+                              },
+                            },
+                            `${suggestion.similarity}%`
+                          ),
+                        ]
+                      )
+                    )
+                  : React.createElement(
+                      'div',
+                      {
+                        key: 'no-suggestions',
+                        style: {
+                          color: '#666',
+                          fontStyle: 'italic',
+                          textAlign: 'center',
+                          padding: '20px',
+                        },
+                      },
+                      'Brak sugerowanych mapowań'
+                    ),
+              ]),
+            ]
+          )
+        )
+      ),
+
+      React.createElement(
+        'div',
+        {
+          key: 'actions',
+          style: {
+            marginTop: '30px',
+            textAlign: 'center',
+            padding: '20px',
+            borderTop: '1px solid #ddd',
+          },
+        },
+        [
+          React.createElement(
+            'button',
+            {
+              key: 'submit',
+              onClick: submitMappings,
+              disabled: isLoading,
+              style: {
+                padding: '10px 20px',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                fontSize: '14px',
+                margin: '0 10px',
+                backgroundColor: '#417690',
+                color: 'white',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Zapisywanie...' : 'Zapisz mapowania'
+          ),
+
+          React.createElement(
+            'button',
+            {
+              key: 'cancel',
+              onClick: () => window.history.back(),
+              disabled: isLoading,
+              style: {
+                padding: '10px 20px',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '14px',
+                margin: '0 10px',
+                backgroundColor: '#6c757d',
+                color: 'white',
+              },
+            },
+            'Anuluj'
+          ),
+        ]
+      ),
+    ]
+  );
 }
 
 // BulkCreate Component
@@ -771,13 +971,15 @@ function BulkCreate({ productsData, onComplete }) {
 
   useEffect(() => {
     // Inicjalizuj dane produktów
-    setEditedProducts(productsData.map(product => ({
-      ...product,
-      name: product.name || '',
-      description: product.description || '',
-      brand_name: product.brand_name || '',
-      variants: product.variants || []
-    })));
+    setEditedProducts(
+      productsData.map(product => ({
+        ...product,
+        name: product.name || '',
+        description: product.description || '',
+        brand_name: product.brand_name || '',
+        variants: product.variants || [],
+      }))
+    );
   }, [productsData]);
 
   const showMessage = (text, type) => {
@@ -787,49 +989,58 @@ function BulkCreate({ productsData, onComplete }) {
   };
 
   const updateProduct = (index, field, value) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === index ? { ...product, [field]: value } : product
-    ));
+    setEditedProducts(prev =>
+      prev.map((product, i) => (i === index ? { ...product, [field]: value } : product))
+    );
   };
 
   const updateVariant = (productIndex, variantIndex, field, value) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === productIndex 
-        ? {
-            ...product,
-            variants: product.variants.map((variant, j) => 
-              j === variantIndex ? { ...variant, [field]: value } : variant
-            )
-          }
-        : product
-    ));
+    setEditedProducts(prev =>
+      prev.map((product, i) =>
+        i === productIndex
+          ? {
+              ...product,
+              variants: product.variants.map((variant, j) =>
+                j === variantIndex ? { ...variant, [field]: value } : variant
+              ),
+            }
+          : product
+      )
+    );
   };
 
-  const addVariant = (productIndex) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === productIndex 
-        ? {
-            ...product,
-            variants: [...product.variants, {
-              size_name: '',
-              stock: 0,
-              ean: '',
-              producer_code: ''
-            }]
-          }
-        : product
-    ));
+  const addVariant = productIndex => {
+    setEditedProducts(prev =>
+      prev.map((product, i) =>
+        i === productIndex
+          ? {
+              ...product,
+              variants: [
+                ...product.variants,
+                {
+                  size_name: '',
+                  stock: 0,
+                  ean: '',
+                  producer_code: '',
+                },
+              ],
+            }
+          : product
+      )
+    );
   };
 
   const removeVariant = (productIndex, variantIndex) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === productIndex 
-        ? {
-            ...product,
-            variants: product.variants.filter((_, j) => j !== variantIndex)
-          }
-        : product
-    ));
+    setEditedProducts(prev =>
+      prev.map((product, i) =>
+        i === productIndex
+          ? {
+              ...product,
+              variants: product.variants.filter((_, j) => j !== variantIndex),
+            }
+          : product
+      )
+    );
   };
 
   const submitProducts = async () => {
@@ -839,13 +1050,13 @@ function BulkCreate({ productsData, onComplete }) {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ products: editedProducts })
+        body: JSON.stringify({ products: editedProducts }),
       });
 
       const data = await response.json();
-      
+
       if (data.success) {
         showMessage(data.message, 'success');
         setTimeout(() => {
@@ -863,289 +1074,407 @@ function BulkCreate({ productsData, onComplete }) {
     }
   };
 
-  return React.createElement('div', {
-    style: { maxWidth: '1200px', margin: '20px auto', padding: '20px' }
-  }, [
-    React.createElement('h1', { key: 'title' }, 'Tworzenie nowych produktów w MPD'),
-    
-    message && React.createElement('div', {
-      key: 'message',
-      className: `status-message ${messageType}`,
-      style: {
-        margin: '20px 0',
-        padding: '15px',
-        borderRadius: '4px',
-        backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-        color: messageType === 'success' ? '#155724' : '#721c24',
-        border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-      }
-    }, message),
+  return React.createElement(
+    'div',
+    {
+      style: { maxWidth: '1200px', margin: '20px auto', padding: '20px' },
+    },
+    [
+      React.createElement('h1', { key: 'title' }, 'Tworzenie nowych produktów w MPD'),
 
-    React.createElement('div', { key: 'products' }, editedProducts.map((product, productIndex) =>
-      React.createElement('div', {
-        key: product.matterhorn_product_id,
-        style: {
-          border: '1px solid #ddd',
-          borderRadius: '8px',
-          marginBottom: '20px',
-          padding: '20px',
-          backgroundColor: '#f9f9f9'
-        }
-      }, [
-        React.createElement('h3', { key: 'title' }, `Produkt ID: ${product.matterhorn_product_id}`),
-        
-        React.createElement('div', { key: 'name', style: { marginBottom: '15px' } }, [
-          React.createElement('label', {
-            key: 'label',
-            style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' }
-          }, 'Nazwa:'),
-          React.createElement('input', {
-            key: 'input',
-            type: 'text',
-            value: product.name,
-            onChange: (e) => updateProduct(productIndex, 'name', e.target.value),
+      message &&
+        React.createElement(
+          'div',
+          {
+            key: 'message',
+            className: `status-message ${messageType}`,
             style: {
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #ccc',
-              borderRadius: '4px'
-            }
-          })
-        ]),
+              margin: '20px 0',
+              padding: '15px',
+              borderRadius: '4px',
+              backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+              color: messageType === 'success' ? '#155724' : '#721c24',
+              border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+            },
+          },
+          message
+        ),
 
-        React.createElement('div', { key: 'description', style: { marginBottom: '15px' } }, [
-          React.createElement('label', {
-            key: 'label',
-            style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' }
-          }, 'Opis:'),
-          React.createElement('textarea', {
-            key: 'textarea',
-            value: product.description,
-            onChange: (e) => updateProduct(productIndex, 'description', e.target.value),
-            rows: 3,
-            style: {
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #ccc',
-              borderRadius: '4px'
-            }
-          })
-        ]),
-
-        React.createElement('div', { key: 'brand', style: { marginBottom: '15px' } }, [
-          React.createElement('label', {
-            key: 'label',
-            style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' }
-          }, 'Marka:'),
-          React.createElement('input', {
-            key: 'input',
-            type: 'text',
-            value: product.brand_name,
-            onChange: (e) => updateProduct(productIndex, 'brand_name', e.target.value),
-            style: {
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #ccc',
-              borderRadius: '4px'
-            }
-          })
-        ]),
-
-        React.createElement('div', { key: 'variants' }, [
-          React.createElement('div', {
-            key: 'header',
-            style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }
-          }, [
-            React.createElement('h4', { key: 'title' }, 'Warianty:'),
-            React.createElement('button', {
-              key: 'add',
-              onClick: () => addVariant(productIndex),
+      React.createElement(
+        'div',
+        { key: 'products' },
+        editedProducts.map((product, productIndex) =>
+          React.createElement(
+            'div',
+            {
+              key: product.matterhorn_product_id,
               style: {
-                background: '#28a745',
-                color: 'white',
-                border: 'none',
-                padding: '5px 10px',
-                borderRadius: '4px',
-                cursor: 'pointer'
-              }
-            }, '+ Dodaj wariant')
-          ]),
+                border: '1px solid #ddd',
+                borderRadius: '8px',
+                marginBottom: '20px',
+                padding: '20px',
+                backgroundColor: '#f9f9f9',
+              },
+            },
+            [
+              React.createElement(
+                'h3',
+                { key: 'title' },
+                `Produkt ID: ${product.matterhorn_product_id}`
+              ),
 
-          product.variants.map((variant, variantIndex) =>
-            React.createElement('div', {
-              key: variantIndex,
-              style: {
-                border: '1px solid #e0e0e0',
-                borderRadius: '4px',
-                padding: '15px',
-                marginBottom: '10px',
-                backgroundColor: 'white'
-              }
-            }, [
-              React.createElement('div', {
-                key: 'header',
-                style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }
-              }, [
-                React.createElement('h5', { key: 'title' }, `Wariant ${variantIndex + 1}`),
-                React.createElement('button', {
-                  key: 'remove',
-                  onClick: () => removeVariant(productIndex, variantIndex),
+              React.createElement('div', { key: 'name', style: { marginBottom: '15px' } }, [
+                React.createElement(
+                  'label',
+                  {
+                    key: 'label',
+                    style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+                  },
+                  'Nazwa:'
+                ),
+                React.createElement('input', {
+                  key: 'input',
+                  type: 'text',
+                  value: product.name,
+                  onChange: e => updateProduct(productIndex, 'name', e.target.value),
                   style: {
-                    background: '#dc3545',
-                    color: 'white',
-                    border: 'none',
-                    padding: '3px 8px',
+                    width: '100%',
+                    padding: '8px',
+                    border: '1px solid #ccc',
                     borderRadius: '4px',
-                    cursor: 'pointer'
-                  }
-                }, 'Usuń')
+                  },
+                }),
               ]),
 
-              React.createElement('div', {
-                key: 'fields',
-                style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' }
-              }, [
-                React.createElement('div', { key: 'size' }, [
-                  React.createElement('label', {
+              React.createElement('div', { key: 'description', style: { marginBottom: '15px' } }, [
+                React.createElement(
+                  'label',
+                  {
                     key: 'label',
-                    style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                  }, 'Rozmiar:'),
-                  React.createElement('input', {
-                    key: 'input',
-                    type: 'text',
-                    value: variant.size_name,
-                    onChange: (e) => updateVariant(productIndex, variantIndex, 'size_name', e.target.value),
-                    style: {
-                      width: '100%',
-                      padding: '6px',
-                      border: '1px solid #ccc',
-                      borderRadius: '4px'
-                    }
-                  })
-                ]),
+                    style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+                  },
+                  'Opis:'
+                ),
+                React.createElement('textarea', {
+                  key: 'textarea',
+                  value: product.description,
+                  onChange: e => updateProduct(productIndex, 'description', e.target.value),
+                  rows: 3,
+                  style: {
+                    width: '100%',
+                    padding: '8px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                  },
+                }),
+              ]),
 
-                React.createElement('div', { key: 'stock' }, [
-                  React.createElement('label', {
+              React.createElement('div', { key: 'brand', style: { marginBottom: '15px' } }, [
+                React.createElement(
+                  'label',
+                  {
                     key: 'label',
-                    style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                  }, 'Stan magazynowy:'),
-                  React.createElement('input', {
-                    key: 'input',
-                    type: 'number',
-                    value: variant.stock,
-                    onChange: (e) => updateVariant(productIndex, variantIndex, 'stock', parseInt(e.target.value) || 0),
-                    style: {
-                      width: '100%',
-                      padding: '6px',
-                      border: '1px solid #ccc',
-                      borderRadius: '4px'
-                    }
-                  })
-                ]),
+                    style: { display: 'block', marginBottom: '5px', fontWeight: 'bold' },
+                  },
+                  'Marka:'
+                ),
+                React.createElement('input', {
+                  key: 'input',
+                  type: 'text',
+                  value: product.brand_name,
+                  onChange: e => updateProduct(productIndex, 'brand_name', e.target.value),
+                  style: {
+                    width: '100%',
+                    padding: '8px',
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                  },
+                }),
+              ]),
 
-                React.createElement('div', { key: 'ean' }, [
-                  React.createElement('label', {
-                    key: 'label',
-                    style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                  }, 'EAN:'),
-                  React.createElement('input', {
-                    key: 'input',
-                    type: 'text',
-                    value: variant.ean,
-                    onChange: (e) => updateVariant(productIndex, variantIndex, 'ean', e.target.value),
+              React.createElement('div', { key: 'variants' }, [
+                React.createElement(
+                  'div',
+                  {
+                    key: 'header',
                     style: {
-                      width: '100%',
-                      padding: '6px',
-                      border: '1px solid #ccc',
-                      borderRadius: '4px'
-                    }
-                  })
-                ]),
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '10px',
+                    },
+                  },
+                  [
+                    React.createElement('h4', { key: 'title' }, 'Warianty:'),
+                    React.createElement(
+                      'button',
+                      {
+                        key: 'add',
+                        onClick: () => addVariant(productIndex),
+                        style: {
+                          background: '#28a745',
+                          color: 'white',
+                          border: 'none',
+                          padding: '5px 10px',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                        },
+                      },
+                      '+ Dodaj wariant'
+                    ),
+                  ]
+                ),
 
-                React.createElement('div', { key: 'producer' }, [
-                  React.createElement('label', {
-                    key: 'label',
-                    style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' }
-                  }, 'Kod producenta:'),
-                  React.createElement('input', {
-                    key: 'input',
-                    type: 'text',
-                    value: variant.producer_code,
-                    onChange: (e) => updateVariant(productIndex, variantIndex, 'producer_code', e.target.value),
-                    style: {
-                      width: '100%',
-                      padding: '6px',
-                      border: '1px solid #ccc',
-                      borderRadius: '4px'
-                    }
-                  })
-                ])
-              ])
-            ])
+                product.variants.map((variant, variantIndex) =>
+                  React.createElement(
+                    'div',
+                    {
+                      key: variantIndex,
+                      style: {
+                        border: '1px solid #e0e0e0',
+                        borderRadius: '4px',
+                        padding: '15px',
+                        marginBottom: '10px',
+                        backgroundColor: 'white',
+                      },
+                    },
+                    [
+                      React.createElement(
+                        'div',
+                        {
+                          key: 'header',
+                          style: {
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            marginBottom: '10px',
+                          },
+                        },
+                        [
+                          React.createElement(
+                            'h5',
+                            { key: 'title' },
+                            `Wariant ${variantIndex + 1}`
+                          ),
+                          React.createElement(
+                            'button',
+                            {
+                              key: 'remove',
+                              onClick: () => removeVariant(productIndex, variantIndex),
+                              style: {
+                                background: '#dc3545',
+                                color: 'white',
+                                border: 'none',
+                                padding: '3px 8px',
+                                borderRadius: '4px',
+                                cursor: 'pointer',
+                              },
+                            },
+                            'Usuń'
+                          ),
+                        ]
+                      ),
+
+                      React.createElement(
+                        'div',
+                        {
+                          key: 'fields',
+                          style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' },
+                        },
+                        [
+                          React.createElement('div', { key: 'size' }, [
+                            React.createElement(
+                              'label',
+                              {
+                                key: 'label',
+                                style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                              },
+                              'Rozmiar:'
+                            ),
+                            React.createElement('input', {
+                              key: 'input',
+                              type: 'text',
+                              value: variant.size_name,
+                              onChange: e =>
+                                updateVariant(
+                                  productIndex,
+                                  variantIndex,
+                                  'size_name',
+                                  e.target.value
+                                ),
+                              style: {
+                                width: '100%',
+                                padding: '6px',
+                                border: '1px solid #ccc',
+                                borderRadius: '4px',
+                              },
+                            }),
+                          ]),
+
+                          React.createElement('div', { key: 'stock' }, [
+                            React.createElement(
+                              'label',
+                              {
+                                key: 'label',
+                                style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                              },
+                              'Stan magazynowy:'
+                            ),
+                            React.createElement('input', {
+                              key: 'input',
+                              type: 'number',
+                              value: variant.stock,
+                              onChange: e =>
+                                updateVariant(
+                                  productIndex,
+                                  variantIndex,
+                                  'stock',
+                                  parseInt(e.target.value) || 0
+                                ),
+                              style: {
+                                width: '100%',
+                                padding: '6px',
+                                border: '1px solid #ccc',
+                                borderRadius: '4px',
+                              },
+                            }),
+                          ]),
+
+                          React.createElement('div', { key: 'ean' }, [
+                            React.createElement(
+                              'label',
+                              {
+                                key: 'label',
+                                style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                              },
+                              'EAN:'
+                            ),
+                            React.createElement('input', {
+                              key: 'input',
+                              type: 'text',
+                              value: variant.ean,
+                              onChange: e =>
+                                updateVariant(productIndex, variantIndex, 'ean', e.target.value),
+                              style: {
+                                width: '100%',
+                                padding: '6px',
+                                border: '1px solid #ccc',
+                                borderRadius: '4px',
+                              },
+                            }),
+                          ]),
+
+                          React.createElement('div', { key: 'producer' }, [
+                            React.createElement(
+                              'label',
+                              {
+                                key: 'label',
+                                style: { display: 'block', marginBottom: '5px', fontSize: '0.9em' },
+                              },
+                              'Kod producenta:'
+                            ),
+                            React.createElement('input', {
+                              key: 'input',
+                              type: 'text',
+                              value: variant.producer_code,
+                              onChange: e =>
+                                updateVariant(
+                                  productIndex,
+                                  variantIndex,
+                                  'producer_code',
+                                  e.target.value
+                                ),
+                              style: {
+                                width: '100%',
+                                padding: '6px',
+                                border: '1px solid #ccc',
+                                borderRadius: '4px',
+                              },
+                            }),
+                          ]),
+                        ]
+                      ),
+                    ]
+                  )
+                ),
+              ]),
+            ]
           )
-        ])
-      ])
-    )),
-    
-    React.createElement('div', {
-      key: 'actions',
-      style: {
-        marginTop: '30px',
-        textAlign: 'center',
-        padding: '20px',
-        borderTop: '1px solid #ddd'
-      }
-    }, [
-      React.createElement('button', {
-        key: 'submit',
-        onClick: submitProducts,
-        disabled: isLoading,
-        style: {
-          padding: '10px 20px',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: isLoading ? 'not-allowed' : 'pointer',
-          fontSize: '14px',
-          margin: '0 10px',
-          backgroundColor: '#28a745',
-          color: 'white',
-          opacity: isLoading ? 0.6 : 1
-        }
-      }, isLoading ? 'Tworzenie...' : 'Utwórz produkty w MPD'),
-      
-      React.createElement('button', {
-        key: 'cancel',
-        onClick: () => window.history.back(),
-        disabled: isLoading,
-        style: {
-          padding: '10px 20px',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: '14px',
-          margin: '0 10px',
-          backgroundColor: '#6c757d',
-          color: 'white'
-        }
-      }, 'Anuluj')
-    ])
-  ]);
+        )
+      ),
+
+      React.createElement(
+        'div',
+        {
+          key: 'actions',
+          style: {
+            marginTop: '30px',
+            textAlign: 'center',
+            padding: '20px',
+            borderTop: '1px solid #ddd',
+          },
+        },
+        [
+          React.createElement(
+            'button',
+            {
+              key: 'submit',
+              onClick: submitProducts,
+              disabled: isLoading,
+              style: {
+                padding: '10px 20px',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: isLoading ? 'not-allowed' : 'pointer',
+                fontSize: '14px',
+                margin: '0 10px',
+                backgroundColor: '#28a745',
+                color: 'white',
+                opacity: isLoading ? 0.6 : 1,
+              },
+            },
+            isLoading ? 'Tworzenie...' : 'Utwórz produkty w MPD'
+          ),
+
+          React.createElement(
+            'button',
+            {
+              key: 'cancel',
+              onClick: () => window.history.back(),
+              disabled: isLoading,
+              style: {
+                padding: '10px 20px',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '14px',
+                margin: '0 10px',
+                backgroundColor: '#6c757d',
+                color: 'white',
+              },
+            },
+            'Anuluj'
+          ),
+        ]
+      ),
+    ]
+  );
 }
 
 // Inicjalizacja komponentów
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   // ProductMapping - dla pojedynczego produktu
   const productMappingContainer = document.getElementById('product-mapping-container');
   if (productMappingContainer) {
     const productId = parseInt(productMappingContainer.dataset.productId);
     const isMapped = productMappingContainer.dataset.isMapped === 'true';
     const mappedProductId = productMappingContainer.dataset.mappedProductId;
-    
+
     ReactDOM.render(
       React.createElement(ProductMapping, {
         productId: productId,
         isMapped: isMapped,
-        mappedProductId: mappedProductId
+        mappedProductId: mappedProductId,
       }),
       productMappingContainer
     );
@@ -1155,11 +1484,11 @@ document.addEventListener('DOMContentLoaded', function() {
   const bulkMappingContainer = document.getElementById('bulk-mapping-container');
   if (bulkMappingContainer) {
     const mappings = JSON.parse(bulkMappingContainer.dataset.mappings || '[]');
-    
+
     ReactDOM.render(
       React.createElement(BulkMapping, {
         mappings: mappings,
-        onComplete: () => window.location.href = '/admin/matterhorn1/product/'
+        onComplete: () => (window.location.href = '/admin/matterhorn1/product/'),
       }),
       bulkMappingContainer
     );
@@ -1169,11 +1498,11 @@ document.addEventListener('DOMContentLoaded', function() {
   const bulkCreateContainer = document.getElementById('bulk-create-container');
   if (bulkCreateContainer) {
     const productsData = JSON.parse(bulkCreateContainer.dataset.productsData || '[]');
-    
+
     ReactDOM.render(
       React.createElement(BulkCreate, {
         productsData: productsData,
-        onComplete: () => window.location.href = '/admin/matterhorn1/product/'
+        onComplete: () => (window.location.href = '/admin/matterhorn1/product/'),
       }),
       bulkCreateContainer
     );

--- a/src/apps/matterhorn1/static/matterhorn1/js/components/BulkCreate.jsx
+++ b/src/apps/matterhorn1/static/matterhorn1/js/components/BulkCreate.jsx
@@ -8,13 +8,15 @@ const BulkCreate = ({ productsData, onComplete }) => {
 
   useEffect(() => {
     // Inicjalizuj dane produktów
-    setEditedProducts(productsData.map(product => ({
-      ...product,
-      name: product.name || '',
-      description: product.description || '',
-      brand_name: product.brand_name || '',
-      variants: product.variants || []
-    })));
+    setEditedProducts(
+      productsData.map(product => ({
+        ...product,
+        name: product.name || '',
+        description: product.description || '',
+        brand_name: product.brand_name || '',
+        variants: product.variants || [],
+      }))
+    );
   }, [productsData]);
 
   const showMessage = (text, type) => {
@@ -24,49 +26,58 @@ const BulkCreate = ({ productsData, onComplete }) => {
   };
 
   const updateProduct = (index, field, value) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === index ? { ...product, [field]: value } : product
-    ));
+    setEditedProducts(prev =>
+      prev.map((product, i) => (i === index ? { ...product, [field]: value } : product))
+    );
   };
 
   const updateVariant = (productIndex, variantIndex, field, value) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === productIndex 
-        ? {
-            ...product,
-            variants: product.variants.map((variant, j) => 
-              j === variantIndex ? { ...variant, [field]: value } : variant
-            )
-          }
-        : product
-    ));
+    setEditedProducts(prev =>
+      prev.map((product, i) =>
+        i === productIndex
+          ? {
+              ...product,
+              variants: product.variants.map((variant, j) =>
+                j === variantIndex ? { ...variant, [field]: value } : variant
+              ),
+            }
+          : product
+      )
+    );
   };
 
-  const addVariant = (productIndex) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === productIndex 
-        ? {
-            ...product,
-            variants: [...product.variants, {
-              size_name: '',
-              stock: 0,
-              ean: '',
-              producer_code: ''
-            }]
-          }
-        : product
-    ));
+  const addVariant = productIndex => {
+    setEditedProducts(prev =>
+      prev.map((product, i) =>
+        i === productIndex
+          ? {
+              ...product,
+              variants: [
+                ...product.variants,
+                {
+                  size_name: '',
+                  stock: 0,
+                  ean: '',
+                  producer_code: '',
+                },
+              ],
+            }
+          : product
+      )
+    );
   };
 
   const removeVariant = (productIndex, variantIndex) => {
-    setEditedProducts(prev => prev.map((product, i) => 
-      i === productIndex 
-        ? {
-            ...product,
-            variants: product.variants.filter((_, j) => j !== variantIndex)
-          }
-        : product
-    ));
+    setEditedProducts(prev =>
+      prev.map((product, i) =>
+        i === productIndex
+          ? {
+              ...product,
+              variants: product.variants.filter((_, j) => j !== variantIndex),
+            }
+          : product
+      )
+    );
   };
 
   const submitProducts = async () => {
@@ -76,13 +87,13 @@ const BulkCreate = ({ productsData, onComplete }) => {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ products: editedProducts })
+        body: JSON.stringify({ products: editedProducts }),
       });
 
       const data = await response.json();
-      
+
       if (data.success) {
         showMessage(data.message, 'success');
         setTimeout(() => {
@@ -103,16 +114,19 @@ const BulkCreate = ({ productsData, onComplete }) => {
   return (
     <div style={{ maxWidth: '1200px', margin: '20px auto', padding: '20px' }}>
       <h1>Tworzenie nowych produktów w MPD</h1>
-      
+
       {message && (
-        <div className={`status-message ${messageType}`} style={{
-          margin: '20px 0',
-          padding: '15px',
-          borderRadius: '4px',
-          backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-          color: messageType === 'success' ? '#155724' : '#721c24',
-          border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-        }}>
+        <div
+          className={`status-message ${messageType}`}
+          style={{
+            margin: '20px 0',
+            padding: '15px',
+            borderRadius: '4px',
+            backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+            color: messageType === 'success' ? '#155724' : '#721c24',
+            border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+          }}
+        >
           {message}
         </div>
       )}
@@ -126,11 +140,11 @@ const BulkCreate = ({ productsData, onComplete }) => {
               borderRadius: '8px',
               marginBottom: '20px',
               padding: '20px',
-              backgroundColor: '#f9f9f9'
+              backgroundColor: '#f9f9f9',
             }}
           >
             <h3>Produkt ID: {product.matterhorn_product_id}</h3>
-            
+
             <div style={{ marginBottom: '15px' }}>
               <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>
                 Nazwa:
@@ -138,12 +152,12 @@ const BulkCreate = ({ productsData, onComplete }) => {
               <input
                 type="text"
                 value={product.name}
-                onChange={(e) => updateProduct(productIndex, 'name', e.target.value)}
+                onChange={e => updateProduct(productIndex, 'name', e.target.value)}
                 style={{
                   width: '100%',
                   padding: '8px',
                   border: '1px solid #ccc',
-                  borderRadius: '4px'
+                  borderRadius: '4px',
                 }}
               />
             </div>
@@ -154,13 +168,13 @@ const BulkCreate = ({ productsData, onComplete }) => {
               </label>
               <textarea
                 value={product.description}
-                onChange={(e) => updateProduct(productIndex, 'description', e.target.value)}
+                onChange={e => updateProduct(productIndex, 'description', e.target.value)}
                 rows="3"
                 style={{
                   width: '100%',
                   padding: '8px',
                   border: '1px solid #ccc',
-                  borderRadius: '4px'
+                  borderRadius: '4px',
                 }}
               />
             </div>
@@ -172,18 +186,25 @@ const BulkCreate = ({ productsData, onComplete }) => {
               <input
                 type="text"
                 value={product.brand_name}
-                onChange={(e) => updateProduct(productIndex, 'brand_name', e.target.value)}
+                onChange={e => updateProduct(productIndex, 'brand_name', e.target.value)}
                 style={{
                   width: '100%',
                   padding: '8px',
                   border: '1px solid #ccc',
-                  borderRadius: '4px'
+                  borderRadius: '4px',
                 }}
               />
             </div>
 
             <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '10px',
+                }}
+              >
                 <h4>Warianty:</h4>
                 <button
                   onClick={() => addVariant(productIndex)}
@@ -193,7 +214,7 @@ const BulkCreate = ({ productsData, onComplete }) => {
                     border: 'none',
                     padding: '5px 10px',
                     borderRadius: '4px',
-                    cursor: 'pointer'
+                    cursor: 'pointer',
                   }}
                 >
                   + Dodaj wariant
@@ -208,10 +229,17 @@ const BulkCreate = ({ productsData, onComplete }) => {
                     borderRadius: '4px',
                     padding: '15px',
                     marginBottom: '10px',
-                    backgroundColor: 'white'
+                    backgroundColor: 'white',
                   }}
                 >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '10px',
+                    }}
+                  >
                     <h5>Wariant {variantIndex + 1}</h5>
                     <button
                       onClick={() => removeVariant(productIndex, variantIndex)}
@@ -221,7 +249,7 @@ const BulkCreate = ({ productsData, onComplete }) => {
                         border: 'none',
                         padding: '3px 8px',
                         borderRadius: '4px',
-                        cursor: 'pointer'
+                        cursor: 'pointer',
                       }}
                     >
                       Usuń
@@ -236,12 +264,14 @@ const BulkCreate = ({ productsData, onComplete }) => {
                       <input
                         type="text"
                         value={variant.size_name}
-                        onChange={(e) => updateVariant(productIndex, variantIndex, 'size_name', e.target.value)}
+                        onChange={e =>
+                          updateVariant(productIndex, variantIndex, 'size_name', e.target.value)
+                        }
                         style={{
                           width: '100%',
                           padding: '6px',
                           border: '1px solid #ccc',
-                          borderRadius: '4px'
+                          borderRadius: '4px',
                         }}
                       />
                     </div>
@@ -253,12 +283,19 @@ const BulkCreate = ({ productsData, onComplete }) => {
                       <input
                         type="number"
                         value={variant.stock}
-                        onChange={(e) => updateVariant(productIndex, variantIndex, 'stock', parseInt(e.target.value) || 0)}
+                        onChange={e =>
+                          updateVariant(
+                            productIndex,
+                            variantIndex,
+                            'stock',
+                            parseInt(e.target.value) || 0
+                          )
+                        }
                         style={{
                           width: '100%',
                           padding: '6px',
                           border: '1px solid #ccc',
-                          borderRadius: '4px'
+                          borderRadius: '4px',
                         }}
                       />
                     </div>
@@ -270,12 +307,14 @@ const BulkCreate = ({ productsData, onComplete }) => {
                       <input
                         type="text"
                         value={variant.ean}
-                        onChange={(e) => updateVariant(productIndex, variantIndex, 'ean', e.target.value)}
+                        onChange={e =>
+                          updateVariant(productIndex, variantIndex, 'ean', e.target.value)
+                        }
                         style={{
                           width: '100%',
                           padding: '6px',
                           border: '1px solid #ccc',
-                          borderRadius: '4px'
+                          borderRadius: '4px',
                         }}
                       />
                     </div>
@@ -287,12 +326,14 @@ const BulkCreate = ({ productsData, onComplete }) => {
                       <input
                         type="text"
                         value={variant.producer_code}
-                        onChange={(e) => updateVariant(productIndex, variantIndex, 'producer_code', e.target.value)}
+                        onChange={e =>
+                          updateVariant(productIndex, variantIndex, 'producer_code', e.target.value)
+                        }
                         style={{
                           width: '100%',
                           padding: '6px',
                           border: '1px solid #ccc',
-                          borderRadius: '4px'
+                          borderRadius: '4px',
                         }}
                       />
                     </div>
@@ -303,13 +344,15 @@ const BulkCreate = ({ productsData, onComplete }) => {
           </div>
         ))}
       </div>
-      
-      <div style={{
-        marginTop: '30px',
-        textAlign: 'center',
-        padding: '20px',
-        borderTop: '1px solid #ddd'
-      }}>
+
+      <div
+        style={{
+          marginTop: '30px',
+          textAlign: 'center',
+          padding: '20px',
+          borderTop: '1px solid #ddd',
+        }}
+      >
         <button
           onClick={submitProducts}
           disabled={isLoading}
@@ -322,12 +365,12 @@ const BulkCreate = ({ productsData, onComplete }) => {
             margin: '0 10px',
             backgroundColor: '#28a745',
             color: 'white',
-            opacity: isLoading ? 0.6 : 1
+            opacity: isLoading ? 0.6 : 1,
           }}
         >
           {isLoading ? 'Tworzenie...' : 'Utwórz produkty w MPD'}
         </button>
-        
+
         <button
           onClick={() => window.history.back()}
           disabled={isLoading}
@@ -339,7 +382,7 @@ const BulkCreate = ({ productsData, onComplete }) => {
             fontSize: '14px',
             margin: '0 10px',
             backgroundColor: '#6c757d',
-            color: 'white'
+            color: 'white',
           }}
         >
           Anuluj

--- a/src/apps/matterhorn1/static/matterhorn1/js/components/BulkMapping.jsx
+++ b/src/apps/matterhorn1/static/matterhorn1/js/components/BulkMapping.jsx
@@ -15,14 +15,14 @@ const BulkMapping = ({ mappings, onComplete }) => {
   const handleSuggestionClick = (productId, mpdId) => {
     setSelectedMappings(prev => ({
       ...prev,
-      [productId]: mpdId
+      [productId]: mpdId,
     }));
   };
 
   const submitMappings = async () => {
     const mappingsData = Object.entries(selectedMappings).map(([productId, mpdId]) => ({
       product_id: parseInt(productId),
-      mpd_product_id: parseInt(mpdId)
+      mpd_product_id: parseInt(mpdId),
     }));
 
     if (mappingsData.length === 0) {
@@ -36,13 +36,13 @@ const BulkMapping = ({ mappings, onComplete }) => {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ mappings: mappingsData })
+        body: JSON.stringify({ mappings: mappingsData }),
       });
 
       const data = await response.json();
-      
+
       if (data.success) {
         showMessage(data.message, 'success');
         setTimeout(() => {
@@ -64,22 +64,25 @@ const BulkMapping = ({ mappings, onComplete }) => {
     <div style={{ maxWidth: '1200px', margin: '20px auto', padding: '20px' }}>
       <h1>Mapowanie produktów do MPD</h1>
       <p>Wybierz mapowania dla wybranych produktów:</p>
-      
+
       {message && (
-        <div className={`status-message ${messageType}`} style={{
-          margin: '20px 0',
-          padding: '15px',
-          borderRadius: '4px',
-          backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-          color: messageType === 'success' ? '#155724' : '#721c24',
-          border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-        }}>
+        <div
+          className={`status-message ${messageType}`}
+          style={{
+            margin: '20px 0',
+            padding: '15px',
+            borderRadius: '4px',
+            backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+            color: messageType === 'success' ? '#155724' : '#721c24',
+            border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+          }}
+        >
           {message}
         </div>
       )}
 
       <div>
-        {mappings.map((mapping) => (
+        {mappings.map(mapping => (
           <div
             key={mapping.product.id}
             style={{
@@ -87,39 +90,44 @@ const BulkMapping = ({ mappings, onComplete }) => {
               borderRadius: '8px',
               marginBottom: '20px',
               padding: '20px',
-              backgroundColor: '#f9f9f9'
+              backgroundColor: '#f9f9f9',
             }}
           >
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: '15px'
-            }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '15px',
+              }}
+            >
               <div style={{ flex: 1 }}>
-                <div style={{
-                  fontWeight: 'bold',
-                  fontSize: '1.1em',
-                  color: '#333'
-                }}>
+                <div
+                  style={{
+                    fontWeight: 'bold',
+                    fontSize: '1.1em',
+                    color: '#333',
+                  }}
+                >
                   {mapping.product.name}
                 </div>
-                <div style={{
-                  color: '#666',
-                  fontSize: '0.9em',
-                  marginTop: '5px'
-                }}>
-                  ID: {mapping.product.product_uid} | 
-                  Marka: {mapping.product.brand?.name || 'Brak'} | 
-                  Kategoria: {mapping.product.category?.name || 'Brak'}
+                <div
+                  style={{
+                    color: '#666',
+                    fontSize: '0.9em',
+                    marginTop: '5px',
+                  }}
+                >
+                  ID: {mapping.product.product_uid} | Marka: {mapping.product.brand?.name || 'Brak'}{' '}
+                  | Kategoria: {mapping.product.category?.name || 'Brak'}
                 </div>
               </div>
             </div>
-            
+
             <div style={{ marginTop: '15px' }}>
               <h4>Sugerowane mapowania:</h4>
               {mapping.suggestions && mapping.suggestions.length > 0 ? (
-                mapping.suggestions.map((suggestion) => (
+                mapping.suggestions.map(suggestion => (
                   <div
                     key={suggestion.id}
                     onClick={() => handleSuggestionClick(mapping.product.id, suggestion.id)}
@@ -128,42 +136,44 @@ const BulkMapping = ({ mappings, onComplete }) => {
                       justifyContent: 'space-between',
                       alignItems: 'center',
                       padding: '10px',
-                      border: selectedMappings[mapping.product.id] === suggestion.id 
-                        ? '2px solid #28a745' 
-                        : '1px solid #e0e0e0',
+                      border:
+                        selectedMappings[mapping.product.id] === suggestion.id
+                          ? '2px solid #28a745'
+                          : '1px solid #e0e0e0',
                       borderRadius: '4px',
                       marginBottom: '8px',
-                      backgroundColor: selectedMappings[mapping.product.id] === suggestion.id 
-                        ? '#f8fff9' 
-                        : 'white',
+                      backgroundColor:
+                        selectedMappings[mapping.product.id] === suggestion.id
+                          ? '#f8fff9'
+                          : 'white',
                       cursor: 'pointer',
-                      transition: 'all 0.3s'
+                      transition: 'all 0.3s',
                     }}
                   >
                     <div style={{ flex: 1 }}>
-                      <div style={{ fontWeight: 500, color: '#333' }}>
-                        {suggestion.name}
-                      </div>
-                      <div style={{ color: '#666', fontSize: '0.9em' }}>
-                        {suggestion.brand}
-                      </div>
+                      <div style={{ fontWeight: 500, color: '#333' }}>{suggestion.name}</div>
+                      <div style={{ color: '#666', fontSize: '0.9em' }}>{suggestion.brand}</div>
                     </div>
-                    <div style={{
-                      color: '#28a745',
-                      fontWeight: 'bold',
-                      marginLeft: '10px'
-                    }}>
+                    <div
+                      style={{
+                        color: '#28a745',
+                        fontWeight: 'bold',
+                        marginLeft: '10px',
+                      }}
+                    >
                       {suggestion.similarity}%
                     </div>
                   </div>
                 ))
               ) : (
-                <div style={{
-                  color: '#666',
-                  fontStyle: 'italic',
-                  textAlign: 'center',
-                  padding: '20px'
-                }}>
+                <div
+                  style={{
+                    color: '#666',
+                    fontStyle: 'italic',
+                    textAlign: 'center',
+                    padding: '20px',
+                  }}
+                >
                   Brak sugerowanych mapowań
                 </div>
               )}
@@ -171,13 +181,15 @@ const BulkMapping = ({ mappings, onComplete }) => {
           </div>
         ))}
       </div>
-      
-      <div style={{
-        marginTop: '30px',
-        textAlign: 'center',
-        padding: '20px',
-        borderTop: '1px solid #ddd'
-      }}>
+
+      <div
+        style={{
+          marginTop: '30px',
+          textAlign: 'center',
+          padding: '20px',
+          borderTop: '1px solid #ddd',
+        }}
+      >
         <button
           onClick={submitMappings}
           disabled={isLoading}
@@ -190,12 +202,12 @@ const BulkMapping = ({ mappings, onComplete }) => {
             margin: '0 10px',
             backgroundColor: '#417690',
             color: 'white',
-            opacity: isLoading ? 0.6 : 1
+            opacity: isLoading ? 0.6 : 1,
           }}
         >
           {isLoading ? 'Zapisywanie...' : 'Zapisz mapowania'}
         </button>
-        
+
         <button
           onClick={() => window.history.back()}
           disabled={isLoading}
@@ -207,7 +219,7 @@ const BulkMapping = ({ mappings, onComplete }) => {
             fontSize: '14px',
             margin: '0 10px',
             backgroundColor: '#6c757d',
-            color: 'white'
+            color: 'white',
           }}
         >
           Anuluj

--- a/src/apps/matterhorn1/static/matterhorn1/js/components/ProductMapping.jsx
+++ b/src/apps/matterhorn1/static/matterhorn1/js/components/ProductMapping.jsx
@@ -18,12 +18,15 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
     } catch (error) {
       console.error('Error:', error);
       showMessage('Wystąpił błąd podczas uploadowania obrazów', 'error');
@@ -39,13 +42,16 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
-      
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
+
       if (data.success) {
         setTimeout(() => window.location.reload(), 1500);
       }
@@ -64,13 +70,16 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value,
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+        },
       });
-      
+
       const data = await response.json();
-      showMessage(data.message || data.error || 'Wystąpił nieznany błąd', data.success ? 'success' : 'error');
-      
+      showMessage(
+        data.message || data.error || 'Wystąpił nieznany błąd',
+        data.success ? 'success' : 'error'
+      );
+
       if (data.success) {
         setTimeout(() => window.location.reload(), 1500);
       }
@@ -89,20 +98,23 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
   return (
     <div style={{ marginTop: '20px', borderTop: '1px solid #ccc', paddingTop: '20px' }}>
       <h3>Zaawansowane funkcje</h3>
-      
+
       {message && (
-        <div className={`status-message ${messageType}`} style={{
-          margin: '10px 0',
-          padding: '10px',
-          borderRadius: '4px',
-          backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
-          color: messageType === 'success' ? '#155724' : '#721c24',
-          border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`
-        }}>
+        <div
+          className={`status-message ${messageType}`}
+          style={{
+            margin: '10px 0',
+            padding: '10px',
+            borderRadius: '4px',
+            backgroundColor: messageType === 'success' ? '#d4edda' : '#f8d7da',
+            color: messageType === 'success' ? '#155724' : '#721c24',
+            border: `1px solid ${messageType === 'success' ? '#c3e6cb' : '#f5c6cb'}`,
+          }}
+        >
           {message}
         </div>
       )}
-      
+
       <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
         <button
           onClick={uploadImages}
@@ -114,12 +126,12 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
             padding: '8px 16px',
             borderRadius: '4px',
             cursor: isLoading ? 'not-allowed' : 'pointer',
-            opacity: isLoading ? 0.6 : 1
+            opacity: isLoading ? 0.6 : 1,
           }}
         >
           {isLoading ? 'Przetwarzanie...' : 'Upload obrazów'}
         </button>
-        
+
         <button
           onClick={autoMapVariants}
           disabled={isLoading}
@@ -130,12 +142,12 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
             padding: '8px 16px',
             borderRadius: '4px',
             cursor: isLoading ? 'not-allowed' : 'pointer',
-            opacity: isLoading ? 0.6 : 1
+            opacity: isLoading ? 0.6 : 1,
           }}
         >
           {isLoading ? 'Przetwarzanie...' : 'Auto-mapuj warianty'}
         </button>
-        
+
         <button
           onClick={syncWithMpd}
           disabled={isLoading}
@@ -146,7 +158,7 @@ const ProductMapping = ({ productId, isMapped, mappedProductId }) => {
             padding: '8px 16px',
             borderRadius: '4px',
             cursor: isLoading ? 'not-allowed' : 'pointer',
-            opacity: isLoading ? 0.6 : 1
+            opacity: isLoading ? 0.6 : 1,
           }}
         >
           {isLoading ? 'Przetwarzanie...' : 'Synchronizuj z MPD'}

--- a/src/apps/matterhorn1/static/matterhorn1/js/webpack.config.js
+++ b/src/apps/matterhorn1/static/matterhorn1/js/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
-    publicPath: '/static/matterhorn1/js/dist/'
+    publicPath: '/static/matterhorn1/js/dist/',
   },
   module: {
     rules: [
@@ -15,18 +15,18 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-env', '@babel/preset-react']
-          }
-        }
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
       },
       {
         test: /\.css$/,
-        use: ['style-loader', 'css-loader']
-      }
-    ]
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
   },
   resolve: {
-    extensions: ['.js', '.jsx']
+    extensions: ['.js', '.jsx'],
   },
   devServer: {
     static: {
@@ -34,6 +34,6 @@ module.exports = {
     },
     compress: true,
     port: 3000,
-    hot: true
-  }
+    hot: true,
+  },
 };

--- a/src/static/css/admin-custom.css
+++ b/src/static/css/admin-custom.css
@@ -2,76 +2,81 @@
 
 /* Header */
 #header {
-    background: #417690 !important;
+  background: #417690 !important;
 }
 
 /* Sidebar */
 #nav-sidebar {
-    background: #f8f8f8 !important;
+  background: #f8f8f8 !important;
 }
 
 /* Content area */
 #content {
-    background: #ffffff !important;
+  background: #ffffff !important;
 }
 
 /* Links */
-a:link, a:visited {
-    color: #417690 !important;
+a:link,
+a:visited {
+  color: #417690 !important;
 }
 
 /* Hover effects */
 a:hover {
-    color: #205067 !important;
+  color: #205067 !important;
 }
 
 /* Filter sidebar */
 #changelist-filter {
-    background: #f8f8f8 !important;
+  background: #f8f8f8 !important;
 }
 
 /* Filter links */
 #changelist-filter a {
-    color: #417690 !important;
+  color: #417690 !important;
 }
 
 #changelist-filter a:hover {
-    color: #205067 !important;
+  color: #205067 !important;
 }
 
 /* Buttons */
-.default, input[type=submit].default, .submit-row input.default {
-    background: #417690 !important;
-    color: white !important;
+.default,
+input[type='submit'].default,
+.submit-row input.default {
+  background: #417690 !important;
+  color: white !important;
 }
 
-.default:hover, input[type=submit].default:hover, .submit-row input.default:hover {
-    background: #205067 !important;
+.default:hover,
+input[type='submit'].default:hover,
+.submit-row input.default:hover {
+  background: #205067 !important;
 }
 
 /* Table headers */
 #result_list thead th {
-    background: #f8f8f8 !important;
-    color: #333 !important;
+  background: #f8f8f8 !important;
+  color: #333 !important;
 }
 
 /* Selected rows */
 .selected {
-    background: #e8f4fd !important;
+  background: #e8f4fd !important;
 }
 
 /* Messages */
 .messagelist .success {
-    background: #dff0d8 !important;
-    color: #3c763d !important;
+  background: #dff0d8 !important;
+  color: #3c763d !important;
 }
 
 .messagelist .warning {
-    background: #fcf8e3 !important;
-    color: #8a6d3b !important;
+  background: #fcf8e3 !important;
+  color: #8a6d3b !important;
 }
 
 .messagelist .error {
-    background: #f2dede !important;
-    color: #a94442 !important;
+  background: #f2dede !important;
+  color: #a94442 !important;
 }


### PR DESCRIPTION
admin-changelist-django6-fix.css (5d95b31) zakladal DOM inny niz ten, ktory faktycznie renderuje Django (potwierdzone az do 6.0.7 - #changelist-filter jest bezposrednim rodzenstwem .changelist-form-container pod #changelist, NIE jest w niej zagniezdzone). Dwa realne bugi:

1. '#changelist { display: block }' na koncu pliku nadpisywalo poprawny natywny flex z Django (core admin/css/changelists.css). Panel filtrow tracil sizing/kolejnosc flex i spadal w block-flow POD cala tabele (setki wierszy w dol).

2. '.changelist-form-container > div { flex: 1 1 auto; min-width: 0 }' lapalo #toolbar (div - pasek wyszukiwania) jako flex-item, ale omijalo form#changelist-form (nie div, zawiera cala tabele). Przy shrinkowaniu flexa #toolbar zapadal sie do ~0px szerokosci, bo form z ogromna tabela mial znacznie wiekszy flex-basis i wygrywal.

Usunieto obie regulyi. Zostawiono tylko nieszkodliwy dodatek UX (sticky panel filtrow przy scrollu), ktory nie zmienia display/flex-basis .changelist-form-container ani #toolbar.

Zweryfikowane na zywo przez Playwright (bounding boxy + screenshoty na /admin/matterhorn1/product/): filtr wraca na miejsce (240px z boku), #toolbar wraca do pelnej szerokosci zamiast 0px.