### PR TITLE
fix(deps): bump pydantic 2.13.4 + odepnij tranzytywy (pydantic-core, pydantic-settings)

### DIFF
--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -70,9 +70,7 @@ prompt_toolkit==3.0.53
 psutil==7.0.0
 psycopg2-binary==2.9.12
 pycparser==3.0
-pydantic==2.11.7
-pydantic-settings==2.10.1
-pydantic_core==2.33.2
+pydantic==2.13.4
 Pygments==2.20.0
 PySocks==1.7.1
 python-crontab==3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -70,9 +70,7 @@ prompt_toolkit==3.0.53
 psutil==7.0.0
 psycopg2-binary==2.9.12
 pycparser==3.0
-pydantic==2.11.7
-pydantic-settings==2.10.1
-pydantic_core==2.33.2
+pydantic==2.13.4
 Pygments==2.20.0
 PySocks==1.7.1
 python-crontab==3.2.0


### PR DESCRIPTION
## Problem

`requirements.txt` pinował `pydantic-core` i `pydantic-settings` — **czyste tranzytywy** (nieimportowane w `src/`; `pydantic-settings` ciąga `mcp`). Dependabot bumpuje `pydantic` i próbuje osobno bumpować tranzytywy do ich latest, ale `pydantic X.Y` wymaga **dokładnie** określonego `pydantic-core`:

- **#149**: `pydantic 2.13.4` solo → `pydantic-core` został na 2.33.2
- **#151** (grupa pydantic): wszystkie 3, ale `pydantic-core==2.48.0` zamiast wymaganego `2.46.4`

Za każdym razem `pip` → `ResolutionImpossible`. Grupa tego nie naprawia — Dependabot nie sprawdza exact-pinu z `pydantic`.

## Fix

- `pydantic==2.11.7 → 2.13.4`
- **usunięte** piny `pydantic-core` i `pydantic-settings` → `pip` dobiera zgodne automatycznie

`pip install --dry-run -r requirements.ci.txt` → **OK**. CI zweryfikuje pełnym pakietem testów.

## Po merge
Zamknąć #149, #151 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)