### PR TITLE
fix(mapping): duplicate key colors_name_key przy przypinaniu kolejnego koloru

### DIFF
--- a/src/apps/MPD/migrations/0023_colors_name_unique.py
+++ b/src/apps/MPD/migrations/0023_colors_name_unique.py
@@ -1,0 +1,39 @@
+# colors_name_key (UNIQUE) i colors_name_not_null istnieją w bazie MPD od dawna —
+# model dotąd tego nie odzwierciedlał (name = CharField(null=True) bez unique).
+# DDL idempotentne (IF NOT EXISTS), bo na prod baza już to ma.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('MPD', '0022_merge_20260829_1405'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE colors ALTER COLUMN name SET NOT NULL;",
+                    reverse_sql="ALTER TABLE colors ALTER COLUMN name DROP NOT NULL;",
+                ),
+                migrations.RunSQL(
+                    sql=(
+                        "DO $$ BEGIN "
+                        "IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'colors_name_key') "
+                        "THEN ALTER TABLE colors ADD CONSTRAINT colors_name_key UNIQUE (name); "
+                        "END IF; END $$;"
+                    ),
+                    reverse_sql="ALTER TABLE colors DROP CONSTRAINT IF EXISTS colors_name_key;",
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name='colors',
+                    name='name',
+                    field=models.CharField(max_length=50, unique=True),
+                ),
+            ],
+        ),
+    ]

--- a/src/apps/MPD/models.py
+++ b/src/apps/MPD/models.py
@@ -74,7 +74,9 @@ class Collection(models.Model):
 
 class Colors(models.Model):
     id = models.BigAutoField(primary_key=True)
-    name = models.CharField(max_length=50, blank=True, null=True)
+    # colors_name_key (UNIQUE) + colors_name_not_null istnieją w bazie od dawna —
+    # model to teraz odzwierciedla (patrz Sources.type / paths.name).
+    name = models.CharField(max_length=50, unique=True)
     hex_code = models.CharField(max_length=7, blank=True, null=True)
     parent = models.ForeignKey(
         'self', on_delete=models.SET_NULL, null=True, blank=True, db_column='parent_id')

