### PR TITLE
feat(mpd): ustaw producer_color_id przy uploadzie zdjęć z hurtowni

### DIFF
--- a/src/apps/matterhorn1/saga.py
+++ b/src/apps/matterhorn1/saga.py
@@ -647,6 +647,16 @@ class SagaService:
                 logger.info("ℹ️ Brak zdjęć do uploadu")
                 return {"uploaded_images": 0}
 
+            # Jawne przypisanie do koloru — grupowanie po producer_color_id zamiast
+            # heurystyki po nazwie pliku. colors.name jest UNIQUE, więc lookup deterministyczny.
+            producer_color_id = None
+            _pc = (producer_color_name or '').strip()
+            if _pc:
+                with connections['MPD'].cursor() as _c:
+                    _c.execute("SELECT id FROM colors WHERE name = %s", [_pc])
+                    _row = _c.fetchone()
+                    producer_color_id = _row[0] if _row else None
+
             uploaded_count = 0
             uploaded_images = []
 
@@ -665,10 +675,10 @@ class SagaService:
                             bucket_url = resolve_image_url(bucket_key)
                             # Zapisz do MPD
                             mpd_cursor.execute("""
-                                INSERT INTO product_images (product_id, file_path)
-                                VALUES (%s, %s)
+                                INSERT INTO product_images (product_id, file_path, producer_color_id)
+                                VALUES (%s, %s, %s)
                                 ON CONFLICT (product_id, file_path) DO NOTHING
-                            """, [mpd_product_id, bucket_key])
+                            """, [mpd_product_id, bucket_key, producer_color_id])
 
                             uploaded_count += 1
                             uploaded_images.append({

--- a/src/apps/tabu/services.py
+++ b/src/apps/tabu/services.py
@@ -244,7 +244,7 @@ def _saga_create_mpd_tabu(
                         ProductImage.objects.using(mpd_db).get_or_create(
                             product=mpd_product,
                             file_path=bucket_key,
-                            defaults={'product': mpd_product, 'file_path': bucket_key},
+                            defaults={'producer_color': producer_color},
                         )
             except Exception as img_err:
                 logger.warning("Błąd uploadu zdjęć Tabu→MPD: %s", img_err)
@@ -598,7 +598,7 @@ def upload_tabu_images_to_mpd(
     """
     try:
         from tabu.models import TabuProduct
-        from MPD.models import Products, ProductImage
+        from MPD.models import Colors, Products, ProductImage
         from core.db_routers import _get_mpd_db, _get_tabu_db
         from matterhorn1.defs_db import upload_image_to_bucket_and_get_url
 
