### PR TITLE
fix(mpd): warianty Mady dopinane podwójnie przy mapowaniu z Tabu

### DIFF
--- a/src/apps/MPD/management/commands/merge_duplicate_source.py
+++ b/src/apps/MPD/management/commands/merge_duplicate_source.py
@@ -1,0 +1,97 @@
+"""
+Scala zduplikowany rekord Sources w MPD do rekordu docelowego.
+
+Kontekst: przez zbyt luźne dopasowanie w rejestrze adapterów stary, pusty
+rekord Sources "MADA" łapał adapter "Mada API" i linkowanie po EAN dopinało
+warianty Mady podwójnie — raz pod źródłem "MADA", raz pod "Mada API".
+
+Komenda przenosi ProductvariantsSources / StockAndPrices ze źródła --from do
+--to (pomijając wiersze, dla których w --to już istnieje odpowiednik), a na
+końcu — jeśli po przeniesieniu źródło --from nie ma już żadnych powiązań —
+usuwa sam rekord Sources.
+
+Użycie:
+  python manage.py merge_duplicate_source --from "MADA" --to "Mada API" --dry-run
+  python manage.py merge_duplicate_source --from "MADA" --to "Mada API"
+"""
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from core.db_routers import _get_mpd_db
+from MPD.models import ProductvariantsSources, Sources, StockAndPrices
+
+
+class Command(BaseCommand):
+    help = 'Scala zduplikowany rekord Sources (--from) do docelowego (--to) w bazie MPD.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--from', dest='src_name', required=True, help='Nazwa źródła do zlania (usuwanego).')
+        parser.add_argument('--to', dest='dst_name', required=True, help='Nazwa źródła docelowego.')
+        parser.add_argument('--dry-run', action='store_true', help='Pokaż plan, nic nie zapisuj.')
+
+    def handle(self, *args, **options):
+        db = _get_mpd_db()
+        src_name, dst_name = options['src_name'], options['dst_name']
+        dry_run = options['dry_run']
+
+        src = Sources.objects.using(db).filter(name=src_name).first()
+        dst = Sources.objects.using(db).filter(name=dst_name).first()
+        if not src:
+            raise CommandError(f'Źródło {src_name!r} nie istnieje.')
+        if not dst:
+            raise CommandError(f'Źródło docelowe {dst_name!r} nie istnieje.')
+        if src.id == dst.id:
+            raise CommandError('--from i --to to ten sam rekord.')
+
+        dst_variant_ids = set(
+            ProductvariantsSources.objects.using(db)
+            .filter(source_id=dst.id).values_list('variant_id', flat=True)
+        )
+        dst_sap_variant_ids = set(
+            StockAndPrices.objects.using(db)
+            .filter(source_id=dst.id).values_list('variant_id', flat=True)
+        )
+
+        src_pvs = list(ProductvariantsSources.objects.using(db).filter(source_id=src.id))
+        src_sap = list(StockAndPrices.objects.using(db).filter(source_id=src.id))
+
+        pvs_move = [r for r in src_pvs if r.variant_id not in dst_variant_ids]
+        pvs_drop = [r for r in src_pvs if r.variant_id in dst_variant_ids]
+        sap_move = [r for r in src_sap if r.variant_id not in dst_sap_variant_ids]
+        sap_drop = [r for r in src_sap if r.variant_id in dst_sap_variant_ids]
+
+        self.stdout.write(
+            f'Źródło {src_name!r} (id={src.id}) → {dst_name!r} (id={dst.id})\n'
+            f'  PVS: {len(pvs_move)} do przeniesienia, {len(pvs_drop)} zdublowanych do usunięcia\n'
+            f'  StockAndPrices: {len(sap_move)} do przeniesienia, {len(sap_drop)} zdublowanych do usunięcia'
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('[dry-run] bez zapisu.'))
+            return
+
+        with transaction.atomic(using=db):
+            for r in pvs_move:
+                ProductvariantsSources.objects.using(db).filter(pk=r.pk).update(source_id=dst.id)
+            ProductvariantsSources.objects.using(db).filter(
+                pk__in=[r.pk for r in pvs_drop]
+            ).delete()
+            for r in sap_move:
+                StockAndPrices.objects.using(db).filter(pk=r.pk).update(source_id=dst.id)
+            StockAndPrices.objects.using(db).filter(
+                pk__in=[r.pk for r in sap_drop]
+            ).delete()
+
+            still_used = (
+                ProductvariantsSources.objects.using(db).filter(source_id=src.id).exists()
+                or StockAndPrices.objects.using(db).filter(source_id=src.id).exists()
+            )
+            if still_used:
+                self.stdout.write(self.style.WARNING(
+                    f'Źródło {src_name!r} nadal ma powiązania — rekordu Sources nie usuwam.'
+                ))
+            else:
+                Sources.objects.using(db).filter(pk=src.id).delete()
+                self.stdout.write(self.style.SUCCESS(f'Usunięto pusty rekord Sources {src_name!r}.'))
+
+        self.stdout.write(self.style.SUCCESS('Gotowe.'))

--- a/src/apps/MPD/source_adapters/registry.py
+++ b/src/apps/MPD/source_adapters/registry.py
@@ -40,9 +40,13 @@ def get_adapter_for_source(source_id: int) -> Optional[object]:
 
     try:
         source = Sources.objects.using(_get_mpd_db()).get(id=source_id)