--- a/src/apps/MPD/tests_integration.py
+++ b/src/apps/MPD/tests_integration.py
@@ -398,3 +398,140 @@ class MPDProductImagesImportTest(TestCase):
         self.assertFalse(
             ProductImage.objects.using(_mpd_db()).filter(pk=img.id).exists()
         )
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class MPDAttachOrphanVariantTest(TestCase):
+    """
+    POST /api/mpd/products/<id>/orphan-variants/ — przypięcie „orphaned" wariantu
+    do produktu, który JUŻ jest zmapowany (Tabu.mapped_product_uid ustawione,
+    jeden wariant już zlinkowany).
+    """
+
+    databases = '__all__'
+
+    def setUp(self):
+        from datetime import datetime as _dt
+        mpd_db = _mpd_db()
+        tabu_db = _tabu_db()
+
+        self.tabu_source = Sources.objects.using(mpd_db).create(name='Tabu API', type='api')
+        brand = Brands.objects.using(mpd_db).create(name='B')
+        self.color = Colors.objects.using(mpd_db).create(name='Czarny')
+        size_s = Sizes.objects.using(mpd_db).create(name='S', category='default')
+        self.mpd_product = Products.objects.using(mpd_db).create(name='Anya K422', brand=brand)
+        self.mpd_variant = ProductVariants.objects.using(mpd_db).create(
+            product=self.mpd_product, color=self.color, size=size_s,
+        )
+        ProductvariantsSources.objects.using(mpd_db).create(
+            variant=self.mpd_variant, source=self.tabu_source,
+            ean='5900000000001', variant_uid=5001,
+        )
+
+        # Tabu: produkt zmapowany, wariant 'S' zlinkowany, wariant 'M' orphaned
+        self.tabu_product = TabuProduct.objects.using(tabu_db).create(
+            api_id=9001, symbol='K422', name='Biustonosz K422',
+            last_update=_dt(2026, 1, 1),
+            mapped_product_uid=self.mpd_product.id,
+        )
+        TabuProductVariant.objects.using(tabu_db).create(
+            api_id=5001, product=self.tabu_product, symbol='K422-S',
+            ean='5900000000001', size='S', store=2,
+            mapped_variant_uid=self.mpd_variant.variant_id, is_mapped=True,
+        )
+        self.tabu_orphan = TabuProductVariant.objects.using(tabu_db).create(
+            api_id=5002, product=self.tabu_product, symbol='K422-M',
+            ean='5900000000002', size='M', store=3,
+        )
+
+    def _post(self, payload):
+        from MPD.api_views import MPDProductOrphanVariantsAPI
+        req = type('R', (), {'data': payload})()
+        return MPDProductOrphanVariantsAPI().post(req, product_id=self.mpd_product.id)
+
+    def test_attach_orphan_as_new_variant(self):
+        from MPD.models import ProductVariants as PV, ProductvariantsSources as PVS
+
+        resp = self._post({
+            'source_id': self.tabu_source.id,
+            'source_variant_uid': '5002',
+            'source_product_id': self.tabu_product.id,
+            'ean': '5900000000002',
+            'stock': 3,
+            'price': 61.63,
+            'mode': 'new',
+            'color_id': self.color.id,
+            'size_name': 'M',
+        })
+        self.assertEqual(resp.data['status'], 'success', resp.data)
+
+        new_v = PV.objects.using(_mpd_db()).get(pk=resp.data['variant_id'])
+        self.assertEqual(new_v.product_id, self.mpd_product.id)
+        self.assertTrue(PVS.objects.using(_mpd_db()).filter(
+            variant_id=new_v.variant_id, source=self.tabu_source,
+        ).exists())
+
+        self.tabu_orphan.refresh_from_db(using=_tabu_db())
+        self.assertEqual(self.tabu_orphan.mapped_variant_uid, new_v.variant_id)
+
+    def test_get_orphans_on_mapped_product(self):
+        from MPD.api_views import MPDProductOrphanVariantsAPI
+        req = type('R', (), {'query_params': {}})()
+        resp = MPDProductOrphanVariantsAPI().get(req, product_id=self.mpd_product.id)
+        self.assertEqual(resp.data['status'], 'success', resp.data)
+        eans = {r['ean'] for r in resp.data['results']}
+        self.assertIn('5900000000002', eans)      # orphaned 'M'
+        self.assertNotIn('5900000000001', eans)   # 'S' już zlinkowany
+
+    def test_reattach_orphan_to_already_linked_variant(self):
+        # mpd_variant już MA źródło Tabu (variant_uid=5001). Przypinamy do niego
+        # orphaned wariant 5002 — nie może wybuchnąć na unique (variant, source).
+        resp = self._post({
+            'source_id': self.tabu_source.id,
+            'source_variant_uid': '5002',
+            'source_product_id': self.tabu_product.id,
+            'ean': '5900000000002',
+            'stock': 3, 'price': 61.63,
+            'mode': 'existing',
+            'target_variant_id': self.mpd_variant.variant_id,
+        })
+        self.assertEqual(resp.data['status'], 'success', resp.data)
+
+    def test_attach_new_with_second_tabu_source_present(self):
+        # Druga „Tabu"-owa Sources (duplikat nazwy) — get_all_adapters / matching
+        # nie może wysypać endpointu.
+        Sources.objects.using(_mpd_db()).create(name='Tabu', type='api')
+        resp = self._post({
+            'source_id': self.tabu_source.id,
+            'source_variant_uid': '5002',
+            'source_product_id': self.tabu_product.id,
+            'ean': '5900000000002',
+            'stock': 3, 'price': 61.63,
+            'mode': 'new', 'color_id': self.color.id, 'size_name': 'M',
+        })
+        self.assertEqual(resp.data['status'], 'success', resp.data)
+
+    def test_attach_orphan_to_existing_variant(self):
+        from MPD.models import ProductvariantsSources as PVS
+
+        # nowy wariant MPD 'M' bez źródła — cel przypięcia
+        size_m = Sizes.objects.using(_mpd_db()).create(name='M', category='default')
+        target = ProductVariants.objects.using(_mpd_db()).create(
+            product=self.mpd_product, color=self.color, size=size_m,
+        )
+        resp = self._post({
+            'source_id': self.tabu_source.id,
+            'source_variant_uid': '5002',
+            'source_product_id': self.tabu_product.id,
+            'ean': '5900000000002',
+            'stock': 3,
+            'price': 61.63,
+            'mode': 'existing',
+            'target_variant_id': target.variant_id,
+        })
+        self.assertEqual(resp.data['status'], 'success', resp.data)
+        self.assertTrue(PVS.objects.using(_mpd_db()).filter(
+            variant_id=target.variant_id, source=self.tabu_source,
+        ).exists())
+        self.tabu_orphan.refresh_from_db(using=_tabu_db())
+        self.assertEqual(self.tabu_orphan.mapped_variant_uid, target.variant_id)

