### PR TITLE
chore(deps): grupy pydantic + openai-stack w Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,8 +74,26 @@ updates:
           - version-update:semver-major
           - version-update:semver-minor
     groups:
-      # Tylko patch grupowo — minory potrafią rozjechać sprzężone pakiety
-      # (pydantic/pydantic-core, openai/openai-agents) przy zbiorczym bumpie.
+      # Rodziny sprzężone: pinujemy tranzytywy (pydantic-core, pydantic-settings),
+      # więc muszą się ruszać razem z rodzicem — inaczej pip nie rozwiąże
+      # (pydantic 2.13.4 wymaga dokładnie pydantic-core 2.46.4).
+      pydantic:
+        patterns:
+          - "pydantic"
+          - "pydantic-core"
+          - "pydantic_core"
+          - "pydantic-settings"
+        update-types:
+          - minor
+          - patch
+      openai-stack:
+        patterns:
+          - "openai"
+          - "openai-agents"
+        update-types:
+          - minor
+          - patch
+      # Reszta: tylko patch grupowo (minory pojedynczo, przez bramkę testową).
       python-patch:
         patterns:
           - "*"


### PR DESCRIPTION
## Problem

`requirements.txt` pinuje **tranzytywne** zależności rodzin (`pydantic-core`, `pydantic-settings`). Gdy Dependabot bumpuje rodzica solo → piny się rozjeżdżają, `pip` nie rozwiązuje.

**PR #149**: `pydantic 2.11.7 → 2.13.4` (solo). `pydantic 2.13.4` wymaga dokładnie `pydantic-core==2.46.4`, a w pliku został `pydantic_core==2.33.2` → `ResolutionImpossible`. Nie do naprawienia rebasem.

## Fix

`dependabot.yml` — grupy `pydantic` (`pydantic` + `pydantic-core` + `pydantic-settings`) i `openai-stack` (`openai` + `openai-agents`), minor+patch razem.

## Po merge

Zamknąć **#149** (`@dependabot recreate` w komentarzu albo Close) — wróci jako spójny grouped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)