### PR TITLE
fix(tabu): parent_id na kolorze producenta w sadze MPD

### DIFF
--- a/src/apps/tabu/services.py
+++ b/src/apps/tabu/services.py
@@ -144,9 +144,12 @@ def _saga_create_mpd_tabu(
 
         producer_color = None
         if producer_color_name:
+            # Lookup po samej nazwie (colors.name jest UNIQUE) – parent_id tylko w
+            # defaults, analogicznie do Matterhorn, żeby nie wywalić się na
+            # colors_name_key gdy kolor już istnieje z innym parentem.
             producer_color, _ = Colors.objects.using(mpd_db).get_or_create(
                 name=producer_color_name[:50],
-                defaults={'name': producer_color_name[:50]},
+                defaults={'parent_id': main_color.id if main_color else None},
             )
 
         tabu_source, _ = Sources.objects.using(mpd_db).get_or_create(


### PR DESCRIPTION
Wyrównanie Tabu do Matterhorn: `_saga_create_mpd_tabu` tworzył kolor producenta
przez `get_or_create(name=..., defaults={'name': ...})` — **bez `parent_id`**.
Matterhorn (`saga_variants.create_mpd_variants`) ustawia `parent_id=main_color_id`.

Teraz lookup po samej nazwie (`colors.name` UNIQUE), `parent_id` trafia do
`defaults` — więc kolor dostaje właściwego rodzica przy tworzeniu, a przy
istniejącym kolorze z innym parentem nie ma `colors_name_key` crasha.

Ścieżka `assign-mapping` (`create_mpd_variants_from_tabu`) już to robiła poprawnie.

Testy: `python manage.py test tabu` → 31 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)