### PR TITLE
feat(MPD): linkowanie po EAN tylko po EAN + panel wariantów orphaned

### DIFF
--- a/docs/MPD_WAREHOUSE_ADAPTER_PATTERN.md
+++ b/docs/MPD_WAREHOUSE_ADAPTER_PATTERN.md
@@ -65,8 +65,18 @@ Adapter dziedziczy po `SourceAdapter` (z `base.py`) i musi zaimplementować:
 
 ### 4.2. Opcjonalne (ale zalecane)
 
+- **`get_unmapped_variants_for_mpd_product(mpd_product_id)`**  
+  Warianty z produktów tej hurtowni zmapowanych do danego produktu MPD
+  (`product.mapped_product_uid == mpd_product_id`), które nie mają jeszcze
+  `mapped_variant_uid`. Zasilają panel „Warianty nieprzypisane (orphaned)" na karcie
+  produktu MPD (`GET /api/mpd/products/<id>/orphan-variants/`).
+
 - **`get_all_variants_for_product(source_product_id)`**  
-  Wszystkie warianty produktu w hurtowni – do dopinania „pozostałych” rozmiarów przy linkowaniu (te same pola co wyżej, w tym `variant_uid` jako string).
+  Wszystkie warianty produktu w hurtowni (te same pola co wyżej, w tym `variant_uid` jako string).  
+  ⚠️ Linkowanie **nie** tworzy już automatycznie wariantów MPD dla nietrafionych EAN-ów
+  (hurtownia potrafi trzymać kilka kolorów pod jednym produktem, a nazwy kolorów bywają
+  rozjechane między hurtowniami). Takie warianty pokazują się jako „orphaned" i dopina się
+  je ręcznie albo automatycznie po EAN, gdy powstanie właściwy produkt MPD.
 
 - **`update_source_product_mapped(source_product_id, mpd_product_id)`**  
   Ustaw w hurtowni na **produkcie**: `mapped_product_uid = mpd_product_id` (oraz ewentualnie `is_mapped=True` jeśli jest).
@@ -95,6 +105,11 @@ Linkowanie wywołuje adaptery z tego rejestru.
    - Wywołanie **`adapter.update_source_variant_mapped(source_product_id, variant_uid, mpd_variant_id)`** – dla każdego wariantu (ustawia `mapped_variant_uid` / `is_mapped` w hurtowni).
 
 Dzięki temu po stronie hurtowni masz uzupełnione `mapped_product_uid` na produkcie i `mapped_variant_uid` (oraz opcjonalnie `is_mapped`) na wariantach – spójnie z Matterhorn i Tabu.
+
+3. Warianty z produktu źródłowego, których EAN nie trafił w żaden wariant MPD, **nie są
+   dopinane** – zostają jako „orphaned" (widoczne na karcie produktu MPD). Dopięcie:
+   - automatyczne – gdy powstanie produkt MPD z tym EAN (kolejne uruchomienie linkowania),
+   - ręczne – z panelu „Warianty nieprzypisane" (`POST /api/mpd/products/<id>/orphan-variants/`).
 
 ---
 

--- a/frontend/mpd/src/api/mpd.ts
+++ b/frontend/mpd/src/api/mpd.ts
@@ -140,9 +140,7 @@ export async function updateRetailPrices(
   return data;
 }
 
