### PR TITLE
fix(tabu): napraw migracje 0013 tworzaca PeriodicTask watchdoga (cros…

### DIFF
--- a/deployments/k8s/nc-prod/migrate-job.yaml
+++ b/deployments/k8s/nc-prod/migrate-job.yaml
@@ -40,7 +40,7 @@ spec:
               python manage.py migrate web_agent --database=web_agent --noinput
               python manage.py migrate django_celery_beat --database=default --noinput
               python manage.py migrate django_celery_results --database=default --noinput
-              python manage.py migrate tabu --database=tabu --noinput || true
+              python manage.py migrate tabu --database=tabu --noinput
               echo "Migracje zakonczone."
           env:
             - name: DJANGO_SETTINGS_MODULE

--- a/src/apps/tabu/migrations/0013_watchdog_tabu_stock_lock_periodic_task.py
+++ b/src/apps/tabu/migrations/0013_watchdog_tabu_stock_lock_periodic_task.py
@@ -1,31 +1,42 @@
 from django.db import migrations
+from django.db.utils import OperationalError, ProgrammingError
+
+TASK_NAME = 'tabu: watchdog sync_tabu_stock lock (co 5 min)'
 
 
 def create_watchdog_periodic_task(apps, schema_editor):
-    IntervalSchedule = apps.get_model('django_celery_beat', 'IntervalSchedule')
-    PeriodicTask = apps.get_model('django_celery_beat', 'PeriodicTask')
+    # django_celery_beat zyje w bazie 'default' (DefaultRouter), a ta migracja
+    # bywa uruchamiana z --database=tabu (TabuRouter) — dlatego uzywamy realnych
+    # modeli z jawnym using('default') zamiast apps.get_model(), i lapiemy blad
+    # gdy celery_beat nie jest zainstalowany albo tabele w 'default' jeszcze nie
+    # istnieja (standalone `migrate tabu`).
+    try:
+        from django_celery_beat.models import IntervalSchedule, PeriodicTask
 
-    interval, _ = IntervalSchedule.objects.get_or_create(
-        every=5,
-        period='minutes',
-    )
-
-    PeriodicTask.objects.update_or_create(
-        name='tabu: watchdog sync_tabu_stock lock (co 5 min)',
-        defaults={
-            'interval': interval,
-            'task': 'tabu.tasks.watchdog_tabu_stock_lock',
-            'enabled': True,
-            'description': 'Sprząta martwy lock sync_tabu_stock, jeśli worker padł w trakcie',
-        }
-    )
+        interval, _ = IntervalSchedule.objects.using('default').get_or_create(
+            every=5,
+            period=IntervalSchedule.MINUTES,
+        )
+        PeriodicTask.objects.using('default').update_or_create(
+            name=TASK_NAME,
+            defaults={
+                'interval': interval,
+                'task': 'tabu.tasks.watchdog_tabu_stock_lock',
+                'enabled': True,
+                'description': 'Sprząta martwy lock sync_tabu_stock, jeśli worker padł w trakcie',
+            },
+        )
+    except (ImportError, OperationalError, ProgrammingError):
+        pass
 
 
 def remove_watchdog_periodic_task(apps, schema_editor):
-    PeriodicTask = apps.get_model('django_celery_beat', 'PeriodicTask')
-    PeriodicTask.objects.filter(
-        name='tabu: watchdog sync_tabu_stock lock (co 5 min)'
-    ).delete()
+    try:
+        from django_celery_beat.models import PeriodicTask
+
+        PeriodicTask.objects.using('default').filter(name=TASK_NAME).delete()
+    except (ImportError, OperationalError, ProgrammingError):
+        pass
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
…s-db)

Migracja 0013 wywalala sie na `LookupError: No installed app with label 'django_celery_beat'`. Powody:
- brak `django_celery_beat` w dependencies -> nie ma go w stanie migracji, wiec `apps.get_model('django_celery_beat', ...)` rzuca LookupError;
- migracje `tabu` leca z `--database=tabu` (TabuRouter), a tabele django_celery_beat zyja w bazie `default` (DefaultRouter) - to data-migracja miedzybazowa.

Zmiana: uzycie realnych modeli django_celery_beat z jawnym `.using('default')` zamiast `apps.get_model()`, guard na ImportError/OperationalError/ProgrammingError, w pelni idempotentne (update_or_create).

Dodatkowo usuniete `|| true` z `migrate tabu` w migrate-job.yaml (nc-prod) - maskowalo kazda awarie migracji tabu, przez co job konczyl sie zielono a 0013 nigdy sie nie aplikowala.