### PR TITLE
feat(tabu,mada): mapowanie do MPD per kolor hurtowni + fix 403 zdjęć Mada

### DIFF
--- a/src/apps/mada/admin.py
+++ b/src/apps/mada/admin.py
@@ -113,6 +113,11 @@ class MadaProductAdmin(RouterScopedQuerysetMixin, admin.ModelAdmin):
                 product.name, product.brand.name if product.brand else None,
                 mpd_db_alias=_get_mpd_db(),
             )
+            mpd_context['source_colors'] = sorted({
+                (c or '').strip()
+                for c in product.variants.values_list('color', flat=True)
+                if c and c.strip()
+            })
             extra_context.update(mpd_context)
         except MadaProduct.DoesNotExist:
             extra_context['is_mapped'] = False
@@ -138,6 +143,7 @@ class MadaProductAdmin(RouterScopedQuerysetMixin, admin.ModelAdmin):
             'main_color_id': request.POST.get('main_color_id'),
             'producer_color_name': request.POST.get('producer_color_name'),
             'producer_code': request.POST.get('producer_code'),
+            'source_color': request.POST.get('source_color'),
             'mpd_paths': request.POST.getlist('mpd_paths'),
             'mpd_attributes': request.POST.getlist('mpd_attributes'),
             'fabric_component': request.POST.getlist('fabric_component[]'),
@@ -196,6 +202,7 @@ class MadaProductAdmin(RouterScopedQuerysetMixin, admin.ModelAdmin):
                     size_category = row[0]
 
             producer_color_name = (request.POST.get('producer_color_name') or '').strip() or None
+            source_color = (request.POST.get('source_color') or '').strip() or None
             mapping_info = {}
             if size_category:
                 producer_code = request.POST.get('producer_code', '').strip() or None
@@ -209,6 +216,7 @@ class MadaProductAdmin(RouterScopedQuerysetMixin, admin.ModelAdmin):
                         producer_code=producer_code,
                         main_color_id=main_color_id,
                         producer_color_name=producer_color_name,
+                        source_color=source_color,
                     )
                     logger.info("Wynik dodawania wariantów Mada→MPD: %s", mapping_info)
                 except Exception as e:

--- a/src/apps/mada/services.py
+++ b/src/apps/mada/services.py
@@ -169,7 +169,16 @@ def _saga_create_mpd_mada(
         )
 
         product_price = mada_product.price or Decimal('0')
+        # Produkt Mada trzyma kilka kolorów pod jednym api_id (np. czarny + beżowy) —
+        # gdy formularz wskazał kolor hurtowni, mapujemy tylko warianty tego koloru
+        # (reszta kolorów = osobne mapowanie do osobnego produktu MPD).
+        source_color = _post('source_color').strip()
         variants = list(mada_product.variants.all())
+        if source_color:
+            variants = [
+                v for v in variants
+                if (v.color or '').strip().casefold() == source_color.casefold()
+            ]
         for v in variants:
             color_obj = main_color if main_color else None
             if not color_obj and v.color:
