### PR TITLE
fix(mpd-api): jawne TokenAuthentication na endpointach orphaned/images

### DIFF
--- a/src/apps/MPD/api_views.py
+++ b/src/apps/MPD/api_views.py
@@ -517,6 +517,7 @@ class MPDProductOrphanVariantsAPI(APIView):
     """
 
     permission_classes = [IsAdminUser]
+    authentication_classes = [TokenAuthentication]
 
     def get(self, request, product_id, *args, **kwargs):  # pylint: disable=unused-argument
         from .source_adapters.registry import get_all_adapters, register_default_adapters
@@ -693,6 +694,7 @@ class MPDProductImagesImportAPI(APIView):
     """
 
     permission_classes = [IsAdminUser]
+    authentication_classes = [TokenAuthentication]
 
     def post(self, request, product_id, *args, **kwargs):  # pylint: disable=unused-argument
         from matterhorn1.defs_db import upload_image_to_bucket_and_get_url
@@ -770,6 +772,7 @@ class MPDProductImageDetailAPI(APIView):
     """
 
     permission_classes = [IsAdminUser]
+    authentication_classes = [TokenAuthentication]
 
     def _get_image(self, product_id, image_id):
         from .models import ProductImage


### PR DESCRIPTION
## Problem

`CSRF Failed: CSRF token missing` przy „Zatwierdź" w panelu orphaned (POST) — GET działał.

`MPDProductOrphanVariantsAPI` / `MPDProductImagesImportAPI` / `MPDProductImageDetailAPI` miały tylko `permission_classes = [IsAdminUser]`, bez `authentication_classes` → DRF brał `DEFAULT_AUTHENTICATION_CLASSES` = `[SessionAuthentication, TokenAuthentication]`.

`SessionAuthentication` wymusza **CSRF** na metodach niebezpiecznych. Przeglądarka zalogowana też w `/admin` ma cookie sesji → SessionAuth je łapie → CSRF check → axios wysyła `Authorization: Token …` bez `X-CSRFToken` → **fail**.

## Fix

`authentication_classes = [TokenAuthentication]` na tych 3 klasach — jak reszta `api_views.py`. Zdejmuje SessionAuthentication i CSRF; Token z headera (React app go wysyła) autoryzuje admina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)