### PR TITLE
fix(docker): podaj placeholder DJANGO_SECRET_KEY dla collectstatic w …

### DIFF
--- a/deployments/docker/Dockerfile.ml
+++ b/deployments/docker/Dockerfile.ml
@@ -63,7 +63,11 @@ RUN chown -R celery:celery /app /var/lib/celery /var/lib/flower && \
 ENV DJANGO_SETTINGS_MODULE=core.settings.prod
 
 # Zbierz pliki statyczne
-RUN python manage.py collectstatic --noinput --clear
+# collectstatic nie potrzebuje prawdziwego SECRET_KEY, ale prod.py przerywa
+# import przy pustej wartosci. Podajemy atrape TYLKO na czas tego RUN (nie jako
+# ENV), zeby dzialajacy kontener nadal wymuszal prawdziwy klucz z Secret nc-env.
+RUN DJANGO_SECRET_KEY="build-time-placeholder-not-used-at-runtime" \
+    python manage.py collectstatic --noinput --clear
 
 # Zmień właściciela plików statycznych
 RUN chown -R celery:celery /app/staticfiles

--- a/deployments/docker/Dockerfile.prod
+++ b/deployments/docker/Dockerfile.prod
@@ -77,7 +77,11 @@ ENV DJANGO_SETTINGS_MODULE=core.settings.prod
 ENV MPD_SPA_ROOT=/app/mpd_spa
 
 # Zbierz pliki statyczne
-RUN python manage.py collectstatic --noinput --clear
+# collectstatic nie potrzebuje prawdziwego SECRET_KEY, ale prod.py przerywa
+# import przy pustej wartosci. Podajemy atrape TYLKO na czas tego RUN (nie jako
+# ENV), zeby dzialajacy kontener nadal wymuszal prawdziwy klucz z Secret nc-env.
+RUN DJANGO_SECRET_KEY="build-time-placeholder-not-used-at-runtime" \
+    python manage.py collectstatic --noinput --clear
 
 # Zmień właściciela plików statycznych
 RUN chown -R celery:celery /app/staticfiles /app/mpd_spa


### PR DESCRIPTION
…buildzie

collectstatic uruchamia sie w trakcie `docker build`, gdzie nie ma jeszcze zmiennych z .env.prod ani z Secreta nc-env. Po usunieciu fallbacku SECRET_KEY w prod.py (8b44f1e) import ustawien przerywa build z ImproperlyConfigured.

Atrapa klucza podana tylko na czas RUN (nie jako ENV) - build przechodzi, a dzialajacy kontener nadal wymaga prawdziwego klucza z Secreta.