### PR TITLE
perf(mada): usuń N+1 na liście produktów w adminie

### DIFF
--- a/src/apps/mada/admin.py
+++ b/src/apps/mada/admin.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib import admin
 from django.db import connections
+from django.db.models import OuterRef, Subquery
 from django.http import JsonResponse
 from django.urls import path
 from django.utils.decorators import method_decorator
@@ -83,10 +84,23 @@ class MadaProductAdmin(RouterScopedQuerysetMixin, admin.ModelAdmin):
     ordering = ['-api_id']
     change_form_template = 'admin/mada/madaproduct/change_form.html'
 
+    def get_queryset(self, request):
+        first_image_subquery = (
+            MadaProductImage.objects.filter(product_id=OuterRef('pk'))
+            .order_by('order', 'api_image_id')
+            .values('image_url')[:1]
+        )
+        return (
+            super()
+            .get_queryset(request)
+            .select_related('brand', 'category')
+            .annotate(first_image_url=Subquery(first_image_subquery))
+        )
+
     def thumbnail(self, obj):
-        first_image = obj.images.order_by('order').first()
-        if first_image:
-            return render_product_thumbnail(first_image.image_url, fallback_host='mada.pl')
+        url = getattr(obj, 'first_image_url', None)
+        if url:
+            return render_product_thumbnail(url, fallback_host='mada.pl')
         return '-'
     thumbnail.short_description = 'Zdjęcie'
 


### PR DESCRIPTION
## Diagnoza

Wrażenie „wolnych stron" w adminie: **lista produktów Mada robiła ~267 zapytań SQL na 100 wierszy**:

| źródło | zapytań |
|---|---|
| `thumbnail()` → `obj.images.order_by('order').first()` per wiersz | 100 |
| FK `brand` bez `select_related` | 81 |
| FK `category` bez `select_related` | 81 |

Bazy dev są za tunelem SSH (~20–30 ms/zapytanie) — 267 sekwencyjnych round-tripów = **~3 s** na samo ładowanie listy.

## Fix

Wzór jak w `TabuProductAdmin` (który jest szybki):

```python
def get_queryset(self, request):
    first_image_subquery = MadaProductImage.objects.filter(
        product_id=OuterRef('pk')).order_by('order','api_image_id').values('image_url')[:1]
    return super().get_queryset(request).select_related('brand','category') \
        .annotate(first_image_url=Subquery(first_image_subquery))
```

`thumbnail()` czyta annotację zamiast osobnego zapytania.

**Wynik:** ~267 → ~20 zapytań, ~3.1 s → ~0.7 s (zmierzone lokalnie `Client` + `DEBUG`).

## Uwaga — czynnik systemowy

To nie jedyna przyczyna. Bazy dev chodzą po tunelu SSH; każde zapytanie to ~20–30 ms round-trip. Strona edycji produktu ze 107 wariantami-inline (~1,3 s) i inne cięższe widoki będą wolniejsze niż na prod, gdzie baza jest lokalnie przy aplikacji. Tu nie ma czego „naprawić" w kodzie — to setup dev.

Testy: `mada` + `tabu` → 58 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)