-        name = (source.name or '').strip()
+        name = (source.name or '').strip().lower()
+        # Nazwa źródła MUSI zawierać zarejestrowaną nazwę adaptera (np. "Mada API",
+        # "Mada API PL"). Dawniej dopuszczano też odwrotność (name ⊂ reg_name), przez
+        # co stary, pusty rekord Sources "MADA" łapał adapter "Mada API" i linkowanie
+        # dopinało warianty Mady podwójnie (raz pod "MADA", raz pod "Mada API").
         for reg_name, adapter_class in _ADAPTER_REGISTRY.items():
-            if reg_name.lower() in name.lower() or name.lower() in reg_name.lower():
+            if reg_name.lower() in name:
                 adapter = adapter_class(source_id=source_id)
                 _ADAPTER_CACHE[source_id] = adapter
                 return adapter

--- a/src/apps/MPD/tests_integration.py
+++ b/src/apps/MPD/tests_integration.py
@@ -337,6 +337,39 @@ class VariantUidIntTest(TestCase):
         self.assertIsNone(_variant_uid_int(M(None)))
 
 
+class SourceAdapterRegistryMatchTest(TestCase):
+    """Nazwa źródła musi ZAWIERAĆ zarejestrowaną nazwę adaptera. Stary, pusty
+    rekord Sources 'MADA' nie może łapać adaptera 'Mada API' (to powodowało
+    podwójne dopinanie wariantów Mady)."""
+
+    databases = '__all__'
+
+    def setUp(self):
+        from MPD.source_adapters.registry import _ADAPTER_CACHE, register_default_adapters
+        register_default_adapters()
+        _ADAPTER_CACHE.clear()
+        self.addCleanup(_ADAPTER_CACHE.clear)
+
+    def test_short_stale_name_does_not_match_longer_adapter_name(self):
+        from MPD.source_adapters.registry import get_adapter_for_source
+        from MPD.source_adapters.mada import MadaAdapter
+
+        mpd_db = _mpd_db()
+        stale = Sources.objects.using(mpd_db).create(name='MADA', type='api')
+        proper = Sources.objects.using(mpd_db).create(name='Mada API', type='api')
+
+        self.assertIsNone(get_adapter_for_source(stale.id))
+        self.assertIsInstance(get_adapter_for_source(proper.id), MadaAdapter)
+
+    def test_suffixed_source_name_still_matches(self):
+        from MPD.source_adapters.registry import get_adapter_for_source
+        from MPD.source_adapters.mada import MadaAdapter
+
+        mpd_db = _mpd_db()
+        src = Sources.objects.using(mpd_db).create(name='Mada API PL', type='api')
+        self.assertIsInstance(get_adapter_for_source(src.id), MadaAdapter)
+
+
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class MPDProductImagesImportTest(TestCase):
     """Import galerii z hurtowni do „tacki" produktu MPD + dedup po origin_url."""


### PR DESCRIPTION
## Objaw

Po zmapowaniu produktu z Tabu (`mpd-create` dla Tabu 19513 → MPD 1897) warianty Mady „nie przypięły się" — a właściwie **przypięły się dwa razy**. MPD 1897 miał:

| źródło | PVS |
|---|---|
| Tabu API | 53 |
| **MADA** | **51** |
| **Mada API** | **51** |
| Matterhorn | 49 |

51 wariantów MPD miało po **dwa** wpisy `product_variants_sources` dla Mady (podwójny stan/cena).

## Przyczyna

W bazie MPD były **dwa** rekordy `Sources`: `MADA` (id 10, stary, pusty) i `Mada API` (id 11, właściwy). `get_adapter_for_source` dopasowywał adapter gdy:

```python
reg_name.lower() in name.lower() or name.lower() in reg_name.lower()
```

Druga gałąź (`name in reg_name`) sprawiała, że `"mada"` ⊂ `"mada api"` → stary rekord `MADA` też dostawał `MadaAdapter`, a `link_variants_from_other_sources` iteruje po **wszystkich** dopasowanych źródłach → każdy wariant Mady dopinany raz jako `MADA`, raz jako `Mada API`.

## Fix

1. **registry**: dopasowanie tylko jednokierunkowe — nazwa źródła MUSI zawierać zarejestrowaną nazwę adaptera (zgodnie z docstringiem `register_adapter`: „dodaj wpis Sources … nazwa zawierająca source_name"). `"Mada API PL"` nadal łapie, `"MADA"` już nie.
2. **komenda** `merge_duplicate_source --from "MADA" --to "Mada API" [--dry-run]` — przenosi PVS/StockAndPrices do właściwego źródła (pomijając duplikaty) i kasuje pusty rekord `Sources`.
3. **testy**: `SourceAdapterRegistryMatchTest`.

## Wykonane na dev

`merge_duplicate_source` scalił `MADA` → `Mada API`: 51 zdublowanych PVS + 51 SAP usuniętych, pusty rekord `Sources 'MADA'` skasowany. MPD 1897 teraz: Tabu 53 / Mada API 51 / Matterhorn 49. **Do puszczenia na prod po deployu** (jeśli tam też są zdublowane źródła — sprawdzić `SELECT id,name FROM sources`).

> Pozostałe 56 wariantów Mady produktu 1476 (50 beżowy + 6 czarny bez trafienia EAN) jest w panelu „orphaned" — to zachowanie zgodne z projektem (EAN-only).

Testy: `MPD.tests_integration` 16 OK, `mada`+`tabu` 58 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)