@@ -399,6 +408,7 @@ def create_mpd_variants_from_mada(
     producer_code: Optional[str] = None,
     main_color_id: Optional[int] = None,
     producer_color_name: Optional[str] = None,
+    source_color: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Tworzy/dopina warianty w MPD z wariantów Mada (wzór: create_mpd_variants_from_tabu).
@@ -426,8 +436,11 @@ def create_mpd_variants_from_mada(
     mada_variants = list(
         MadaProductVariant.objects.using(mada_db).filter(product_id=mada_product_id)
     )
+    if source_color and (source_color or '').strip():
+        wanted = source_color.strip().casefold()
+        mada_variants = [v for v in mada_variants if (v.color or '').strip().casefold() == wanted]
     if not mada_variants:
-        logger.warning("Brak wariantów Mada dla produktu %s", mada_product_id)
+        logger.warning("Brak wariantów Mada dla produktu %s (source_color=%r)", mada_product_id, source_color)
         return {"created_variants": 0, "variant_ids": []}
 
     color_id = None

--- a/src/apps/mada/templates/admin/mada/madaproduct/change_form.html
+++ b/src/apps/mada/templates/admin/mada/madaproduct/change_form.html
@@ -47,6 +47,7 @@
               <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 100px;">Główny kolor</th>
               <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 100px;">Kolor prod.</th>
               <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 80px;">Kod prod.</th>
+              <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 90px;">Kolor hurt.</th>
               <th style="text-align: center; border: 1px solid #ddd; padding: 6px; width: 90px;">Akcja</th>
             </tr>
           </thead>
@@ -75,6 +76,16 @@
               </td>
               <td style="border: 1px solid #ddd; padding: 4px;">
                 <input type="text" class="mada-producer-code-input" placeholder="Kod" style="width:100%; font-size:11px; padding:2px; border:1px solid #ccc; border-radius:3px;" />
+              </td>
+              <td style="border: 1px solid #ddd; padding: 4px;">
+                {% if source_colors %}
+                <select class="mada-source-color-select" style="width:100%; font-size:11px; padding:2px; border:1px solid #ccc; border-radius:3px;">
+                  <option value="">-- wszystkie --</option>
+                  {% for c in source_colors %}
+                  <option value="{{ c }}">{{ c }}</option>
+                  {% endfor %}
+                </select>
+                {% else %}<span style="color:#bbb">—</span>{% endif %}
               </td>
               <td style="border: 1px solid #ddd; padding: 4px; text-align: center;">
                 <button type="button" class="mada-assign-mpd-btn" data-mpd-id="{{ p.id }}" style="background: #007cba; color: white; border: none; padding: 4px 10px; border-radius: 3px; font-size: 11px; cursor: pointer; margin-right: 6px;">Przypisz</button>
@@ -136,6 +147,19 @@
             </select>
           </div>
         </div>
+
+        {% if source_colors %}
+        <div class="form-row">
+          <label for="source_color">Kolor hurtowni (Mada) do zmapowania:</label>
+          <select id="source_color" name="source_color">
+            <option value="">-- wszystkie warianty --</option>
+            {% for c in source_colors %}
+            <option value="{{ c }}">{{ c }}</option>
+            {% endfor %}
+          </select>
+          <small style="color:#777">Produkt Mada ma kilka kolorów — wybierz jeden; reszta = osobne mapowanie.</small>
+        </div>
+        {% endif %}
 
         <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; margin-bottom: 10px">
           <div class="form-row">
@@ -255,6 +279,8 @@ document.addEventListener('DOMContentLoaded', function() {
       formData.append('main_color_id', document.getElementById('main_color_id').value);
       formData.append('producer_color_name', document.getElementById('producer_color_name').value);
       formData.append('producer_code', document.getElementById('producer_code').value);
+      var srcColorEl = document.getElementById('source_color');
+      formData.append('source_color', srcColorEl ? srcColorEl.value : '');
       formData.append('series_name', document.getElementById('series_name').value);
       formData.append('unit_id', document.getElementById('unit_id').value);
       Array.from(document.getElementById('mpd_paths').selectedOptions).forEach(function(o) { formData.append('mpd_paths', o.value); });
@@ -304,6 +330,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var mainColorId = row ? (row.querySelector('.mada-main-color-select') && row.querySelector('.mada-main-color-select').value) || '' : '';
     var producerColorName = row ? (row.querySelector('.mada-producer-color-input') && row.querySelector('.mada-producer-color-input').value) || '' : '';
     var producerCode = row ? (row.querySelector('.mada-producer-code-input') && row.querySelector('.mada-producer-code-input').value) || '' : '';
+    var sourceColor = row ? (row.querySelector('.mada-source-color-select') && row.querySelector('.mada-source-color-select').value) || '' : '';
     var statusEl = document.getElementById('mada-mpd-status');
     if (statusEl) {
       statusEl.style.display = 'block';
@@ -312,7 +339,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     var csrf = getMadaCsrfToken();
     var assignUrl = '/admin/mada/madaproduct/assign-mapping/{{ original.id }}/' + mpdId + '/';
-    var body = 'csrfmiddlewaretoken=' + encodeURIComponent(csrf) + '&main_color_id=' + encodeURIComponent(mainColorId) + '&producer_color_name=' + encodeURIComponent(producerColorName) + '&producer_code=' + encodeURIComponent(producerCode);
+    var body = 'csrfmiddlewaretoken=' + encodeURIComponent(csrf) + '&main_color_id=' + encodeURIComponent(mainColorId) + '&producer_color_name=' + encodeURIComponent(producerColorName) + '&producer_code=' + encodeURIComponent(producerCode) + '&source_color=' + encodeURIComponent(sourceColor);
     fetch(assignUrl, {
       method: 'POST',
       headers: {

--- a/src/apps/mada/tests_saga.py
+++ b/src/apps/mada/tests_saga.py
@@ -80,6 +80,40 @@ class MadaSagaTest(TestCase):
         self.assertEqual([s.step_name for s in steps], ['create_mpd', 'update_mada_mapping'])
         self.assertTrue(all(s.status == 'completed' for s in steps))
 
+    def test_saga_maps_only_selected_source_color(self):
+        """Gdy form_data ma source_color, saga mapuje tylko warianty tego koloru Mada."""
+        mada_db = _mada_db()
+        mpd_db = _mpd_db()
+        from MPD.models import ProductVariants
+
+        # drugi kolor pod tym samym produktem Mada
+        MadaProductVariant.objects.using(mada_db).create(
+            product=self.mada_product,
+            variant_key='5901234567891',
+            size='M',
+            color='beżowy',
+            ean='5901234567891',
+            stock=3,
+        )
+
+        result = create_mpd_product_from_mada(
+            self.mada_product.pk, form_data={'source_color': 'Czerwony'},
+        )
+        self.assertTrue(result['success'], result.get('error_message'))
+
+        mpd_variants = list(
+            ProductVariants.objects.using(mpd_db)
+            .filter(product_id=result['mpd_product_id'])
+            .select_related('color')
+        )
+        # tylko wariant 'Czerwony', bez 'beżowy'
+        self.assertEqual(len(mpd_variants), 1)
+
+        self.mada_variant.refresh_from_db(using=mada_db)
+        self.assertIsNotNone(self.mada_variant.mapped_variant_uid)
+        bezowy = MadaProductVariant.objects.using(mada_db).get(variant_key='5901234567891')
+        self.assertIsNone(bezowy.mapped_variant_uid)
+
     def test_saga_compensation_when_step2_fails(self):
         mada_db = _mada_db()
         mpd_db = _mpd_db()

--- a/src/apps/matterhorn1/defs_db.py
+++ b/src/apps/matterhorn1/defs_db.py
@@ -9,6 +9,16 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Część hostów hurtowni (np. www.mada.pl) odrzuca żądania bez nagłówka
+# User-Agent zwracając HTTP 403 — przy pobieraniu zdjęć udajemy przeglądarkę.
+_IMAGE_DOWNLOAD_HEADERS = {
+    'User-Agent': (
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+        '(KHTML, like Gecko) Chrome/124.0 Safari/537.36'
+    ),
+    'Accept': 'image/avif,image/webp,image/png,image/jpeg,*/*;q=0.8',
+}
+
 # Załaduj zmienne środowiskowe
 load_dotenv('.env.dev')
 
@@ -164,7 +174,10 @@ def upload_image_to_bucket_and_get_url(image_path, product_id, producer_color_na
         if image_path.startswith(('http://', 'https://')):
             logger.info(f"Pobieranie pliku z URL: {image_path}")
             try:
-                response = requests.get(image_path, stream=True, timeout=30)
+                response = requests.get(
+                    image_path, stream=True, timeout=30,
+                    headers=_IMAGE_DOWNLOAD_HEADERS,
+                )
                 if response.status_code != 200:
                     logger.error(
                         f"Nie można pobrać pliku z URL: {image_path}. Status code: {response.status_code}")

--- a/src/apps/tabu/admin.py
+++ b/src/apps/tabu/admin.py
@@ -185,6 +185,11 @@ class TabuProductAdmin(admin.ModelAdmin):
                 product.name, product.brand.name if product.brand else None,
                 mpd_db_alias=_get_mpd_db(),
             )
+            mpd_context['source_colors'] = sorted({
+                (c or '').strip()
+                for c in product.api_variants.values_list('color', flat=True)
+                if c and c.strip()
+            })
             extra_context.update(mpd_context)
         except TabuProduct.DoesNotExist:
             extra_context['is_mapped'] = False
@@ -210,6 +215,7 @@ class TabuProductAdmin(admin.ModelAdmin):
             'main_color_id': request.POST.get('main_color_id'),
             'producer_color_name': request.POST.get('producer_color_name'),
             'producer_code': request.POST.get('producer_code'),
+            'source_color': request.POST.get('source_color'),
             'mpd_paths': request.POST.getlist('mpd_paths'),
             'mpd_attributes': request.POST.getlist('mpd_attributes'),
             'fabric_component': request.POST.getlist('fabric_component[]'),
@@ -269,6 +275,7 @@ class TabuProductAdmin(admin.ModelAdmin):
                     size_category = row[0]
 
             producer_color_name = (request.POST.get('producer_color_name') or '').strip() or None
+            source_color = (request.POST.get('source_color') or '').strip() or None
             mapping_info = {}
             if size_category:
                 producer_code = request.POST.get('producer_code', '').strip() or None
@@ -282,6 +289,7 @@ class TabuProductAdmin(admin.ModelAdmin):
                         producer_code=producer_code,
                         main_color_id=main_color_id,
                         producer_color_name=producer_color_name,
+                        source_color=source_color,
                     )
                     logger.info("Wynik dodawania wariantów Tabu→MPD: %s", mapping_info)
                 except Exception as e:

--- a/src/apps/tabu/services.py
+++ b/src/apps/tabu/services.py
@@ -157,7 +157,16 @@ def _saga_create_mpd_tabu(
             defaults={'type': 'api', 'location': 'https://b2b.tabu.com.pl'},
         )
 
+        # Produkt Tabu potrafi trzymać kilka kolorów pod jednym api_id — gdy formularz
+        # wskazał konkretny kolor hurtowni, mapujemy tylko warianty tego koloru
+        # (reszta kolorów = osobne mapowanie do osobnego produktu MPD).
+        source_color = _post('source_color').strip()
         variants = list(tabu_product.api_variants.all())
+        if source_color:
+            variants = [
+                v for v in variants
+                if (v.color or '').strip().casefold() == source_color.casefold()
+            ]
         for v in variants:
             color_obj = main_color if main_color else None
             if not color_obj and v.color:
@@ -403,6 +412,7 @@ def create_mpd_variants_from_tabu(
     producer_code: Optional[str] = None,
     main_color_id: Optional[int] = None,
     producer_color_name: Optional[str] = None,
+    source_color: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Tworzy/dopina warianty w MPD z wariantów Tabu (wzór: matterhorn1/saga_variants.create_mpd_variants).
@@ -430,8 +440,11 @@ def create_mpd_variants_from_tabu(
     tabu_variants = list(
         TabuProductVariant.objects.using(tabu_db).filter(product_id=tabu_product_id)
     )
+    if source_color and (source_color or '').strip():
+        wanted = source_color.strip().casefold()
+        tabu_variants = [v for v in tabu_variants if (v.color or '').strip().casefold() == wanted]
     if not tabu_variants:
-        logger.warning("Brak wariantów Tabu dla produktu %s", tabu_product_id)
+        logger.warning("Brak wariantów Tabu dla produktu %s (source_color=%r)", tabu_product_id, source_color)
         return {"created_variants": 0, "variant_ids": []}
 
     # Główny kolor: z formularza (main_color_id) albo z produktu MPD / Tabu

--- a/src/apps/tabu/templates/admin/tabu/tabuproduct/change_form.html
+++ b/src/apps/tabu/templates/admin/tabu/tabuproduct/change_form.html
@@ -63,6 +63,7 @@
               <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 100px;">Główny kolor</th>
               <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 100px;">Kolor prod.</th>
               <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 80px;">Kod prod.</th>
+              <th style="text-align: left; border: 1px solid #ddd; padding: 6px; width: 90px;">Kolor hurt.</th>
               <th style="text-align: center; border: 1px solid #ddd; padding: 6px; width: 90px;">Akcja</th>
             </tr>
           </thead>
@@ -91,6 +92,16 @@
               </td>
               <td style="border: 1px solid #ddd; padding: 4px;">
                 <input type="text" class="tabu-producer-code-input" placeholder="Kod" style="width:100%; font-size:11px; padding:2px; border:1px solid #ccc; border-radius:3px;" />
+              </td>
+              <td style="border: 1px solid #ddd; padding: 4px;">
+                {% if source_colors %}
+                <select class="tabu-source-color-select" style="width:100%; font-size:11px; padding:2px; border:1px solid #ccc; border-radius:3px;">
+                  <option value="">-- wszystkie --</option>
+                  {% for c in source_colors %}
+                  <option value="{{ c }}">{{ c }}</option>
+                  {% endfor %}
+                </select>
+                {% else %}<span style="color:#bbb">—</span>{% endif %}
               </td>
               <td style="border: 1px solid #ddd; padding: 4px; text-align: center;">
                 <button type="button" class="tabu-assign-mpd-btn" data-mpd-id="{{ p.id }}" style="background: #007cba; color: white; border: none; padding: 4px 10px; border-radius: 3px; font-size: 11px; cursor: pointer; margin-right: 6px;">Przypisz</button>
@@ -152,6 +163,19 @@
             </select>
           </div>
         </div>
+
+        {% if source_colors %}
+        <div class="form-row">
+          <label for="source_color">Kolor hurtowni (Tabu) do zmapowania:</label>
+          <select id="source_color" name="source_color">
+            <option value="">-- wszystkie warianty --</option>
+            {% for c in source_colors %}
+            <option value="{{ c }}">{{ c }}</option>
+            {% endfor %}
+          </select>
+          <small style="color:#777">Produkt Tabu ma kilka kolorów — wybierz jeden; reszta = osobne mapowanie.</small>
+        </div>
+        {% endif %}
 
         <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; margin-bottom: 10px">
           <div class="form-row">
@@ -271,6 +295,8 @@ document.addEventListener('DOMContentLoaded', function() {
       formData.append('main_color_id', document.getElementById('main_color_id').value);
       formData.append('producer_color_name', document.getElementById('producer_color_name').value);
       formData.append('producer_code', document.getElementById('producer_code').value);
+      var srcColorEl = document.getElementById('source_color');
+      formData.append('source_color', srcColorEl ? srcColorEl.value : '');
       formData.append('series_name', document.getElementById('series_name').value);
       formData.append('unit_id', document.getElementById('unit_id').value);
       Array.from(document.getElementById('mpd_paths').selectedOptions).forEach(function(o) { formData.append('mpd_paths', o.value); });
@@ -320,6 +346,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var mainColorId = row ? (row.querySelector('.tabu-main-color-select') && row.querySelector('.tabu-main-color-select').value) || '' : '';
     var producerColorName = row ? (row.querySelector('.tabu-producer-color-input') && row.querySelector('.tabu-producer-color-input').value) || '' : '';
     var producerCode = row ? (row.querySelector('.tabu-producer-code-input') && row.querySelector('.tabu-producer-code-input').value) || '' : '';
+    var sourceColor = row ? (row.querySelector('.tabu-source-color-select') && row.querySelector('.tabu-source-color-select').value) || '' : '';
     var statusEl = document.getElementById('tabu-mpd-status');
     if (statusEl) {
       statusEl.style.display = 'block';
@@ -328,7 +355,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     var csrf = getTabuCsrfToken();
     var assignUrl = '/admin/tabu/tabuproduct/assign-mapping/{{ original.id }}/' + mpdId + '/';
-    var body = 'csrfmiddlewaretoken=' + encodeURIComponent(csrf) + '&main_color_id=' + encodeURIComponent(mainColorId) + '&producer_color_name=' + encodeURIComponent(producerColorName) + '&producer_code=' + encodeURIComponent(producerCode);
+    var body = 'csrfmiddlewaretoken=' + encodeURIComponent(csrf) + '&main_color_id=' + encodeURIComponent(mainColorId) + '&producer_color_name=' + encodeURIComponent(producerColorName) + '&producer_code=' + encodeURIComponent(producerCode) + '&source_color=' + encodeURIComponent(sourceColor);
     fetch(assignUrl, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Problem 1 — wymieszane kolory

Produkt w **Tabu i Mada** trzyma kilka kolorów pod jednym `api_id` (np. Gorsenia K 422 Anya w Mada = 57 czarny + 50 beżowy). Mapowanie do MPD brało **wszystkie** warianty produktu hurtowni i wrzucało je pod jeden `main_color` / `producer_color` z formularza → beżowe EAN-y lądowały w „czarnym" produkcie MPD. Ten sam problem, przez który linkowanie po EAN zrobiliśmy „EAN-only".

### Fix

- `create_mpd_product_from_{tabu,mada}` + `create_mpd_variants_from_{tabu,mada}` — nowy parametr **`source_color`**. Gdy podany, przetwarzane są tylko warianty tego koloru hurtowni (`casefold` match). Bez niego — zachowanie jak dotąd (kompatybilne z `web_agent` automation, które woła z `form_data=None`).
- `admin.change_view` dokłada `source_colors` (distinct kolory wariantów produktu).
- `change_form.html`: dropdown **„Kolor hurtowni"** w formularzu „Utwórz nowy produkt" oraz w każdym wierszu tabeli sugerowanych produktów (ścieżka „Przypisz").

Workflow: jeden produkt Tabu/Mada → osobne mapowanie per kolor do osobnego produktu MPD (jak Matterhorn 150350 / 150351).

## Problem 2 — zdjęcia Mada „poszły bez"

`www.mada.pl` zwraca **HTTP 403** na pobranie obrazka bez nagłówka `User-Agent` (log: `Nie można pobrać pliku z URL: …mada.pl…. Status code: 403`). Sprawdzone: z UA przeglądarki → 200.

### Fix

`upload_image_to_bucket_and_get_url` (wspólny helper) wysyła teraz `User-Agent` + `Accept` — działa też dla pozostałych hurtowni.

## Testy

`mada.tests_saga` +1 (`test_saga_maps_only_selected_source_color`). `tabu` + `mada` → 57 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)