-export async function fetchOrphanVariants(
-  productId: number
-): Promise<MpdOrphanVariantsResponse> {
+export async function fetchOrphanVariants(productId: number): Promise<MpdOrphanVariantsResponse> {
   const { data } = await apiClient.get<MpdOrphanVariantsResponse>(
     `/api/mpd/products/${productId}/orphan-variants/`
   );

--- a/frontend/mpd/src/api/mpd.ts
+++ b/frontend/mpd/src/api/mpd.ts
@@ -3,8 +3,11 @@ import type {
   AuthResponse,
   CatalogResponse,
   ManageActionResponse,
+  MpdAttachOrphanPayload,
+  MpdAttachOrphanResponse,
   MpdFabricItem,
   MpdNamedRef,
+  MpdOrphanVariantsResponse,
   MpdPathRef,
   MpdProduct,
   MpdProductDetailResponse,
@@ -133,6 +136,26 @@ export async function updateRetailPrices(
   const { data } = await apiClient.post<ManageActionResponse>(
     `/api/mpd/products/${productId}/retail-prices/`,
     { prices }
+  );
+  return data;
+}
+
+export async function fetchOrphanVariants(
+  productId: number
+): Promise<MpdOrphanVariantsResponse> {
+  const { data } = await apiClient.get<MpdOrphanVariantsResponse>(
+    `/api/mpd/products/${productId}/orphan-variants/`
+  );
+  return data;
+}
+
+export async function attachOrphanVariant(
+  productId: number,
+  payload: MpdAttachOrphanPayload
+): Promise<MpdAttachOrphanResponse> {
+  const { data } = await apiClient.post<MpdAttachOrphanResponse>(
+    `/api/mpd/products/${productId}/orphan-variants/`,
+    payload
   );
   return data;
 }

--- a/frontend/mpd/src/components/OrphanVariantsPanel.tsx
+++ b/frontend/mpd/src/components/OrphanVariantsPanel.tsx
@@ -1,0 +1,232 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { attachOrphanVariant, fetchOrphanVariants } from '../api/mpd';
+import { useActionMessages } from '../hooks/useActionMessages';
+import type { MpdOrphanVariant, MpdProductDetail } from '../types/mpd';
+
+type RowKey = string;
+
+function rowKey(o: MpdOrphanVariant): RowKey {
+  return `${o.source_id}:${o.variant_uid}:${o.ean}`;
+}
+
+interface DraftState {
+  mode: 'existing' | 'new';
+  targetVariantId: string;
+  colorId: string;
+  producerColorId: string;
+  sizeName: string;
+}
+
+function emptyDraft(o: MpdOrphanVariant): DraftState {
+  return {
+    mode: 'existing',
+    targetVariantId: '',
+    colorId: '',
+    producerColorId: '',
+    sizeName: o.size || '',
+  };
+}
+
+export function OrphanVariantsPanel({
+  productId,
+  product,
+}: {
+  productId: number;
+  product: MpdProductDetail;
+}) {
+  const queryClient = useQueryClient();
+  const { setError, setSuccess, reportError } = useActionMessages();
+  const [openRow, setOpenRow] = useState<RowKey | null>(null);
+  const [drafts, setDrafts] = useState<Record<RowKey, DraftState>>({});
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mpd-orphan-variants', productId],
+    queryFn: () => fetchOrphanVariants(productId),
+    enabled: Number.isFinite(productId) && productId > 0,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (vars: { o: MpdOrphanVariant; draft: DraftState }) => {
+      const { o, draft } = vars;
+      return attachOrphanVariant(productId, {
+        source_id: o.source_id,
+        source_variant_uid: o.variant_uid,
+        source_product_id: o.source_product_id,
+        ean: o.ean,
+        producer_code: o.producer_code || undefined,
+        stock: o.stock,
+        price: o.price,
+        currency: o.currency,
+        mode: draft.mode,
+        target_variant_id:
+          draft.mode === 'existing' ? Number(draft.targetVariantId) : undefined,
+        color_id: draft.mode === 'new' ? Number(draft.colorId) : undefined,
+        producer_color_id:
+          draft.mode === 'new' && draft.producerColorId
+            ? Number(draft.producerColorId)
+            : undefined,
+        size_name: draft.mode === 'new' ? draft.sizeName || undefined : undefined,
+      });
+    },
+    onSuccess: async res => {
+      if (res.status === 'error') {
+        setError(res.message || 'Nie udało się przypiąć wariantu.');
+        return;
+      }
+      setSuccess(res.message || 'Wariant przypięty.');
+      setOpenRow(null);
+      await queryClient.invalidateQueries({ queryKey: ['mpd-orphan-variants', productId] });
+      await queryClient.invalidateQueries({ queryKey: ['mpd-product', productId] });
+    },
+    onError: err => reportError(err, 'Nie udało się przypiąć wariantu.'),
+  });
+
+  const rows = data?.results ?? [];
+
+  return (
+    <div className="page-card product-detail__wide">
+      <h3 className="section-title">
+        Warianty nieprzypisane (orphaned)
+        <span className="section-count">{rows.length}</span>
+      </h3>
+      <p className="muted-note">
+        Warianty z hurtowni, których produkt jest zmapowany do tego produktu MPD, ale sam
+        wariant nie został jeszcze dopięty po EAN (np. inny kolor pod jednym produktem
+        hurtowni albo rozjechany EAN). Przypnij je do istniejącego wariantu MPD lub utwórz
+        nowy.
+      </p>
+
+      {isLoading ? (
+        <div className="loading">Ładowanie…</div>
+      ) : rows.length === 0 ? (
+        <div className="empty-state">Brak nieprzypisanych wariantów.</div>
+      ) : (
+        <div className="table-scroll">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Źródło</th>
+                <th>Kolor (hurtownia)</th>
+                <th>Rozmiar</th>
+                <th>EAN</th>
+                <th style={{ width: 70 }}>Stan</th>
+                <th style={{ width: 90 }}>Cena</th>
+                <th style={{ width: 220 }}>Akcje</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(o => {
+                const key = rowKey(o);
+                const draft = drafts[key] || emptyDraft(o);
+                const isOpen = openRow === key;
+                const setDraft = (patch: Partial<DraftState>) =>
+                  setDrafts(prev => ({ ...prev, [key]: { ...draft, ...patch } }));
+                return (
+                  <tr key={key}>
+                    <td>{o.source_name || o.source_id}</td>
+                    <td>{o.color || <span className="muted">—</span>}</td>
+                    <td>{o.size || <span className="muted">—</span>}</td>
+                    <td>{o.ean || <span className="muted">—</span>}</td>
+                    <td>{o.stock ?? <span className="muted">—</span>}</td>
+                    <td>
+                      {o.price != null ? `${o.price} ${o.currency}` : <span className="muted">—</span>}
+                    </td>
+                    <td>
+                      {!isOpen ? (
+                        <button
+                          type="button"
+                          className="btn btn-muted"
+                          onClick={() => {
+                            setDrafts(prev => ({ ...prev, [key]: emptyDraft(o) }));
+                            setOpenRow(key);
+                          }}
+                        >
+                          Przypnij
+                        </button>
+                      ) : (
+                        <div className="orphan-attach">
+                          <select
+                            className="search-input"
+                            value={draft.mode}
+                            onChange={e =>
+                              setDraft({ mode: e.target.value as 'existing' | 'new' })
+                            }
+                          >
+                            <option value="existing">Do istniejącego wariantu</option>
+                            <option value="new">Utwórz nowy wariant</option>
+                          </select>
+
+                          {draft.mode === 'existing' ? (
+                            <select
+                              className="search-input"
+                              value={draft.targetVariantId}
+                              onChange={e => setDraft({ targetVariantId: e.target.value })}
+                            >
+                              <option value="">Wybierz wariant…</option>
+                              {product.variants.map(v => (
+                                <option key={v.variant_id} value={v.variant_id}>
+                                  {(v.color_name || '—') + ' / ' + (v.size_name || '—')}
+                                  {v.ean ? ` (${v.ean})` : ''}
+                                </option>
+                              ))}
+                            </select>
+                          ) : (
+                            <>
+                              <input
+                                className="search-input"
+                                inputMode="numeric"
+                                placeholder="color_id"
+                                value={draft.colorId}
+                                onChange={e => setDraft({ colorId: e.target.value })}
+                              />
+                              <input
+                                className="search-input"
+                                inputMode="numeric"
+                                placeholder="producer_color_id (opc.)"
+                                value={draft.producerColorId}
+                                onChange={e => setDraft({ producerColorId: e.target.value })}
+                              />
+                              <input
+                                className="search-input"
+                                placeholder="rozmiar"
+                                value={draft.sizeName}
+                                onChange={e => setDraft({ sizeName: e.target.value })}
+                              />
+                            </>
+                          )}
+
+                          <div className="orphan-attach__actions">
+                            <button
+                              type="button"
+                              className="btn btn-primary"
+                              disabled={
+                                mutation.isPending ||
+                                (draft.mode === 'existing' && !draft.targetVariantId) ||
+                                (draft.mode === 'new' && !draft.colorId)
+                              }
+                              onClick={() => mutation.mutate({ o, draft })}
+                            >
+                              {mutation.isPending ? 'Przypinanie…' : 'Zatwierdź'}
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-muted"
+                              onClick={() => setOpenRow(null)}
+                            >
+                              Anuluj
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/mpd/src/components/OrphanVariantsPanel.tsx
+++ b/frontend/mpd/src/components/OrphanVariantsPanel.tsx
@@ -59,13 +59,10 @@ export function OrphanVariantsPanel({
         price: o.price,
         currency: o.currency,
         mode: draft.mode,
-        target_variant_id:
-          draft.mode === 'existing' ? Number(draft.targetVariantId) : undefined,
+        target_variant_id: draft.mode === 'existing' ? Number(draft.targetVariantId) : undefined,
         color_id: draft.mode === 'new' ? Number(draft.colorId) : undefined,
         producer_color_id:
-          draft.mode === 'new' && draft.producerColorId
-            ? Number(draft.producerColorId)
-            : undefined,
+          draft.mode === 'new' && draft.producerColorId ? Number(draft.producerColorId) : undefined,
         size_name: draft.mode === 'new' ? draft.sizeName || undefined : undefined,
       });
     },
@@ -91,10 +88,9 @@ export function OrphanVariantsPanel({
         <span className="section-count">{rows.length}</span>
       </h3>
       <p className="muted-note">
-        Warianty z hurtowni, których produkt jest zmapowany do tego produktu MPD, ale sam
-        wariant nie został jeszcze dopięty po EAN (np. inny kolor pod jednym produktem
-        hurtowni albo rozjechany EAN). Przypnij je do istniejącego wariantu MPD lub utwórz
-        nowy.
+        Warianty z hurtowni, których produkt jest zmapowany do tego produktu MPD, ale sam wariant
+        nie został jeszcze dopięty po EAN (np. inny kolor pod jednym produktem hurtowni albo
+        rozjechany EAN). Przypnij je do istniejącego wariantu MPD lub utwórz nowy.
       </p>
 
       {isLoading ? (
@@ -130,7 +126,11 @@ export function OrphanVariantsPanel({
                     <td>{o.ean || <span className="muted">—</span>}</td>
                     <td>{o.stock ?? <span className="muted">—</span>}</td>
                     <td>
-                      {o.price != null ? `${o.price} ${o.currency}` : <span className="muted">—</span>}
+                      {o.price != null ? (
+                        `${o.price} ${o.currency}`
+                      ) : (
+                        <span className="muted">—</span>
+                      )}
                     </td>
                     <td>
                       {!isOpen ? (
@@ -149,9 +149,7 @@ export function OrphanVariantsPanel({
                           <select
                             className="search-input"
                             value={draft.mode}
-                            onChange={e =>
-                              setDraft({ mode: e.target.value as 'existing' | 'new' })
-                            }
+                            onChange={e => setDraft({ mode: e.target.value as 'existing' | 'new' })}
                           >
                             <option value="existing">Do istniejącego wariantu</option>
                             <option value="new">Utwórz nowy wariant</option>

--- a/frontend/mpd/src/pages/ProductDetailPage.css
+++ b/frontend/mpd/src/pages/ProductDetailPage.css
@@ -247,6 +247,18 @@
   overflow-x: auto;
 }
 
+.orphan-attach {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 200px;
+}
+
+.orphan-attach__actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
 .section-title {
   margin: 0 0 1rem;
   font-size: 1.1rem;

--- a/frontend/mpd/src/pages/ProductDetailPage.tsx
+++ b/frontend/mpd/src/pages/ProductDetailPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
 import { deleteProduct, fetchProduct, updateProduct } from '../api/mpd';
+import { OrphanVariantsPanel } from '../components/OrphanVariantsPanel';
 import { ProductExtrasPanels } from '../components/ProductExtrasPanels';
 import { useActionMessages } from '../hooks/useActionMessages';
 import type { MpdProductDetail, MpdProductUpdatePayload } from '../types/mpd';
@@ -505,6 +506,8 @@ export function ProductDetailPage() {
           </div>
         )}
       </div>
+
+      <OrphanVariantsPanel productId={productId} product={product} />
     </div>
   );
 }

--- a/frontend/mpd/src/types/mpd.ts
+++ b/frontend/mpd/src/types/mpd.ts
@@ -159,6 +159,49 @@ export interface CatalogResponse<T> {
   results: T[];
 }
 
+export interface MpdOrphanVariant {
+  source_id: number;
+  source_name: string | null;
+  ean: string;
+  variant_uid: string;
+  source_product_id: number | null;
+  size: string;
+  color: string;
+  stock: number | null;
+  price: number | null;
+  currency: string;
+  producer_code: string;
+}
+
+export interface MpdOrphanVariantsResponse {
+  status: 'success' | 'error';
+  message?: string;
+  results: MpdOrphanVariant[];
+}
+
+export interface MpdAttachOrphanPayload {
+  source_id: number;
+  source_variant_uid: string;
+  source_product_id: number | null;
+  ean: string;
+  producer_code?: string;
+  stock?: number | null;
+  price?: number | null;
+  currency?: string;
+  mode: 'existing' | 'new';
+  target_variant_id?: number;
+  color_id?: number | null;
+  producer_color_id?: number | null;
+  size_id?: number | null;
+  size_name?: string;
+}
+
+export interface MpdAttachOrphanResponse {
+  status: 'success' | 'error';
+  message?: string;
+  variant_id?: number;
+}
+
 export interface ManageActionResponse {
   status: 'success' | 'error';
   message?: string;

--- a/src/apps/MPD/api_urls.py
+++ b/src/apps/MPD/api_urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
         name="products-retail-prices",
     ),
     path(
+        "products/<int:product_id>/orphan-variants/",
+        api_views.MPDProductOrphanVariantsAPI.as_view(),
+        name="products-orphan-variants",
+    ),
+    path(
         "products/bulk-create/",
         api_views.MPDBulkCreateProductsAPI.as_view(),
         name="products-bulk-create",

--- a/src/apps/MPD/api_views.py
+++ b/src/apps/MPD/api_views.py
@@ -40,6 +40,13 @@ except ImportError:  # pragma: no cover - środowisko bez drf_spectacular
 logger = logging.getLogger(__name__)
 
 
+def _mpd_db():
+    """Alias bazy MPD – 'zzz_MPD' w dev/testach, 'MPD' na produkcji (spójnie z
+    MPD.source_adapters/linking i registry, które też przez to przechodzą)."""
+    from .source_adapters.registry import _get_mpd_db
+    return _get_mpd_db()
+
+
 class MPDProductCreateAPI(APIView):
     """
     API: tworzenie produktu MPD.
@@ -495,6 +502,184 @@ class MPDGetMatterhorn1ProductsAPI(APIView):
     )
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         return mpd_views.get_matterhorn1_products(request._request)
+
+
+class MPDProductOrphanVariantsAPI(APIView):
+    """
+    API: warianty z hurtowni „nieprzypisane" (orphaned) do wariantów produktu MPD.
+
+    GET  – lista wariantów źródłowych z produktów zmapowanych do tego produktu MPD,
+           które nie mają jeszcze `mapped_variant_uid` (patrz
+           `SourceAdapter.get_unmapped_variants_for_mpd_product`).
+    POST – ręczne przypięcie takiego wariantu: do istniejącego wariantu MPD
+           (`mode=existing`, `target_variant_id`) albo jako nowy wariant MPD
+           (`mode=new`, `color_id`, opcjonalnie `producer_color_id` / `size_id` / `size_name`).
+    """
+
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, product_id, *args, **kwargs):  # pylint: disable=unused-argument
+        from .source_adapters.registry import get_all_adapters, register_default_adapters
+        from .models import Sources
+
+        try:
+            Products.objects.using(_mpd_db()).get(pk=product_id)
+        except Products.DoesNotExist:
+            return Response({'status': 'error', 'message': 'Produkt nie istnieje.'}, status=404)
+
+        register_default_adapters()
+        source_names = {
+            s.id: s.name for s in Sources.objects.using(_mpd_db()).all()
+        }
+        results = []
+        for source_id, adapter in get_all_adapters():
+            try:
+                matches = adapter.get_unmapped_variants_for_mpd_product(product_id)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    'Błąd get_unmapped_variants_for_mpd_product source=%s product=%s',
+                    source_id, product_id,
+                )
+                continue
+            for m in matches:
+                results.append({
+                    'source_id': source_id,
+                    'source_name': source_names.get(source_id),
+                    'ean': m.ean or '',
+                    'variant_uid': str(m.variant_uid) if m.variant_uid is not None else '',
+                    'source_product_id': m.source_product_id,
+                    'size': m.size or '',
+                    'color': m.color or '',
+                    'stock': m.stock,
+                    'price': float(m.price) if m.price is not None else None,
+                    'currency': m.currency or 'PLN',
+                    'producer_code': m.producer_code or '',
+                })
+        results.sort(key=lambda r: (r['source_name'] or '', r['color'], r['size']))
+        return Response({'status': 'success', 'results': results})
+
+    def post(self, request, product_id, *args, **kwargs):  # pylint: disable=unused-argument
+        from django.utils import timezone
+        from .source_adapters.registry import get_adapter_for_source, register_default_adapters
+        from .models import (
+            ProductVariants,
+            ProductvariantsSources,
+            Sizes,
+            Sources,
+            StockAndPrices,
+        )
+
+        data = request.data if isinstance(request.data, dict) else {}
+        try:
+            source_id = int(data['source_id'])
+        except (KeyError, TypeError, ValueError):
+            return Response({'status': 'error', 'message': 'Wymagane pole source_id.'}, status=400)
+
+        source_variant_uid = str(data.get('source_variant_uid') or '').strip()
+        source_product_id = data.get('source_product_id')
+        ean = (data.get('ean') or '').strip()
+        producer_code = (data.get('producer_code') or '').strip()[:255] or None
+        mode = (data.get('mode') or 'existing').strip()
+
+        try:
+            product = Products.objects.using(_mpd_db()).get(pk=product_id)
+        except Products.DoesNotExist:
+            return Response({'status': 'error', 'message': 'Produkt nie istnieje.'}, status=404)
+
+        try:
+            source = Sources.objects.using(_mpd_db()).get(pk=source_id)
+        except Sources.DoesNotExist:
+            return Response({'status': 'error', 'message': 'Źródło nie istnieje.'}, status=404)
+
+        register_default_adapters()
+        adapter = get_adapter_for_source(source_id)
+        if adapter is None:
+            return Response(
+                {'status': 'error', 'message': f'Brak adaptera dla źródła {source.name}.'},
+                status=400,
+            )
+
+        if mode == 'new':
+            color_id = data.get('color_id')
+            if not color_id:
+                return Response(
+                    {'status': 'error', 'message': 'Tryb „new" wymaga color_id.'},
+                    status=400,
+                )
+            producer_color_id = data.get('producer_color_id') or None
+            size_id = data.get('size_id') or None
+            if not size_id and (data.get('size_name') or '').strip():
+                size_name = data['size_name'].strip()[:255]
+                size_obj = (
+                    Sizes.objects.using(_mpd_db()).filter(name__iexact=size_name).first()
+                    or Sizes.objects.using(_mpd_db()).create(
+                        name=size_name,
+                        name_lower=size_name.lower(),
+                    )
+                )
+                size_id = size_obj.id
+            variant = ProductVariants.objects.using(_mpd_db()).create(
+                product=product,
+                color_id=color_id,
+                producer_color_id=producer_color_id,
+                size_id=size_id,
+            )
+        else:
+            try:
+                variant = ProductVariants.objects.using(_mpd_db()).get(
+                    variant_id=data['target_variant_id'], product_id=product_id,
+                )
+            except (KeyError, TypeError, ValueError, ProductVariants.DoesNotExist):
+                return Response(
+                    {'status': 'error', 'message': 'Nieprawidłowy target_variant_id.'},
+                    status=400,
+                )
+
+        # PG integer (32-bit); identyfikatory oparte na EAN przekraczają zakres → null
+        variant_uid_int = (
+            int(source_variant_uid)
+            if source_variant_uid.isdigit() and int(source_variant_uid) <= 2_147_483_647
+            else None
+        )
+        pvs, _created = ProductvariantsSources.objects.using(_mpd_db()).get_or_create(
+            variant_id=variant.variant_id,
+            source=source,
+            defaults={
+                'ean': ean[:50],
+                'variant_uid': variant_uid_int,
+                'producer_code': producer_code,
+            },
+        )
+        stock_val = data.get('stock')
+        price_val = data.get('price')
+        StockAndPrices.objects.using(_mpd_db()).get_or_create(
+            variant_id=variant.variant_id,
+            source=source,
+            defaults={
+                'stock': stock_val if stock_val is not None else 0,
+                'price': price_val if price_val is not None else 0,
+                'currency': (data.get('currency') or 'PLN'),
+                'last_updated': timezone.now(),
+            },
+        )
+
+        if source_product_id:
+            try:
+                adapter.update_source_variant_mapped(
+                    int(source_product_id), source_variant_uid or None, variant.variant_id,
+                )
+                adapter.update_source_product_mapped(int(source_product_id), product_id)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    'Błąd ustawiania mapped_* w źródle %s dla wariantu %s',
+                    source_id, source_variant_uid,
+                )
+
+        return Response({
+            'status': 'success',
+            'message': 'Wariant przypięty.',
+            'variant_id': variant.variant_id,
+        })
 
 
 class MPDUpdateProducerCodeAPI(APIView):

--- a/src/apps/MPD/source_adapters/base.py
+++ b/src/apps/MPD/source_adapters/base.py
@@ -68,6 +68,20 @@ class SourceAdapter(ABC):
         """
         return []
 
+    def get_unmapped_variants_for_mpd_product(
+        self,
+        mpd_product_id: int,
+    ) -> List[VariantMatch]:
+        """
+        Zwraca warianty z produktów tej hurtowni zmapowanych do danego produktu MPD
+        (`mapped_product_uid == mpd_product_id`), które nie mają jeszcze przypisania do
+        wariantu MPD (`mapped_variant_uid IS NULL`). Do panelu „nieprzypisane" (orphaned)
+        na karcie produktu MPD.
+
+        Domyślnie brak akcji (dla hurtowni bez pól mapped_*).
+        """
+        return []
+
     def update_source_product_mapped(
         self,
         source_product_id: int,

--- a/src/apps/MPD/source_adapters/linking.py
+++ b/src/apps/MPD/source_adapters/linking.py
@@ -2,7 +2,6 @@
 Logika dopinania wariantów z innych hurtowni po EAN.
 """
 import logging
-from decimal import Decimal
 from typing import Dict, Optional, Set
 
 from django.utils import timezone
@@ -10,7 +9,6 @@ from django.utils import timezone
 from MPD.models import (
     ProductVariants,
     ProductvariantsSources,
-    Sizes,
     Sources,
     StockAndPrices,
 )
@@ -26,13 +24,22 @@ def _get_mpd_db() -> str:
     return 'zzz_MPD' if 'zzz_MPD' in settings.DATABASES else 'MPD'
 
 
+# ProductvariantsSources.variant_uid to PG integer (32-bit). Identyfikatory hurtowni
+# oparte na EAN (np. Mada variant_key = 13 cyfr) przekraczają zakres — wtedy null,
+# tożsamość i tak niesie ean/producer_code.
+_PG_INT_MAX = 2_147_483_647
+
+
 def _variant_uid_int(m) -> Optional[int]:
     """Konwersja variant_uid z matcha na int do kolumny ProductvariantsSources.variant_uid."""
     uid = getattr(m, 'variant_uid', None)
     if uid is None:
         return None
     s = str(uid).strip()
-    return int(s) if s.isdigit() else None
+    if not s.isdigit():
+        return None
+    value = int(s)
+    return value if 0 <= value <= _PG_INT_MAX else None
 
 
 def link_variants_from_other_sources(
@@ -181,95 +188,14 @@ def link_variants_from_other_sources(
                                 m.source_product_id, upd_err
                             )
 
-                # Pozostałe warianty z tego samego produktu w źródle (wszystkie hurtownie)
-                # first_mpd: pierwszy wariant MPD (color_id, producer_color_id) – z variant_ids, nie „variants”
-                if not variant_ids:
-                    stats['sources_processed'] += 1
-                    continue
-                first_mpd = (
-                    ProductVariants.objects.using(db)
-                    .filter(variant_id=variant_ids[0])
-                    .only('variant_id', 'color_id', 'producer_color_id')
-                    .first()
-                )
-                if not first_mpd:
-                    stats['sources_processed'] += 1
-                    continue
-                ean_linked: Set[str] = set(variant_by_ean.keys())
-                for source_product_id in updated_source_products:
-                    try:
-                        all_in_source = adapter.get_all_variants_for_product(source_product_id)
-                        for m in all_in_source:
-                            ean_norm = normalize_ean(m.ean) if m.ean else ''
-                            if ean_norm and ean_norm in ean_linked:
-                                continue
-                            # Nowy wariant MPD dla „pozostałego” rozmiaru z hurtowni
-                            size_name = (m.size or '').strip()[:255] if m.size else ''
-                            size_obj = None
-                            if size_name:
-                                size_obj = (
-                                    Sizes.objects.using(db).filter(name__iexact=size_name).first()
-                                    or Sizes.objects.using(db).filter(name=size_name).first()
-                                )
-                                if not size_obj:
-                                    size_obj = Sizes.objects.using(db).create(
-                                        name=size_name,
-                                        category=None,
-                                        unit=None,
-                                        name_lower=size_name.lower() if size_name else '',
-                                    )
-                            # producer_code tylko gdy jasno podany z hurtowni, inaczej null
-                            pc = (getattr(m, 'producer_code', None) or '').strip()[:255] or None
-                            new_pv = ProductVariants.objects.using(db).create(
-                                product_id=mpd_product_id,
-                                color_id=first_mpd.color_id,
-                                producer_color_id=first_mpd.producer_color_id,
-                                size=size_obj,
-                            )
-                            variant_uid_int = _variant_uid_int(m)
-                            ProductvariantsSources.objects.using(db).create(
-                                variant_id=new_pv.variant_id,
-                                source=source,
-                                ean=(m.ean or '')[:50] if m.ean else '',
-                                variant_uid=variant_uid_int,
-                                producer_code=pc,
-                            )
-                            StockAndPrices.objects.using(db).create(
-                                variant_id=new_pv.variant_id,
-                                source=source,
-                                stock=m.stock or 0,
-                                price=m.price or Decimal('0'),
-                                currency=m.currency or 'PLN',
-                                last_updated=timezone.now(),
-                            )
-                            if ean_norm:
-                                variant_by_ean[ean_norm] = new_pv.variant_id
-                                ean_linked.add(ean_norm)
-                            stats['linked_count'] += 1
-                            logger.info(
-                                "Dodano pozostały wariant z produktu %s: size=%s ean=%s variant_id=%s",
-                                source_product_id, size_name, m.ean, new_pv.variant_id
-                            )
-                            # Ustaw mapped_variant_uid w hurtowni źródłowej (np. Matterhorn productvariant)
-                            if m.source_product_id:
-                                try:
-                                    adapter.update_source_variant_mapped(
-                                        m.source_product_id,
-                                        getattr(m, 'variant_uid', None),
-                                        new_pv.variant_id,
-                                    )
-                                except Exception as var_err:
-                                    logger.warning(
-                                        "Błąd ustawiania mapped_variant_uid (pozostały wariant): %s",
-                                        var_err
-                                    )
-                    except Exception as rem_err:
-                        logger.exception(
-                            "Błąd dopinania pozostałych wariantów dla produktu %s: %s",
-                            source_product_id, rem_err
-                        )
-                        stats['errors'].append(str(rem_err))
-
+                # UWAGA: świadomie NIE dopinamy „pozostałych” rozmiarów z produktu
+                # źródłowego, których EAN nie występuje w MPD. Hurtownia potrafi trzymać
+                # kilka kolorów pod jednym produktem (np. Tabu: czarny + beżowy razem),
+                # a nazwy kolorów bywają rozjechane między hurtowniami ("czarny" vs
+                # "black"), więc automatyczne tworzenie wariantów prowadziło do wciągania
+                # obcego koloru pod zły produkt. Takie warianty pokazujemy jako
+                # „nieprzypisane” (orphaned) na karcie produktu MPD i dopina się je
+                # ręcznie albo automatycznie po EAN, gdy powstanie właściwy produkt.
                 stats['sources_processed'] += 1
             except Exception as e:
                 logger.exception("Błąd linkowania ze źródła %s: %s", source_id, e)

--- a/src/apps/MPD/source_adapters/mada.py
+++ b/src/apps/MPD/source_adapters/mada.py
@@ -83,6 +83,32 @@ class MadaAdapter(SourceAdapter):
             ))
         return result
 
+    def get_unmapped_variants_for_mpd_product(
+        self,
+        mpd_product_id: int,
+    ) -> List[VariantMatch]:
+        """Warianty Mada z produktów zmapowanych do tego MPD, bez przypisania do wariantu MPD."""
+        from mada.models import MadaProductVariant
+
+        qs = MadaProductVariant.objects.using(_get_mada_db()).filter(
+            product__mapped_product_uid=mpd_product_id,
+            mapped_variant_uid__isnull=True,
+        ).select_related('product')
+        result = []
+        for v in qs:
+            result.append(VariantMatch(
+                ean=normalize_ean(v.ean) if v.ean else '',
+                variant_uid=v.variant_key,
+                stock=v.stock or 0,
+                price=v.product.price if v.product_id else Decimal('0'),
+                currency='PLN',
+                size=v.size or '',
+                color=v.color or '',
+                source_product_id=v.product_id if v.product_id else None,
+                producer_code=None,
+            ))
+        return result
+
     def update_source_product_mapped(
         self,
         source_product_id: int,

--- a/src/apps/MPD/source_adapters/matterhorn.py
+++ b/src/apps/MPD/source_adapters/matterhorn.py
@@ -95,6 +95,38 @@ class MatterhornAdapter(SourceAdapter):
             ))
         return result
 
+    def get_unmapped_variants_for_mpd_product(
+        self,
+        mpd_product_id: int,
+    ) -> List[VariantMatch]:
+        """Warianty Matterhorn z produktów zmapowanych do tego MPD, bez przypisania do wariantu MPD."""
+        from matterhorn1.models import ProductVariant
+
+        qs = ProductVariant.objects.using(_get_matterhorn1_db()).filter(
+            product__mapped_product_uid=mpd_product_id,
+            mapped_variant_uid__isnull=True,
+        ).select_related('product')
+        result = []
+        for v in qs:
+            price = Decimal('0')
+            if v.product and v.product.prices:
+                prices = v.product.prices
+                if isinstance(prices, str):
+                    prices = json.loads(prices) if prices else {}
+                price = Decimal(str(prices.get('PLN', 0) or 0))
+            result.append(VariantMatch(
+                ean=normalize_ean(v.ean) if v.ean else '',
+                variant_uid=v.variant_uid,
+                stock=v.stock or 0,
+                price=price,
+                currency='PLN',
+                size=v.name or '',
+                color=v.product.color if v.product else '',
+                source_product_id=v.product_id if v.product_id else None,
+                producer_code=getattr(v, 'producer_code', None) and (v.producer_code or '').strip() or None,
+            ))
+        return result
+
     def update_source_product_mapped(
         self,
         source_product_id: int,

--- a/src/apps/MPD/source_adapters/tabu.py
+++ b/src/apps/MPD/source_adapters/tabu.py
@@ -87,6 +87,32 @@ class TabuAdapter(SourceAdapter):
             ))
         return result
 
+    def get_unmapped_variants_for_mpd_product(
+        self,
+        mpd_product_id: int,
+    ) -> List[VariantMatch]:
+        """Warianty Tabu z produktów zmapowanych do tego MPD, bez przypisania do wariantu MPD."""
+        from tabu.models import TabuProductVariant
+
+        qs = TabuProductVariant.objects.using(_get_tabu_db()).filter(
+            product__mapped_product_uid=mpd_product_id,
+            mapped_variant_uid__isnull=True,
+        ).select_related('product')
+        result = []
+        for v in qs:
+            result.append(VariantMatch(
+                ean=normalize_ean(v.ean) if v.ean else '',
+                variant_uid=str(v.api_id),
+                stock=v.store or 0,
+                price=v.price_net or Decimal('0'),
+                currency='PLN',
+                size=v.size or '',
+                color=v.color or '',
+                source_product_id=v.product_id if v.product_id else None,
+                producer_code=(v.symbol or '').strip() or None,
+            ))
+        return result
+
     def update_source_product_mapped(
         self,
         source_product_id: int,

--- a/src/apps/MPD/tests_integration.py
+++ b/src/apps/MPD/tests_integration.py
@@ -216,11 +216,12 @@ class MPDSavePropagatesLinkTest(TestCase):
             "Powinien powstać wiersz ProductvariantsSources dla wariantu MPD ze źródłem Tabu",
         )
 
-    def test_link_creates_new_mpd_variant_for_extra_size_from_other_source(self):
+    def test_link_does_not_create_mpd_variant_for_unmatched_ean(self):
         """
-        Rozmiar 'M' istnieje tylko w Tabu (inny EAN, nieznany jeszcze w MPD) — linking
-        powinien dla niego utworzyć NOWY wariant w MPD (backfill "pozostałych" wariantów),
-        a nie tylko dopiąć się do istniejącego wariantu 'S'.
+        Rozmiar 'M' istnieje tylko w Tabu (inny EAN, nieznany w MPD). Linking dopina
+        WYŁĄCZNIE po EAN — nie tworzy nowych wariantów MPD dla nietrafionych EAN-ów
+        (hurtownia potrafi trzymać kilka kolorów pod jednym produktem, a nazwy kolorów
+        bywają rozjechane). Takie warianty trafiają do panelu „nieprzypisane".
         """
         from MPD.source_adapters.linking import link_variants_from_other_sources
         from MPD.models import ProductvariantsSources
@@ -237,18 +238,60 @@ class MPDSavePropagatesLinkTest(TestCase):
             current_source_id=self.mh_source.id,
         )
 
-        variants_after = list(
+        variants_after = set(
             ProductVariants.objects.using(mpd_db)
             .filter(product=self.mpd_product)
             .values_list('variant_id', flat=True)
         )
-        new_variant_ids = set(variants_after) - variants_before
         self.assertEqual(
-            len(new_variant_ids), 1,
-            "Powinien powstać dokładnie jeden nowy wariant MPD dla rozmiaru 'M' z Tabu",
+            variants_after, variants_before,
+            "Linking nie powinien tworzyć nowych wariantów MPD dla nietrafionych EAN-ów",
         )
-        new_variant_id = new_variant_ids.pop()
-        pvs = ProductvariantsSources.objects.using(mpd_db).get(
-            variant_id=new_variant_id, source=self.tabu_source,
+        # Rozmiar 'S' (ten sam EAN) nadal dopięty do istniejącego wariantu
+        self.assertTrue(
+            ProductvariantsSources.objects.using(mpd_db).filter(
+                variant=self.mpd_variant, source=self.tabu_source,
+            ).exists()
         )
-        self.assertEqual(pvs.ean, self.tabu_variant_extra.ean)
+        # Rozmiar 'M' (inny EAN) NIE został nigdzie dopięty
+        self.assertFalse(
+            ProductvariantsSources.objects.using(mpd_db).filter(
+                source=self.tabu_source, ean=self.tabu_variant_extra.ean,
+            ).exists()
+        )
+
+    def test_get_unmapped_variants_returns_orphaned_tabu_variant(self):
+        """
+        Po zlinkowaniu po EAN wariant 'M' z Tabu (nietrafiony EAN, ten sam produkt
+        źródłowy zmapowany po 'S') jest zwracany jako „nieprzypisany" (orphaned).
+        """
+        from MPD.source_adapters.linking import link_variants_from_other_sources
+        from MPD.source_adapters.registry import get_adapter_for_source
+
+        link_variants_from_other_sources(
+            mpd_product_id=self.mpd_product.id,
+            current_source_id=self.mh_source.id,
+        )
+
+        adapter = get_adapter_for_source(self.tabu_source.id)
+        orphans = adapter.get_unmapped_variants_for_mpd_product(self.mpd_product.id)
+        orphan_eans = {o.ean for o in orphans}
+        self.assertIn(self.tabu_variant_extra.ean, orphan_eans)
+        self.assertNotIn(self.ean, orphan_eans)
+
+
+class VariantUidIntTest(TestCase):
+    """`_variant_uid_int` chroni kolumnę PG integer (32-bit) przed przepełnieniem —
+    identyfikatory hurtowni oparte na EAN (np. Mada variant_key = 13 cyfr) → null."""
+
+    def test_clamps_values_outside_pg_integer_range(self):
+        from MPD.source_adapters.linking import _variant_uid_int
+
+        class M:
+            def __init__(self, uid):
+                self.variant_uid = uid
+
+        self.assertEqual(_variant_uid_int(M('19410')), 19410)
+        self.assertIsNone(_variant_uid_int(M('5902771173479')))  # 13-cyfrowy EAN
+        self.assertIsNone(_variant_uid_int(M('GOS-BIU-105B')))
+        self.assertIsNone(_variant_uid_int(M(None)))


### PR DESCRIPTION
- link_variants_from_other_sources: usunięty backfill "pozostałych" wariantów (tworzył warianty MPD dla nietrafionych EAN-ów → wciągał obcy kolor pod zły produkt, bo hurtownie trzymają kilka kolorów pod jednym produktem)
- _variant_uid_int: guard na zakres PG integer (Mada variant_key = 13-cyfrowy EAN przepełniał kolumnę → "integer out of range")
- SourceAdapter.get_unmapped_variants_for_mpd_product (Tabu/Matterhorn/Mada)
- GET/POST /api/mpd/products/<id>/orphan-variants/ + panel OrphanVariantsPanel (przypięcie do istniejącego wariantu MPD albo utworzenie nowego)