--- a/src/apps/matterhorn1/saga_variants.py
+++ b/src/apps/matterhorn1/saga_variants.py
@@ -74,13 +74,15 @@ def create_mpd_variants(
             raise ValueError("Color %s not found in MPD" % product_color)
         color_id = color.id
 
-        # Producer color
+        # Producer color. UWAGA: colors.name jest UNIQUE — szukamy po samej nazwie,
+        # parent_id trafia tylko do defaults. Lookup po (name, parent_id) wywalał się
+        # na colors_name_key, gdy kolor o tej nazwie już istniał z innym parentem
+        # (np. „Beige" przypięty do innego koloru głównego).
         producer_color_id = None
         if producer_color_name and main_color_id:
             producer_color, created = Colors.objects.using(mpd_db).get_or_create(
                 name=producer_color_name,
-                parent_id=main_color_id,
-                defaults={'hex_code': ''},
+                defaults={'hex_code': '', 'parent_id': main_color_id},
             )
             producer_color_id = producer_color.id
             if created:

--- a/src/apps/matterhorn1/tests_saga_variants.py
+++ b/src/apps/matterhorn1/tests_saga_variants.py
@@ -173,6 +173,38 @@ class CreateMpdVariantsTest(TestCase):
         self.assertTrue(self.mh_var1.is_mapped)
         self.assertTrue(self.mh_var2.is_mapped)
 
+    def test_create_mpd_variants_reuses_existing_producer_color_with_other_parent(self):
+        """
+        Regresja: kolor producenta o danej nazwie już istnieje w MPD, ale z INNYM
+        parentem (colors.name jest UNIQUE). Lookup po (name, parent_id) wywalał
+        `duplicate key value violates unique constraint "colors_name_key"`
+        przy przypinaniu kolejnego koloru do już zmapowanego produktu.
+        """
+        mpd_db = _mpd_db()
+        parent_a = Colors.objects.using(mpd_db).create(name='Beżowy główny A')
+        parent_b = Colors.objects.using(mpd_db).create(name='Beżowy główny B')
+        Colors.objects.using(mpd_db).create(name='Beige K422', parent_id=parent_a.id)
+
+        result = create_mpd_variants(
+            mpd_product_id=self.mpd_product.id,
+            matterhorn_product_id=self.mh_product.id,
+            size_category='test_category',
+            producer_code='PROD',
+            main_color_id=parent_b.id,
+            producer_color_name='Beige K422',
+        )
+        self.assertEqual(result['created_variants'], 2)
+
+        beige = Colors.objects.using(mpd_db).get(name='Beige K422')
+        # Istniejący kolor został użyty (nie próbowaliśmy tworzyć duplikatu)
+        self.assertEqual(
+            Colors.objects.using(mpd_db).filter(name='Beige K422').count(), 1
+        )
+        pv = ProductVariants.objects.using(mpd_db).filter(
+            product_id=self.mpd_product.id
+        ).first()
+        self.assertEqual(pv.producer_color_id, beige.id)
+
     def test_create_mpd_variants_empty_variants_returns_zero(self):
         """Gdy produkt nie ma wariantów, zwraca created_variants=0"""
         mh_db, mpd_db = _mh_db(), _mpd_db()


### PR DESCRIPTION
## Problem

Mapowanie kolejnego koloru (np. beżowy Matterhorn → istniejący produkt MPD) przez akcję **„przypisz"** w adminie kończyło się `{"error": "Błąd mapowania wariantów"}` — warianty się nie dopinały.

W logach:
```
Błąd podczas dodawania wariantów: Failed to create MPD variants:
duplicate key value violates unique constraint "colors_name_key"
DETAIL: Key (name)=(Beige K422) already exists.
```

## Przyczyna

`create_mpd_variants` (`matterhorn1/saga_variants.py`) robił:
```python
Colors.objects.get_or_create(name=producer_color_name, parent_id=main_color_id, defaults={...})
```
`colors.name` jest **UNIQUE** (`colors_name_key`). Gdy kolor o tej nazwie już istniał, ale z **innym `parent_id`**, lookup po `(name, parent_id)` nie trafiał → `.create()` → `IntegrityError`.

## Fix

- `get_or_create` szuka po **samej nazwie**, `parent_id` → `defaults`
- `Colors.name`: `unique=True` + NOT NULL (model dogania bazę — jak `Sources.type`/`paths.name`). Migracja `0023` = `SeparateDatabaseAndState`, DDL idempotentne (`IF NOT EXISTS`), bo prod baza to już ma
- test regresyjny (bez fixu: `Exception: ... colors_name_key`)
- + testy `MPDProductOrphanVariantsAPI` — przypięcie orphaned wariantu do już zmapowanego produktu

308 testów `matterhorn1` + `MPD` przechodzi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)