### PR TITLE
fix(deps): cofnij redis 8.1.0 -> 5.2.1 (brak wsparcia w celery/kombu)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,13 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      # redis-py: kombu (nawet 5.6.2) trzyma redis<6.5. redis 8.x nie ma wsparcia
+      # w żadnej wersji celery/kombu (PR #141 podbił do 8.1.0 — broker by się wywalił).
+      # Bump dopiero gdy celery/kombu dogonią.
+      - dependency-name: "redis"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       # Rodziny sprzężone: pinujemy tranzytywy (pydantic-core, pydantic-settings),
       # więc muszą się ruszać razem z rodzicem — inaczej pip nie rozwiąże

--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -84,7 +84,7 @@ pytz==2026.3.post1
 PyYAML==6.0.3
 pyzmq==26.4.0
 RapidFuzz==3.13.0
-redis==8.1.0
+redis==5.2.1
 referencing==0.36.2
 requests==2.33.0
 rpds-py==0.26.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -84,7 +84,7 @@ pytz==2026.3.post1
 PyYAML==6.0.3
 pyzmq==26.4.0
 RapidFuzz==3.13.0
-redis==8.1.0
+redis==5.2.1
 referencing==0.36.2
 requests==2.33.0
 rpds-py==0.26.0


### PR DESCRIPTION
## Problem

**PR #141** podbił `redis` (redis-py) `5.2.1 → 8.1.0`. `pip install` przeszło (nie ma extra `celery[redis]`, więc constraint się nie egzekwuje), CI zielone — bo testy chodzą w `CELERY_TASK_ALWAYS_EAGER` i **nie dotykają brokera**.

Ale w prod broker Celery = `redis://...` → **kombu redis transport** → kombu woła redis-py wewnętrznie.

| pakiet | pin redis-py |
|---|---|
| `kombu 5.4.2` (w main) | `>=4.5.2` (extra) |
| `kombu 5.6.2` (latest) | **`<6.5`** |
| `celery 5.4.0` (extra `[redis]`) | `<6.0.0` |

**Żadna wersja celery/kombu nie wspiera redis-py 8.x.** Broker by się wywalił przy najbliższym rebuildzie/deployu (redis-py 6+ usunął sporo API).

Cache = `DatabaseCache`, result backend = `django-db` → redis-py to **wyłącznie broker**, i to ta ścieżka pękała.

## Fix

- `redis==5.2.1` z powrotem (`git revert -m 1` merge #141)
- `dependabot.yml`: `ignore` redis minor/major — bump dopiero gdy celery/kombu dogonią (wtedy najwyżej do 6.4.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)