### PR TITLE
fix(mada): czyść mapowanie w Mada przy usunięciu produktu MPD

### DIFF
--- a/src/apps/MPD/signals.py
+++ b/src/apps/MPD/signals.py
@@ -16,6 +16,7 @@ def _get_connections_db():
         'zzz_MPD' if 'zzz_MPD' in settings.DATABASES else 'MPD',
         'zzz_matterhorn1' if 'zzz_matterhorn1' in settings.DATABASES else 'matterhorn1',
         'zzz_tabu' if 'zzz_tabu' in settings.DATABASES else 'tabu',
+        'zzz_mada' if 'zzz_mada' in settings.DATABASES else 'mada',
     )
 
 
@@ -87,7 +88,7 @@ def capture_variant_ids(sender, instance, using=None, **kwargs):
 def remove_mapping_in_matterhorn(sender, instance, using=None, **kwargs):
     # Sprawdź czy to produkt z bazy MPD - sprawdź using lub _state.db
     db = using or getattr(instance, '_state', {}).db or 'default'
-    mpd_db, mh_db, tabu_db = _get_connections_db()
+    mpd_db, mh_db, tabu_db, mada_db = _get_connections_db()
     if db != mpd_db and 'MPD' not in str(db):
         # Sprawdź czy instancja pochodzi z bazy MPD
         try:
@@ -184,6 +185,42 @@ def remove_mapping_in_matterhorn(sender, instance, using=None, **kwargs):
                                 f"Zaktualizowano {tabu_variants_updated} rekordów w tabu_product_variant (mapped_variant_uid)")
             except Exception as e:
                 logger.warning(f"Nie udało się zaktualizować Tabu dla produktu MPD {instance.id}: {e}")
+
+        # Usunięcie mapped_product_uid i mapped_variant_uid w Mada
+        if mada_db in settings.DATABASES:
+            try:
+                with connections[mada_db].cursor() as cursor:
+                    cursor.execute(
+                        """
+                        UPDATE mada_product
+                        SET mapped_product_uid = NULL,
+                            updated_at = NOW()
+                        WHERE mapped_product_uid = %s
+                        """, [instance.id]
+                    )
+                    mada_updated = cursor.rowcount
+                    if mada_updated:
+                        logger.info(
+                            f"Zaktualizowano {mada_updated} rekordów w mada_product (mapped_product_uid = {instance.id})")
+                    # Usunięcie mapped_variant_uid z wariantów Mada (mada_product_variant)
+                    if variant_ids:
+                        placeholders = ', '.join(['%s'] * len(variant_ids))
+                        cursor.execute(
+                            f"""
+                            UPDATE mada_product_variant
+                            SET mapped_variant_uid = NULL,
+                                is_mapped = FALSE,
+                                updated_at = NOW()
+                            WHERE mapped_variant_uid IN ({placeholders})
+                            """,
+                            variant_ids,
+                        )
+                        mada_variants_updated = cursor.rowcount
+                        if mada_variants_updated:
+                            logger.info(
+                                f"Zaktualizowano {mada_variants_updated} rekordów w mada_product_variant (mapped_variant_uid)")
+            except Exception as e:
+                logger.warning(f"Nie udało się zaktualizować Mada dla produktu MPD {instance.id}: {e}")
 
         logger.info(
             f"Zakończono usuwanie mapowań dla produktu MPD ID: {instance.id}")

--- a/src/apps/MPD/tests_integration.py
+++ b/src/apps/MPD/tests_integration.py
@@ -20,6 +20,7 @@ from MPD.models import (
     Sources,
 )
 from matterhorn1.models import Product as MhProduct
+from mada.models import Brand as MadaBrand, MadaProduct, MadaProductVariant
 from tabu.models import TabuProduct, TabuProductVariant, Brand as TabuBrand
 
 
@@ -35,6 +36,10 @@ def _tabu_db():
     return 'zzz_tabu' if 'zzz_tabu' in settings.DATABASES else 'tabu'
 
 
