### PR TITLE
fix(MPD): owin narzedzia MCP w sync_to_async (SynchronousOnlyOperation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ __pycache__/
 .env
 .env.dev
 .env.prod
+# Config MCP Claude Code - lokalne, absolutne sciezki per-maszyna (np.
+# C:\Users\...\.venv\Scripts\python.exe), nie do wspoldzielenia w repo.
+.mcp.json
 .vscode/
 *.code-workspace
 .shotgun/

--- a/src/apps/MPD/management/commands/run_mcp_server.py
+++ b/src/apps/MPD/management/commands/run_mcp_server.py
@@ -4,15 +4,20 @@ MCP server (stdio) udostepniajacy katalog MPD DO ODCZYTU dla klientow MCP
 pliku - to jedyna warstwa ochrony przed przypadkowa modyfikacja danych przez
 narzedzie AI, wiec pilnowac tego przy kazdej zmianie.
 
-Funkcje tools sa zwyklymi funkcjami modulu (nieowiniete w @mcp.tool()) i
-rejestrowane recznie w handle() przez mcp.add_tool(fn) - dzieki temu da sie
-je testowac bezposrednio (tests_mcp_server.py) bez uruchamiania serwera MCP.
+Funkcje tools sa zwyklymi, SYNCHRONICZNYMI funkcjami modulu (nieowiniete w
+@mcp.tool()) - dzieki temu da sie je testowac bezposrednio
+(tests_mcp_server.py) bez uruchamiania serwera MCP. Do serwera trafiaja przez
+_add_sync_tool(), ktore owija je w async + sync_to_async (FastMCP wola sync
+tools wprost w petli asyncio, a Django ORM tego zabrania).
 
 Uzycie (lokalnie, bez Dockera - patrz docs/MCP_SERVER.md):
   .venv/Scripts/python.exe src/manage.py run_mcp_server --settings=core.settings.dev
 """
+import functools
+import inspect
 from decimal import Decimal
 
+from asgiref.sync import sync_to_async
 from django.core.management.base import BaseCommand
 
 from MPD.models import (
@@ -134,6 +139,20 @@ def list_categories() -> list[dict]:
     ]
 
 
+def _add_sync_tool(mcp, fn):
+    """FastMCP wola synchroniczne funkcje-narzedzia wprost w petli asyncio,
+    a Django ORM tego zabrania (SynchronousOnlyOperation). Owijamy wiec kazde
+    narzedzie w async + sync_to_async, zachowujac sygnature i docstring, zeby
+    FastMCP zbudowal poprawny schemat wejscia. Oryginalne funkcje zostaja
+    synchroniczne - tak sa testowane w tests_mcp_server.py."""
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        return await sync_to_async(fn, thread_sensitive=True)(*args, **kwargs)
+
+    wrapper.__signature__ = inspect.signature(fn)
+    mcp.add_tool(wrapper)
+
+
 class Command(BaseCommand):
     help = 'Uruchamia MCP server (stdio, read-only) udostepniajacy katalog MPD.'
     requires_system_checks = []
@@ -151,9 +170,7 @@ class Command(BaseCommand):
                 'list_categories do zobaczenia drzewa kategorii.'
             ),
         )
-        mcp.add_tool(search_products)
-        mcp.add_tool(get_product)
-        mcp.add_tool(get_stock_by_ean)
-        mcp.add_tool(list_categories)
+        for tool in (search_products, get_product, get_stock_by_ean, list_categories):
+            _add_sync_tool(mcp, tool)
 
         mcp.run(transport='stdio')

--- a/src/apps/MPD/tests_mcp_server.py
+++ b/src/apps/MPD/tests_mcp_server.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from django.test import TestCase
 
 from .management.commands.run_mcp_server import (
+    _add_sync_tool,
     get_product,
     get_stock_by_ean,
     list_categories,
@@ -137,3 +138,37 @@ class ListCategoriesTest(TestCase):
         names = {c['name']: c for c in categories}
         self.assertIsNone(names['Bielizna']['parent_id'])
         self.assertEqual(names['Biustonosze']['parent_id'], parent.id)
+
+
+class AddSyncToolTest(TestCase):
+    """FastMCP wola narzedzia wprost w petli asyncio - synchroniczne funkcje
+    uzywajace Django ORM (jak search_products/get_product) rzucaja tam
+    SynchronousOnlyOperation, jesli nie sa owiniete w sync_to_async.
+    _add_sync_tool to naprawia; te testy pilnuja zeby nie zniknelo przy
+    kolejnej zmianie."""
+    databases = {'default', 'MPD'}
+
+    def setUp(self):
+        Products.objects.using('MPD').create(name='Testowy Produkt MCP')
+
+    async def test_wrapped_tool_is_awaitable_and_returns_same_result(self):
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP('test-server')
+        _add_sync_tool(mcp, search_products)
+
+        tool = mcp._tool_manager.get_tool('search_products')
+        result = await tool.fn('Testowy')
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'Testowy Produkt MCP')
+
+    def test_wrapper_preserves_name_and_signature(self):
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP('test-server')
+        _add_sync_tool(mcp, get_stock_by_ean)
+
+        tool = mcp._tool_manager._tools['get_stock_by_ean']
+        self.assertEqual(tool.name, 'get_stock_by_ean')
+        self.assertIn('ean', tool.parameters['properties'])


### PR DESCRIPTION
FastMCP wola funkcje-narzedzia wprost w petli asyncio. Nieowiniete funkcje synchroniczne uzywajace Django ORM (search_products, get_product, get_stock_by_ean, list_categories) rzucaly SynchronousOnlyOperation przy realnym uzyciu z Claude Code - serwer startowal bez bledu (widac to bylo w manualnym tescie lokalnym), ale kazde wywolanie narzedzia z klienta MCP padalo.

_add_sync_tool(mcp, fn): owija kazda funkcje w async wrapper + sync_to_async(fn, thread_sensitive=True), zachowujac nazwe/sygnature (functools.wraps + __signature__) zeby FastMCP zbudowal poprawny schemat wejscia. Oryginalne funkcje zostaja proste i synchroniczne - tak sa testowane w tests_mcp_server.py (bez zmian w tych testach).

Dodano AddSyncToolTest - realnie potwierdza ze wrapper jest awaitable i zwraca te same dane co wywolanie bezposrednie (nie tylko sprawdza ze funkcje bazowe dzialaja, co juz bylo pokryte).

Zweryfikowane na zywo: search_products('ellen') + get_product(1840) przez faktyczne polaczenie MCP w Claude Code, zwrocily poprawne dane katalogu MPD. 451/451 pelnego regresu.

Dodatkowo: .mcp.json do .gitignore - lokalna konfiguracja Claude Code z absolutna sciezka do .venv per-maszyna, nie do commitowania.