@@ -620,6 +620,12 @@ def upload_tabu_images_to_mpd(
 
         mpd_product = Products.objects.using(mpd_db).get(pk=mpd_product_id)
         producer_color = (producer_color_name or "").strip()
+        # Jawne przypisanie do koloru (grupowanie po producer_color_id, nie heurystyka
+        # po nazwie pliku). colors.name UNIQUE → lookup deterministyczny.
+        producer_color_obj = (
+            Colors.objects.using(mpd_db).filter(name=producer_color).first()
+            if producer_color else None
+        )
         uploaded_count = 0
         uploaded_images = []
         for idx, (img_url, order_num) in enumerate(images_to_upload, 1):
@@ -633,7 +639,7 @@ def upload_tabu_images_to_mpd(
                 ProductImage.objects.using(mpd_db).get_or_create(
                     product=mpd_product,
                     file_path=bucket_key,
-                    defaults={"product": mpd_product, "file_path": bucket_key},
+                    defaults={"producer_color": producer_color_obj},
                 )
                 uploaded_count += 1
                 uploaded_images.append({"original_url": img_url, "storage_key": bucket_key, "order": order_num})

--- a/src/apps/tabu/tests_saga.py
+++ b/src/apps/tabu/tests_saga.py
@@ -161,3 +161,60 @@ class TabuSagaAdminTest(TestCase):
     def test_sagastep_changelist_reachable(self):
         response = self.client.get(reverse('admin:tabu_sagastep_changelist'))
         self.assertEqual(response.status_code, 200)
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class TabuImageUploadProducerColorTest(TestCase):
+    """upload_tabu_images_to_mpd ustawia producer_color_id na product_images
+    (jawne grupowanie po kolorze zamiast heurystyki po nazwie pliku)."""
+
+    databases = '__all__'
+
+    def setUp(self):
+        from MPD.models import Brands, Colors, Products
+        mpd_db = _mpd_db()
+        tabu_db = _tabu_db()
+
+        Colors.objects.using(mpd_db).create(name='Czarny główny')
+        self.pc = Colors.objects.using(mpd_db).create(name='Grafit K999')
+        brand = Brands.objects.using(mpd_db).create(name='B')
+        self.mpd_product = Products.objects.using(mpd_db).create(name='Img PC Test', brand=brand)
+
+        self.tabu_product = TabuProduct.objects.using(tabu_db).create(
+            api_id=930001, symbol='IMG-PC', name='Tabu img pc',
+            last_update=timezone.now(),
+            image_url='https://tabu.example/main.jpg',
+        )
+
+    def test_producer_color_set_from_name(self):
+        from unittest.mock import patch
+        from tabu.services import upload_tabu_images_to_mpd
+        from MPD.models import ProductImage
+
+        with patch(
+            'matterhorn1.defs_db.upload_image_to_bucket_and_get_url',
+            return_value='MPD_test/x/x_1_Grafit.jpg',
+        ):
+            res = upload_tabu_images_to_mpd(
+                self.mpd_product.id, self.tabu_product.id,
+                producer_color_name='Grafit K999',
+            )
+        self.assertEqual(res['uploaded_images'], 1)
+        img = ProductImage.objects.using(_mpd_db()).get(product_id=self.mpd_product.id)
+        self.assertEqual(img.producer_color_id, self.pc.id)
+
+    def test_producer_color_null_when_name_unknown(self):
+        from unittest.mock import patch
+        from tabu.services import upload_tabu_images_to_mpd
+        from MPD.models import ProductImage
+
+        with patch(
+            'matterhorn1.defs_db.upload_image_to_bucket_and_get_url',
+            return_value='MPD_test/x/x_1.jpg',
+        ):
+            upload_tabu_images_to_mpd(
+                self.mpd_product.id, self.tabu_product.id,
+                producer_color_name='NieMaTakiego',
+            )
+        img = ProductImage.objects.using(_mpd_db()).get(product_id=self.mpd_product.id)
+        self.assertIsNone(img.producer_color_id)


### PR DESCRIPTION
## Kontekst

Po przypisaniu koloru beżowego do produktu (Anya K422) zdjęcie beżowe nie grupowało się jawnie — `_upload_product_images` / `upload_tabu_images_to_mpd` wstawiały wiersz do `product_images` z samym `product_id + file_path`. Grupowanie na froncie leciało **wyłącznie z heurystyki po nazwie pliku** (klucz w buckecie koduje `producer_color_name`).

## Zmiana

Upload zna `producer_color_name`, a `colors.name` jest UNIQUE (#145) → rozwiązujemy `producer_color_id` deterministycznie i zapisujemy wprost.

| miejsce | jak |
|---|---|
| `matterhorn1/saga._upload_product_images` | `SELECT id FROM colors WHERE name=%s` → `INSERT ... producer_color_id` |
| `tabu.services.upload_tabu_images_to_mpd` | ORM: `defaults={'producer_color': obj}` |
| `tabu.services._saga_create_mpd_tabu` | ORM, używa `producer_color` z wcześniejszego kroku |

Nieznana nazwa → `NULL` → zdjęcie w tacce „Do przypisania" (front nadal ma fallback po nazwie).

Front bez zmian — `groupImagesByColor` już preferuje `producer_color_id`.

339 testów `tabu` + `matterhorn1` + `MPD` przechodzi. + 2 nowe (`TabuImageUploadProducerColorTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)