+def _mada_db():
+    return 'zzz_mada' if 'zzz_mada' in settings.DATABASES else 'mada'
+
+
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class MPDDeletePropagatesToHurtownieTest(TestCase):
     """
@@ -47,12 +52,16 @@ class MPDDeletePropagatesToHurtownieTest(TestCase):
         mpd_db = _mpd_db()
         mh_db = _mh_db()
         tabu_db = _tabu_db()
+        mada_db = _mada_db()
 
-        # Produkt MPD
+        # Produkt MPD + wariant (do sprawdzenia czyszczenia mapped_variant_uid)
         brand = Brands.objects.using(mpd_db).create(name='Test Brand')
         self.mpd_product = Products.objects.using(mpd_db).create(
             name='Produkt do usunięcia',
             brand=brand,
+        )
+        self.mpd_variant = ProductVariants.objects.using(mpd_db).create(
+            product=self.mpd_product,
         )
 
         # Produkt Matterhorn z mapowaniem
@@ -82,6 +91,24 @@ class MPDDeletePropagatesToHurtownieTest(TestCase):
             mapped_product_uid=self.mpd_product.id,
         )
 
+        # Produkt Mada z mapowaniem (produkt + wariant)
+        MadaBrand.objects.using(mada_db).create(
+            producer_id='MADA_INT_BR',
+            name='Mada Brand',
+        )
+        self.mada_product = MadaProduct.objects.using(mada_db).create(
+            api_id=70001,
+            name='Mada Product',
+            mapped_product_uid=self.mpd_product.id,
+        )
+        self.mada_variant = MadaProductVariant.objects.using(mada_db).create(
+            product=self.mada_product,
+            variant_key='5900000000001',
+            ean='5900000000001',
+            mapped_variant_uid=self.mpd_variant.variant_id,
+            is_mapped=True,
+        )
+
     def test_delete_mpd_product_clears_matterhorn_mapping(self):
         """Usunięcie produktu MPD czyści mapped_product_uid w Matterhorn"""
         mpd_db = _mpd_db()
@@ -102,6 +129,19 @@ class MPDDeletePropagatesToHurtownieTest(TestCase):
 
         self.tabu_product.refresh_from_db(using=tabu_db)
         self.assertIsNone(self.tabu_product.mapped_product_uid)
+
+    def test_delete_mpd_product_clears_mada_mapping(self):
+        """Usunięcie produktu MPD czyści mapped_product_uid/mapped_variant_uid w Mada"""
+        mpd_db = _mpd_db()
+        mada_db = _mada_db()
+
+        self.mpd_product.delete(using=mpd_db)
+
+        self.mada_product.refresh_from_db(using=mada_db)
+        self.assertIsNone(self.mada_product.mapped_product_uid)
+        self.mada_variant.refresh_from_db(using=mada_db)
+        self.assertIsNone(self.mada_variant.mapped_variant_uid)
+        self.assertFalse(self.mada_variant.is_mapped)
 
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)

--- a/src/apps/mada/management/commands/cleanup_orphaned_mada_mapping.py
+++ b/src/apps/mada/management/commands/cleanup_orphaned_mada_mapping.py
@@ -1,0 +1,93 @@
+"""
+Czyści osierocone mapowania Mada -> MPD: rekordy, w ktorych mapped_product_uid
+lub mapped_variant_uid wskazuje na produkt/wariant MPD, ktory juz nie istnieje.
+
+Powod: sygnal post_delete na Products czyscil mapowanie tylko w Matterhorn i
+Tabu (patrz MPD/signals.py). Produkty MPD usuniete przed poprawka zostawily w
+Mada wpisy wskazujace na nieistniejace ID. Ta komenda to jednorazowe
+sprzatanie historii.
+
+Uzycie:
+  python manage.py cleanup_orphaned_mada_mapping --dry-run
+  python manage.py cleanup_orphaned_mada_mapping
+"""
+from django.core.management.base import BaseCommand
+
+from core.db_routers import _get_mada_db, _get_mpd_db
+from mada.models import MadaProduct, MadaProductVariant
+from MPD.models import Products, ProductVariants
+
+
+class Command(BaseCommand):
+    help = 'Czysci osierocone mapped_product_uid / mapped_variant_uid w Mada (produkt MPD juz nie istnieje).'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help='Tylko pokaz ile rekordow zostaloby wyczyszczonych, bez zapisu.',
+        )
+
+    def handle(self, *args, **options):
+        mada_db = _get_mada_db()
+        mpd_db = _get_mpd_db()
+        dry_run = options['dry_run']
+
+        # --- Produkty ---
+        mapped_product_uids = set(
+            MadaProduct.objects.using(mada_db)
+            .filter(mapped_product_uid__isnull=False)
+            .values_list('mapped_product_uid', flat=True)
+        )
+        existing_product_ids = set(
+            Products.objects.using(mpd_db)
+            .filter(id__in=mapped_product_uids)
+            .values_list('id', flat=True)
+        )
+        orphan_product_uids = mapped_product_uids - existing_product_ids
+        orphan_products_qs = MadaProduct.objects.using(mada_db).filter(
+            mapped_product_uid__in=orphan_product_uids
+        )
+        orphan_products_count = orphan_products_qs.count() if orphan_product_uids else 0
+
+        # --- Warianty ---
+        mapped_variant_uids = set(
+            MadaProductVariant.objects.using(mada_db)
+            .filter(mapped_variant_uid__isnull=False)
+            .values_list('mapped_variant_uid', flat=True)
+        )
+        existing_variant_ids = set(
+            ProductVariants.objects.using(mpd_db)
+            .filter(variant_id__in=mapped_variant_uids)
+            .values_list('variant_id', flat=True)
+        )
+        orphan_variant_uids = mapped_variant_uids - existing_variant_ids
+        orphan_variants_qs = MadaProductVariant.objects.using(mada_db).filter(
+            mapped_variant_uid__in=orphan_variant_uids
+        )
+        orphan_variants_count = orphan_variants_qs.count() if orphan_variant_uids else 0
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(
+                f'[dry-run] Osierocone produkty Mada: {orphan_products_count} '
+                f'(mapped_product_uid: {sorted(orphan_product_uids)})'
+            ))
+            self.stdout.write(self.style.WARNING(
+                f'[dry-run] Osierocone warianty Mada: {orphan_variants_count} '
+                f'(mapped_variant_uid: {sorted(orphan_variant_uids)})'
+            ))
+            return
+
+        if orphan_products_count == 0 and orphan_variants_count == 0:
+            self.stdout.write(self.style.SUCCESS('Brak osieroconych mapowan Mada.'))
+            return
+
+        if orphan_products_count:
+            updated = orphan_products_qs.update(mapped_product_uid=None)
+            self.stdout.write(self.style.SUCCESS(
+                f'Wyczyszczono mapped_product_uid w {updated} produktach Mada.'
+            ))
+        if orphan_variants_count:
+            updated = orphan_variants_qs.update(mapped_variant_uid=None, is_mapped=False)
+            self.stdout.write(self.style.SUCCESS(
+                f'Wyczyszczono mapped_variant_uid w {updated} wariantach Mada.'
+            ))


### PR DESCRIPTION
## Problem

Przy usuwaniu produktu w MPD `mapped_product_uid` (i `mapped_variant_uid` na wariantach) **nie był czyszczony w Mada** — zostawał osierocony, wskazując na nieistniejący już produkt MPD.

Sygnał `post_delete` na `Products` ([MPD/signals.py](src/apps/MPD/signals.py) `remove_mapping_in_matterhorn`) obsługiwał tylko Matterhorn (`product`/`productvariant`) i Tabu (`tabu_product_detail`/`tabu_product_variant`) — brakowało gałęzi dla Mada.

## Fix

- `_get_connections_db()` zwraca teraz też alias `mada`
- po bloku Tabu dodany analogiczny `UPDATE mada_product SET mapped_product_uid = NULL` + `UPDATE mada_product_variant SET mapped_variant_uid = NULL, is_mapped = FALSE WHERE mapped_variant_uid IN (…)` (na `variant_ids` złapanych w `pre_delete`)
- opakowane w `try/except` + `if mada_db in settings.DATABASES` (jak Tabu) — nie blokuje usuwania produktu

## Sprzątanie historii

`python manage.py cleanup_orphaned_mada_mapping [--dry-run]` — czyści wpisy Mada wskazujące na nieistniejące produkty/warianty MPD (pozostałość po usunięciach sprzed tej poprawki).

Uruchomione już na dev: wyczyszczono 1 produkt (→ MPD 1890) + 96 wariantów. Do puszczenia na prod po deployu.

## Testy

`MPDDeletePropagatesToHurtownieTest.test_delete_mpd_product_clears_mada_mapping` (produkt + wariant). Pełne `MPD` + `mada` → 244 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)