### PR TITLE
feat(web_agent): ai pipeline przez openrouter + langchain fallback + …

### DIFF
--- a/docs/env.sample.md
+++ b/docs/env.sample.md
@@ -85,3 +85,22 @@ REDIS_DB=
 # CELERY_RESULT_BACKEND w env (pusta wartość jest OK).
 CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/${REDIS_DB}
 CELERY_RESULT_BACKEND=
+
+# AI (web_agent - wzbogacanie nazwy/opisu produktu przy automatyzacji)
+# USE_LANGCHAIN_AI=1 przelacza get_ai_processor() (ai_processor.py) na
+# LangChainAIProcessor: OpenRouter, primary moonshotai/kimi-k2-thinking ->
+# fallback openai/gpt-4o-mini przez LangChain .with_fallbacks(). Wymaga
+# OPENROUTER_API_KEY (NIE OPENAI_API_KEY - inny klucz, inny provider).
+# Bez USE_LANGCHAIN_AI=1 uzywany jest legacy AIProcessor (OPENAI_API_KEY
+# albo HF_TOKEN - patrz ai_processor.py).
+USE_LANGCHAIN_AI=
+OPENROUTER_API_KEY=
+OPENAI_API_KEY=
+HF_TOKEN=
+
+# LangSmith - tracing LangChain (ambient, samo ustawienie tych zmiennych
+# instrumentuje kazde ChatOpenAI.invoke() bez zmian w kodzie). Klucz z
+# smith.langchain.com. Dziala tylko razem z USE_LANGCHAIN_AI=1.
+LANGSMITH_TRACING=
+LANGSMITH_API_KEY=
+LANGSMITH_PROJECT=nc

--- a/docs/env.test.sample.md
+++ b/docs/env.test.sample.md
@@ -59,3 +59,14 @@ MINIO_SECRET_KEY=
 
 FLOWER_USER=admin
 FLOWER_PASSWORD=
+
+# AI (web_agent) - patrz env.sample.md dla opisu. Testy web_agent mockuja
+# wywolania LLM (tests_langchain_ai_processor.py) - te zmienne nie sa
+# wymagane, zeby testy przeszly, tylko dla realnego uruchomienia automatyzacji.
+USE_LANGCHAIN_AI=
+OPENROUTER_API_KEY=
+OPENAI_API_KEY=
+HF_TOKEN=
+LANGSMITH_TRACING=
+LANGSMITH_API_KEY=
+LANGSMITH_PROJECT=nc

--- a/src/apps/web_agent/automation/langchain_ai_processor.py
+++ b/src/apps/web_agent/automation/langchain_ai_processor.py
@@ -1,21 +1,46 @@
 """
-Procesor AI oparty na LangChain – ten sam interfejs co AIProcessor.
-Ustaw USE_LANGCHAIN_AI=1 (lub true/yes), aby z niego korzystać.
+Procesor AI: OpenRouter (moonshotai/kimi-k2-thinking -> openai/gpt-4o-mini
+fallback) przez LangChain, tracing przez LangSmith. Ten sam publiczny
+interfejs co AIProcessor (ai_processor.py) - wołany z tych samych miejsc
+(product_processor.py, background_automation.py, browser_automation.py,
+run_automation.py) bez zadnych zmian tam. Ustaw USE_LANGCHAIN_AI=1
+(get_ai_processor w ai_processor.py), zeby z niego korzystac.
+
+Routing = miedzy modelami (niezawodnosc), nie miedzy promptami - oba modele
+ida przez ten sam prompt/schemat. Fallback jest jawny po stronie LangChain
+(.with_fallbacks()), nie ukryty w OpenRouter-owym multi-model routingu -
+dzieki temu kazda proba (primary i fallback) jest osobnym spanem w
+LangSmith, widac osobno co i dlaczego padlo.
+
+Kontrola = dwa niezalezne mechanizmy, nie jeden zamiast drugiego:
+1. LangSmith (ambient) - samo LANGSMITH_TRACING=true + LANGSMITH_API_KEY w
+   .env.dev instrumentuje KAZDE wywolanie ChatOpenAI.invoke() bez zmian w
+   kodzie. Tu tylko doklejamy tags/metadata (config= w .invoke()), zeby
+   trace'y byly opisane, nie golym UUID.
+2. _CallLogCallback (ponizej) - lokalny, programistyczny zapis per-attempt
+   (ktory model probowal, sukces/blad, czas) NIEZALEZNY od LangSmith - zeby
+   processing_data w Django admin (ProductProcessingLog) mial te informacje
+   nawet bez otwierania LangSmith UI. pop_call_log() to eksponuje.
 """
 import logging
 import os
+import time
 from typing import Dict, List, Optional
 
+from langchain_core.callbacks import BaseCallbackHandler
 from pydantic import BaseModel, Field
 
 from .ai_processor import (
     ProductDescriptionStructure,
     ProductNameStructure,
-    get_product_config,
     is_figi_product,
 )
 
 logger = logging.getLogger(__name__)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_PRIMARY_MODEL = "moonshotai/kimi-k2-thinking"
+DEFAULT_FALLBACK_MODEL = "openai/gpt-4o-mini"
 
 
 class AttributesOutput(BaseModel):
@@ -27,44 +52,144 @@ class AttributesOutput(BaseModel):
     )
 
 
+def _get_prompt(name: str, **kwargs) -> Optional[str]:
+    """Pobiera aktywny prompt z bazy (AIPrompt, edytowalny w Django Admin) i
+    wypełnia zmienne. Ten sam wzorzec i te same nazwy promptów co
+    AIProcessor._get_prompt (ai_processor.py:333) - jedno źródło prawdy dla
+    obu procesorów, edycja w adminie działa niezależnie od tego, który jest
+    aktywny (USE_LANGCHAIN_AI)."""
+    try:
+        from web_agent.models import AIPrompt
+        prompt = AIPrompt.objects.filter(name=name, is_active=True).first()
+        if prompt:
+            return prompt.render(**kwargs)
+        logger.warning("Nie znaleziono aktywnego promptu: %s", name)
+        return None
+    except Exception as e:
+        logger.error("Błąd podczas pobierania promptu %s: %s", name, e)
+        return None
+
+
+class _CallLogCallback(BaseCallbackHandler):
+    """Lekki LangChain callback - zbiera per-attempt info (który model
+    faktycznie odpowiedział primary/fallback, sukces/błąd, bez polegania na
+    tym że .with_fallbacks() to gdziekolwiek wystawia w zwracanym wyniku)."""
+
+    def __init__(self):
+        super().__init__()
+        self.attempts: List[Dict] = []
+
+    def on_chat_model_start(self, serialized, messages, **kwargs):
+        params = kwargs.get("invocation_params") or {}
+        self.attempts.append({
+            "model": params.get("model", "unknown"),
+            "success": None,
+        })
+
+    def on_llm_end(self, response, **kwargs):
+        if self.attempts:
+            self.attempts[-1]["success"] = True
+
+    def on_llm_error(self, error, **kwargs):
+        if self.attempts:
+            self.attempts[-1]["success"] = False
+            self.attempts[-1]["error"] = str(error)
+
+
 class LangChainAIProcessor:
-    """Procesor AI z użyciem LangChain (ChatOpenAI + structured output)."""
+    """Procesor AI: OpenRouter, dwa modele (moonshotai/kimi-k2-thinking ->
+    openai/gpt-4o-mini) spięte przez LangChain .with_fallbacks(), tracing
+    przez LangSmith."""
 
     def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
-        api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY_NOVITA")
-        if not api_key:
+        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
+        if not self.api_key:
             raise ValueError(
-                "API key is required. Set OPENAI_API_KEY or OPENAI_API_KEY_NOVITA."
+                "API key is required. Ustaw OPENROUTER_API_KEY w .env.dev."
             )
-        self.api_key = api_key
-        self.model = model or os.getenv("LANGCHAIN_AI_MODEL", "gpt-4o-mini")
-        self._llm = None
-        self._llm_name_structured = None
-        self._llm_desc_structured = None
-        self._llm_attributes_structured = None
-        logger.info("LangChainAIProcessor zainicjalizowany (model=%s)", self.model)
+        self.primary_model = model or os.getenv(
+            "OPENAI_MODEL_PRODUCT_ENRICHMENT", DEFAULT_PRIMARY_MODEL)
+        self.fallback_model = os.getenv(
+            "LANGCHAIN_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL)
+        self._chains: Dict[str, object] = {}
+        self._call_log: List[Dict] = []
+        logger.info(
+            "LangChainAIProcessor zainicjalizowany (OpenRouter, primary=%s, fallback=%s)",
+            self.primary_model, self.fallback_model,
+        )
 
-    def _get_llm(self):
-        if self._llm is None:
-            from langchain_openai import ChatOpenAI
+    def pop_call_log(self) -> List[Dict]:
+        """Zwraca i czyści dotychczas zebrane wpisy (który model, sukces/błąd,
+        czas trwania) - wołane przez tasks.py po process_product_data(), żeby
+        dopisać do ProductProcessingLog.processing_data."""
+        log = self._call_log
+        self._call_log = []
+        return log
 
-            self._llm = ChatOpenAI(
-                api_key=self.api_key,
-                model=self.model,
-                temperature=0.7,
-                max_tokens=500,
+    def _get_llm(self, model: str):
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            base_url=OPENROUTER_BASE_URL,
+            api_key=self.api_key,
+            model=model,
+            temperature=0.7,
+            max_tokens=1500,
+            # primary (kimi-k2-thinking) jest modelem rozumujacym - bez tego co
+            # najmniej polowa max_tokens znika w niewidocznych reasoning_tokens,
+            # zanim model zdazy dokonczyc strukturyzowany JSON (zweryfikowane na
+            # prawdziwym wywolaniu OpenRouter: max_tokens=1500 -> 989 reasoning,
+            # max_tokens=4000 -> 2467 reasoning, oba razy "length limit was
+            # reached", opis nigdy nie kończył się na primary). OpenRouter-owy
+            # `reasoning.effort` przycina budzet rozumowania niezaleznie od
+            # max_tokens odpowiedzi - z "low" primary faktycznie konczy opis.
+            # Fallback (nie-rozumujacy model) po prostu ignoruje ten parametr.
+            extra_body={"reasoning": {"effort": "low"}},
+        )
+
+    def _get_chain(self, cache_key: str, pydantic_class=None):
+        """Chain primary->fallback (opcjonalnie ze strukturyzowanym wyjściem),
+        cache'owany per (schemat), żeby nie tworzyć nowego klienta HTTP przy
+        każdym wywołaniu."""
+        if cache_key not in self._chains:
+            primary = self._get_llm(self.primary_model)
+            fallback = self._get_llm(self.fallback_model)
+            if pydantic_class is not None:
+                primary = primary.with_structured_output(pydantic_class)
+                fallback = fallback.with_structured_output(pydantic_class)
+            self._chains[cache_key] = primary.with_fallbacks([fallback])
+        return self._chains[cache_key]
+
+    def _invoke(self, cache_key: str, system: str, user: str, *, tags: List[str],
+                pydantic_class=None):
+        """Woła chain (primary+fallback) z tagami dla LangSmith i własnym
+        callbackiem dla pop_call_log(). Zwraca wynik albo None przy błędzie
+        na obu modelach (zalogowane w _call_log jako success=False)."""
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        chain = self._get_chain(cache_key, pydantic_class)
+        call_log = _CallLogCallback()
+        started = time.monotonic()
+        try:
+            result = chain.invoke(
+                [SystemMessage(content=system), HumanMessage(content=user)],
+                config={
+                    "tags": ["web_agent", "product-enrichment", *tags],
+                    "callbacks": [call_log],
+                },
             )
-        return self._llm
-
-    def _get_llm_structured(self, pydantic_class):
-        cache_key = pydantic_class.__name__
-        cache = getattr(self, "_llm_structured_cache", None)
-        if cache is None:
-            self._llm_structured_cache = {}
-            cache = self._llm_structured_cache
-        if cache_key not in cache:
-            cache[cache_key] = self._get_llm().with_structured_output(pydantic_class)
-        return cache[cache_key]
+            return result
+        except Exception as e:
+            logger.error("LangChain invoke (%s) nieudane na obu modelach: %s", cache_key, e)
+            if not call_log.attempts or call_log.attempts[-1].get("success") is not False:
+                call_log.attempts.append(
+                    {"model": self.fallback_model, "success": False, "error": str(e)})
+            return None
+        finally:
+            duration_ms = round((time.monotonic() - started) * 1000)
+            for attempt in call_log.attempts:
+                attempt["duration_ms"] = duration_ms
+                attempt["operation"] = cache_key
+            self._call_log.extend(call_log.attempts)
 
     def enhance_product_name(
         self,
@@ -77,31 +202,36 @@ class LangChainAIProcessor:
         if not use_structured:
             return original_name
 
-        base_type = "Kostium kąpielowy"
         if product_config:
-            base_type = product_config.get("base_type", base_type)
+            base_type = product_config.get("base_type", "Kostium kąpielowy")
         else:
             base_type = "Figi kąpielowe" if is_figi_product(original_name) else "Kostium kąpielowy"
+        example_format = f"{base_type} [model_name]"
+        example_input = f"{base_type} Model Ada M-803 (1) Lilia - Marko"
+        example_output = f'{{"base_type": "{base_type}", "model_name": "Ada", "final_name": "{base_type} Ada"}}'
 
-        from langchain_core.messages import HumanMessage, SystemMessage
-
-        system = (
-            f"Jesteś ekspertem od nazewnictwa produktów tekstylnych. "
-            f"Przekształć nazwę w JSON: base_type (zawsze \"{base_type}\"), "
-            f"model_name (nazwa modelu 1-30 znaków), final_name (\"{base_type} [model_name]\", max 100 znaków). "
-            f"NIE dodawaj koloru, kodu (M-XXX), numerów w nawiasach, marki. Odpowiadaj tylko JSON zgodnym ze schematem."
+        system = _get_prompt(
+            "product_name_system", base_type=base_type,
+            example_format=example_format, example_input=example_input,
+            example_output=example_output,
+        ) or (
+            f'Jesteś ekspertem od nazewnictwa produktów tekstylnych. Przekształć nazwę '
+            f'w JSON: base_type (zawsze "{base_type}"), model_name (nazwa modelu 1-30 '
+            f'znaków), final_name ("{example_format}", max 100 znaków). NIE dodawaj '
+            f'koloru, kodu (M-XXX), numerów w nawiasach, marki. Tylko JSON.'
         )
-        user = f"Przekształć tę nazwę produktu w strukturę JSON:\n\n{original_name}"
+        user = _get_prompt("product_name_user", original_name=original_name) or (
+            f"Przekształć tę nazwę produktu w strukturę JSON:\n\n{original_name}"
+        )
 
-        try:
-            llm = self._get_llm_structured(ProductNameStructure)
-            msg = llm.invoke([SystemMessage(content=system), HumanMessage(content=user)])
-            if isinstance(msg, ProductNameStructure):
-                return msg.to_final_name()
-            return original_name
-        except Exception as e:
-            logger.error("LangChain enhance_product_name: %s", e)
-            raise
+        result = self._invoke(
+            "name", system, user, tags=["name"], pydantic_class=ProductNameStructure)
+        if isinstance(result, ProductNameStructure):
+            return result.to_final_name()
+        raise RuntimeError(
+            f"Nie udało się ulepszyć nazwy produktu ani przez {self.primary_model}, "
+            f"ani przez {self.fallback_model}"
+        )
 
     def enhance_product_description(
         self,
@@ -117,61 +247,79 @@ class LangChainAIProcessor:
 
         if not product_config:
             has_top = not (product_name and is_figi_product(product_name))
-            description_sections = (
-                ["Dół", "Wykończenie", "Pakowanie", "Wskazówka rozmiarowa"]
-                if not has_top
-                else ["Góra", "Dół", "Wykończenie", "Pakowanie", "Wskazówka rozmiarowa"]
-            )
         else:
             has_top = product_config.get("has_top", True)
-            description_sections = product_config.get(
-                "description_sections",
-                ["Góra", "Dół", "Wykończenie", "Pakowanie", "Wskazówka rozmiarowa"],
-            )
+        suffix = "" if has_top else "_figi"
 
-        from langchain_core.messages import HumanMessage, SystemMessage
-
-        system = (
-            "Jesteś ekspertem od copywritingu e-commerce (bielizna, kostiumy kąpielowe). "
-            "Przekształć opis na profesjonalny, sprzedażowy. "
-            "Sekcje: introduction (max 200 zn.), top_features (lista; dla fig pustą []), "
-            "bottom_features (lista, min 1), finishing (50-300 zn.), packaging (30-200 zn.), size_tip (30-200 zn.). "
-            "Odpowiedź wyłącznie w JSON zgodnym ze schematem."
-        )
         if not has_top:
-            system += " To są FIGI KĄPIELOWE – tylko dół. top_features = []."
-        user = f"Przekształć opis produktu na strukturyzowany format:\n\n{original_description}"
+            product_type_instruction = (
+                "To są FIGI KĄPIELOWE - produkt składa się TYLKO z dołu, NIE MA góry. "
+                "NIE generuj sekcji 'Góra'."
+            )
+            top_features_instruction = "top_features: NIE UŻYWAJ, ustaw jako pustą listę []."
+        else:
+            product_type_instruction = "To jest KOSTIUM KĄPIELOWY - góra (biustonosz) i dół (figi)."
+            top_features_instruction = (
+                "top_features: cechy góry, WYMAGANE MINIMUM 1, format "
+                '"cecha – opis korzyści", max 10, każda max 300 znaków.'
+            )
+        description_sections = (
+            ["Dół", "Wykończenie", "Pakowanie", "Wskazówka rozmiarowa"] if not has_top
+            else ["Góra", "Dół", "Wykończenie", "Pakowanie", "Wskazówka rozmiarowa"]
+        )
+        bottom_features_warning = (
+            "bottom_features MUSI zawierać przynajmniej 1 element."
+            if not has_top else
+            "top_features i bottom_features MUSZĄ zawierać przynajmniej 1 element."
+        )
 
-        try:
-            llm = self._get_llm_structured(ProductDescriptionStructure)
-            msg = llm.invoke([SystemMessage(content=system), HumanMessage(content=user)])
-            if isinstance(msg, ProductDescriptionStructure):
-                return msg.to_formatted_text()
-            return original_description
-        except Exception as e:
-            logger.error("LangChain enhance_product_description: %s", e)
-            return original_description
+        system = _get_prompt(
+            f"product_description_system{suffix}",
+            has_top=has_top,
+            product_type_instruction=product_type_instruction,
+            top_features_instruction=top_features_instruction,
+            description_sections=", ".join(f'"{s}"' for s in description_sections),
+            bottom_features_warning=bottom_features_warning,
+        ) or (
+            "Jesteś ekspertem od copywritingu e-commerce (bielizna, kostiumy kąpielowe). "
+            f"{product_type_instruction} Przekształć opis na profesjonalny, sprzedażowy. "
+            f"Sekcje: introduction (max 200 zn.), {top_features_instruction} "
+            "bottom_features (lista, min 1), finishing (50-300 zn.), packaging (30-200 zn.), "
+            f"size_tip (30-200 zn.). {bottom_features_warning} Tylko JSON."
+        )
+        user = _get_prompt(
+            f"product_description_user{suffix}",
+            original_description=original_description, has_top=has_top,
+        ) or f"Przekształć opis produktu na strukturyzowany format:\n\n{original_description}"
+
+        result = self._invoke(
+            "description", system, user, tags=["description"],
+            pydantic_class=ProductDescriptionStructure,
+        )
+        if isinstance(result, ProductDescriptionStructure):
+            return result.to_formatted_text()
+        logger.error(
+            "Nie udało się ulepszyć opisu ani przez %s, ani przez %s - zwracam oryginał",
+            self.primary_model, self.fallback_model,
+        )
+        return original_description
 
     def create_short_description(self, description: str, max_length: int = 250) -> str:
         if not description or not description.strip():
             return ""
 
-        from langchain_core.messages import HumanMessage, SystemMessage
-
         system = (
-            f"Jesteś ekspertem od krótkich opisów produktów. "
-            f"Twórz zwięzły, atrakcyjny opis tekstylny, max {max_length} znaków. Odpowiadaj tylko krótkim opisem."
+            f"Jesteś ekspertem od krótkich opisów produktów. Twórz zwięzły, "
+            f"atrakcyjny opis tekstylny, max {max_length} znaków. Odpowiadaj tylko krótkim opisem."
         )
         user = f"Krótki opis na podstawie:\n\n{description}"
 
-        try:
-            llm = self._get_llm()
-            out = llm.invoke([SystemMessage(content=system), HumanMessage(content=user)])
-            text = out.content.strip() if hasattr(out, "content") else str(out)
-            return (text[:max_length] if text else "") or description[:max_length]
-        except Exception as e:
-            logger.error("LangChain create_short_description: %s", e)
-            return description[:max_length] if description else ""
+        result = self._invoke("short_description", system, user, tags=["short-description"])
+        if result is not None:
+            text = result.content.strip() if hasattr(result, "content") else str(result).strip()
+            if text:
+                return text[:max_length]
+        return description[:max_length]
 
     def extract_attributes_from_description(
         self,
@@ -187,32 +335,56 @@ class LangChainAIProcessor:
         attrs_text = ", ".join(a["name"] for a in available_attributes)
         name_to_id = {a["name"].lower(): a["id"] for a in available_attributes}
 
-        from langchain_core.messages import HumanMessage, SystemMessage
-
-        system = (
+        system = _get_prompt("attributes_extraction_system") or (
             "Wyodrębnij z opisu produktu TYLKO atrybuty BEZPOŚREDNIO wspomniane. "
-            "Zwróć JSON: {\"attributes\": [\"nazwa1\", \"nazwa2\", ...]}. "
-            "Używaj dokładnie nazw z listy dostępnych. Nie myl przeciwnych (np. wysoki stan ≠ niski stan)."
+            'Zwróć JSON: {"attributes": ["nazwa1", "nazwa2", ...]}. '
+            "Używaj dokładnie nazw z listy dostępnych. Nie myl przeciwnych "
+            "(np. wysoki stan ≠ niski stan)."
         )
-        user = (
+        user = _get_prompt(
+            "attributes_extraction_user", description=description,
+            available_attrs_text=attrs_text,
+        ) or (
             f"Opis: {description}\n\nDostępne atrybuty: {attrs_text}\n\n"
             "Zwróć JSON z polem attributes (lista nazw wybranych atrybutów)."
         )
 
-        try:
-            llm = self._get_llm_structured(AttributesOutput)
-            msg = llm.invoke([SystemMessage(content=system), HumanMessage(content=user)])
-            if not isinstance(msg, AttributesOutput):
-                return []
-            ids = []
-            for name in msg.attributes:
-                n = (name or "").strip()
-                if not n:
-                    continue
-                aid = name_to_id.get(n.lower())
-                if aid is not None and aid not in ids:
-                    ids.append(aid)
-            return ids[:max_attributes]
-        except Exception as e:
-            logger.warning("LangChain extract_attributes: %s", e)
+        result = self._invoke(
+            "attributes", system, user, tags=["attributes"],
+            pydantic_class=AttributesOutput,
+        )
+        if not isinstance(result, AttributesOutput):
             return []
+
+        ids = []
+        for name in result.attributes:
+            n = (name or "").strip()
+            if not n:
+                continue
+            aid = name_to_id.get(n.lower())
+            if aid is not None and aid not in ids:
+                ids.append(aid)
+        return ids[:max_attributes]
+
+    def process_product_data(self, product_data: Dict) -> Dict:
+        """Przetwarza name/description/short_description produktu przez AI -
+        ten sam interfejs co AIProcessor.process_product_data
+        (ai_processor.py:2492)."""
+        logger.info(
+            "Przetwarzanie danych produktu przez AI (LangChain/OpenRouter): %s",
+            product_data.get("name", "Unknown"),
+        )
+        processed = product_data.copy()
+
+        if processed.get("name"):
+            processed["name"] = self.enhance_product_name(processed["name"])
+
+        if processed.get("description"):
+            processed["description"] = self.enhance_product_description(
+                processed["description"], product_name=processed.get("name"))
+
+        if not processed.get("short_description") and processed.get("description"):
+            processed["short_description"] = self.create_short_description(
+                processed["description"])
+
+        return processed

--- a/src/apps/web_agent/tasks.py
+++ b/src/apps/web_agent/tasks.py
@@ -169,18 +169,27 @@ def automate_mpd_form_filling(self, brand_id: int = None, category_id: int = Non
         
         admin_username = os.getenv('DJANGO_ADMIN_USERNAME', 'admin')
         admin_password = os.getenv('DJANGO_ADMIN_PASSWORD', '')
+        # USE_LANGCHAIN_AI=1 -> get_ai_processor() zwraca LangChainAIProcessor
+        # (OpenRouter, ai_processor.py:2533), ktory czyta OPENROUTER_API_KEY,
+        # nie OPENAI_API_KEY - wymagac i przekazac wlasciwy klucz do wlasciwej
+        # sciezki, zeby nie wyciekal klucz OpenAI do klienta OpenRouter.
+        use_langchain_ai = os.getenv('USE_LANGCHAIN_AI', '').lower() in ('1', 'true', 'yes')
         openai_api_key = os.getenv('OPENAI_API_KEY', '')
+        openrouter_api_key = os.getenv('OPENROUTER_API_KEY', '')
         headless = os.getenv('BROWSER_HEADLESS', 'False').lower() == 'true'
-        
+
         if not admin_username:
             raise ValueError("DJANGO_ADMIN_USERNAME nie jest ustawione w zmiennych środowiskowych")
-        
+
         if not admin_password:
             raise ValueError("DJANGO_ADMIN_PASSWORD nie jest ustawione w zmiennych środowiskowych")
-        
-        if not openai_api_key:
+
+        if use_langchain_ai:
+            if not openrouter_api_key:
+                raise ValueError("OPENROUTER_API_KEY nie jest ustawione w zmiennych środowiskowych")
+        elif not openai_api_key:
             raise ValueError("OPENAI_API_KEY nie jest ustawione w zmiennych środowiskowych")
-        
+
         # Inicjalizuj komponenty
         browser_automation = BrowserAutomation(
             base_url=base_url,
@@ -189,7 +198,9 @@ def automate_mpd_form_filling(self, brand_id: int = None, category_id: int = Non
             headless=headless
         )
         
-        ai_processor = get_ai_processor(api_key=openai_api_key)
+        ai_processor = get_ai_processor(
+            api_key=openrouter_api_key if use_langchain_ai else openai_api_key
+        )
         
         product_processor = ProductProcessor(
             browser_automation=browser_automation,
@@ -253,6 +264,11 @@ def automate_mpd_form_filling(self, brand_id: int = None, category_id: int = Non
                         product_log.error_message = result.get('error_message', 'Unknown error')
                         automation_run.products_failed += 1
                     
+                    # Podsumowanie wywolan AI (ktory model odpowiedzial - primary/
+                    # fallback, sukces/blad, czas) - patrz pop_call_log() w
+                    # LangChainAIProcessor. getattr z domyslnym no-op, zeby dzialalo
+                    # tez z legacy AIProcessor (bez tej metody).
+                    result['_ai_pipeline'] = getattr(ai_processor, 'pop_call_log', lambda: [])()
                     product_log.processing_data = result
                     product_log.save()
                     

--- a/src/apps/web_agent/tests_langchain_ai_processor.py
+++ b/src/apps/web_agent/tests_langchain_ai_processor.py
@@ -1,0 +1,262 @@
+"""
+Testy `LangChainAIProcessor` (OpenRouter + .with_fallbacks() + LangSmith,
+patrz automation/langchain_ai_processor.py). Zero prawdziwych wywolan
+HTTP/LangSmith - `_get_chain()` jest podmieniane na `_FakeChain`, ktora
+odtwarza dokladnie to, co widzialaby `_invoke()` od prawdziwego
+`primary.with_fallbacks([fallback])`: kolejne proby, wywolania callbacku
+(`_CallLogCallback`) per model, i albo wynik pierwszej udanej proby, albo
+ostatni wyjatek gdy wszystkie zawiedly.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+from pydantic import ValidationError
+
+from web_agent.automation.ai_processor import (
+    ProductDescriptionStructure,
+    ProductNameStructure,
+)
+from web_agent.automation.langchain_ai_processor import (
+    AttributesOutput,
+    LangChainAIProcessor,
+)
+
+
+class _FakeChain:
+    """Podmienia realny Runnable zwracany przez `_get_chain()`. `attempts`
+    to lista (model_name, wynik_albo_wyjatek) w kolejnosci prob -
+    dokladnie tak zachowuje sie `primary.with_fallbacks([fallback])`:
+    probuje po kolei, zwraca pierwszy sukces, albo rzuca ostatni wyjatek
+    gdy wszystkie zawiodly."""
+
+    def __init__(self, attempts):
+        self.attempts = attempts
+
+    def invoke(self, messages, config=None):
+        callbacks = (config or {}).get("callbacks") or []
+        last_exc = None
+        for model_name, outcome in self.attempts:
+            for cb in callbacks:
+                cb.on_chat_model_start(
+                    {}, [messages], invocation_params={"model": model_name})
+            if isinstance(outcome, Exception):
+                last_exc = outcome
+                for cb in callbacks:
+                    cb.on_llm_error(outcome)
+                continue
+            for cb in callbacks:
+                cb.on_llm_end(outcome)
+            return outcome
+        raise last_exc
+
+
+class _FakeMessage:
+    """Odpowiednik AIMessage zwracanego przez ChatOpenAI bez structured output
+    (create_short_description) - liczy się tylko `.content`."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+def _make_processor():
+    return LangChainAIProcessor(api_key="test-openrouter-key")
+
+
+class LangChainAIProcessorNameTest(TestCase):
+    def test_primary_success_fallback_unused(self):
+        proc = _make_processor()
+        expected = ProductNameStructure(
+            base_type="Kostium kąpielowy", model_name="Ada",
+            final_name="Kostium kąpielowy Ada")
+        chain = _FakeChain([(proc.primary_model, expected)])
+
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
+
+        self.assertEqual(result, "Kostium kąpielowy Ada")
+        log = proc.pop_call_log()
+        self.assertEqual(len(log), 1)
+        self.assertEqual(log[0]["model"], proc.primary_model)
+        self.assertTrue(log[0]["success"])
+
+    def test_primary_fails_fallback_takes_over(self):
+        proc = _make_processor()
+        expected = ProductNameStructure(
+            base_type="Figi kąpielowe", model_name="Lupo",
+            final_name="Figi kąpielowe Lupo")
+        chain = _FakeChain([
+            (proc.primary_model, RuntimeError("primary model niedostępny")),
+            (proc.fallback_model, expected),
+        ])
+
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.enhance_product_name("Figi kąpielowe Lupo M-120 - Marko")
+
+        self.assertEqual(result, "Figi kąpielowe Lupo")
+        log = proc.pop_call_log()
+        self.assertEqual(len(log), 2)
+        self.assertEqual(log[0]["model"], proc.primary_model)
+        self.assertFalse(log[0]["success"])
+        self.assertEqual(log[1]["model"], proc.fallback_model)
+        self.assertTrue(log[1]["success"])
+
+    def test_both_models_fail_raises(self):
+        proc = _make_processor()
+        chain = _FakeChain([
+            (proc.primary_model, RuntimeError("primary padł")),
+            (proc.fallback_model, RuntimeError("fallback też padł")),
+        ])
+
+        with patch.object(proc, "_get_chain", return_value=chain):
+            with self.assertRaises(RuntimeError):
+                proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
+
+        log = proc.pop_call_log()
+        self.assertEqual(len(log), 2)
+        self.assertFalse(log[0]["success"])
+        self.assertFalse(log[1]["success"])
+
+    def test_malformed_llm_output_rejected_by_pydantic_falls_back(self):
+        """Gdy primary zwraca cos co nie przejdzie walidacji schematu (to co
+        realnie robi .with_structured_output() gdy LLM zwroci zly JSON -
+        rzuca ValidationError), fallback ma szanse przejąć, tak samo jak przy
+        kazdym innym wyjatku primary."""
+        proc = _make_processor()
+        try:
+            ProductNameStructure(base_type="", model_name="", final_name="")
+        except ValidationError as exc:
+            malformed_error = exc
+        expected = ProductNameStructure(
+            base_type="Kostium kąpielowy", model_name="Ada",
+            final_name="Kostium kąpielowy Ada")
+        chain = _FakeChain([
+            (proc.primary_model, malformed_error),
+            (proc.fallback_model, expected),
+        ])
+
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
+
+        self.assertEqual(result, "Kostium kąpielowy Ada")
+        log = proc.pop_call_log()
+        self.assertFalse(log[0]["success"])
+        self.assertTrue(log[1]["success"])
+
+    def test_empty_name_raises_before_any_call(self):
+        proc = _make_processor()
+        with self.assertRaises(ValueError):
+            proc.enhance_product_name("   ")
+
+
+class LangChainAIProcessorDescriptionTest(TestCase):
+    def test_primary_success(self):
+        proc = _make_processor()
+        expected = ProductDescriptionStructure(
+            introduction="Elegancki kostium kąpielowy o klasycznym kroju i wysokiej jakości wykonaniu.",
+            top_features=["Miękkie fiszbiny – wygodne dopasowanie"],
+            bottom_features=["Regulowane boki – idealne dopasowanie"],
+            finishing="Wykończenie lamówką w tym samym kolorze, staranne szwy, elastyczny materiał.",
+            packaging="Produkt pakowany w ekologiczną torebkę z logo marki.",
+            size_tip="Zalecamy wybór rozmiaru zgodnego z tabelą rozmiarów producenta.",
+        )
+        chain = _FakeChain([(proc.primary_model, expected)])
+
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.enhance_product_description("Kostium kąpielowy, fiszbiny, regulowane boki")
+
+        self.assertIn("Regulowane boki", result)
+        self.assertTrue(proc.pop_call_log()[0]["success"])
+
+    def test_both_models_fail_returns_original_text(self):
+        proc = _make_processor()
+        chain = _FakeChain([
+            (proc.primary_model, RuntimeError("primary padł")),
+            (proc.fallback_model, RuntimeError("fallback też padł")),
+        ])
+        original = "Oryginalny, niezmieniony opis produktu."
+
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.enhance_product_description(original)
+
+        self.assertEqual(result, original)
+        log = proc.pop_call_log()
+        self.assertEqual(len(log), 2)
+        self.assertFalse(log[0]["success"])
+        self.assertFalse(log[1]["success"])
+
+    def test_empty_description_returns_empty_without_calling_model(self):
+        proc = _make_processor()
+        with patch.object(proc, "_get_chain") as get_chain:
+            result = proc.enhance_product_description("")
+        self.assertEqual(result, "")
+        get_chain.assert_not_called()
+
+
+class LangChainAIProcessorShortDescriptionAndAttributesTest(TestCase):
+    def test_create_short_description_truncates(self):
+        proc = _make_processor()
+        chain = _FakeChain([
+            (proc.primary_model, _FakeMessage("x" * 300)),
+        ])
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.create_short_description("opis bazowy", max_length=250)
+        self.assertEqual(len(result), 250)
+
+    def test_create_short_description_both_fail_truncates_original(self):
+        proc = _make_processor()
+        chain = _FakeChain([
+            (proc.primary_model, RuntimeError("padł")),
+            (proc.fallback_model, RuntimeError("padł")),
+        ])
+        original = "y" * 300
+        with patch.object(proc, "_get_chain", return_value=chain):
+            result = proc.create_short_description(original, max_length=250)
+        self.assertEqual(result, original[:250])
+
+    def test_extract_attributes_maps_names_to_ids(self):
+        proc = _make_processor()
+        available = [
+            {"id": 1, "name": "Wysoki stan"},
+            {"id": 2, "name": "Niski stan"},
+            {"id": 3, "name": "Push-up"},
+        ]
+        chain = _FakeChain([
+            (proc.primary_model, AttributesOutput(attributes=["Wysoki stan", "Push-Up", "Nieznany"])),
+        ])
+        with patch.object(proc, "_get_chain", return_value=chain):
+            ids = proc.extract_attributes_from_description("opis", available)
+        self.assertEqual(ids, [1, 3])
+
+    def test_extract_attributes_both_fail_returns_empty_list(self):
+        proc = _make_processor()
+        available = [{"id": 1, "name": "Wysoki stan"}]
+        chain = _FakeChain([
+            (proc.primary_model, RuntimeError("padł")),
+            (proc.fallback_model, RuntimeError("padł")),
+        ])
+        with patch.object(proc, "_get_chain", return_value=chain):
+            ids = proc.extract_attributes_from_description("opis", available)
+        self.assertEqual(ids, [])
+
+
+class LangChainAIProcessorInitTest(TestCase):
+    def test_requires_api_key(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("OPENROUTER_API_KEY", None)
+            with self.assertRaises(ValueError):
+                LangChainAIProcessor()
+
+    def test_default_models(self):
+        proc = LangChainAIProcessor(api_key="test-key")
+        self.assertTrue(proc.primary_model)
+        self.assertTrue(proc.fallback_model)
+        self.assertNotEqual(proc.primary_model, proc.fallback_model)
+
+    def test_pop_call_log_clears_state(self):
+        proc = _make_processor()
+        proc._call_log.append({"model": "x", "success": True})
+        first = proc.pop_call_log()
+        second = proc.pop_call_log()
+        self.assertEqual(len(first), 1)
+        self.assertEqual(second, [])

--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -114,3 +114,4 @@ whitenoise==6.12.0
 wsproto==1.2.0
 langchain-openai==1.1.14
 langchain-core>=1.2.31,<2.0.0
+langsmith==0.11.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -114,3 +114,4 @@ whitenoise==6.12.0
 wsproto==1.2.0
 langchain-openai==1.1.14
 langchain-core>=1.2.31,<2.0.0
+langsmith==0.11.1


### PR DESCRIPTION
…langsmith

Przepisany LangChainAIProcessor (automation/langchain_ai_processor.py), wlaczany flaga USE_LANGCHAIN_AI=1 (bez zmian w product_processor.py, background_automation.py, browser_automation.py, run_automation.py - ten sam publiczny interfejs co dotychczas). Faza 0 z docs/AI_STACK_PLAN.md (#195) - domkniecie WIP.

- Routing miedzy modelami (niezawodnosc) przez OpenRouter: primary moonshotai/kimi-k2-thinking -> fallback openai/gpt-4o-mini, jawnie spiete przez LangChain .with_fallbacks() (nie ukryty routing OpenRoutera)
  - kazda proba osobnym spanem w LangSmith.
- Kontrola: LangSmith (pelny tracing, ambient przez LANGSMITH_TRACING/ LANGSMITH_API_KEY) + lokalny _CallLogCallback/pop_call_log() zapisywany do ProductProcessingLog.processing_data (tasks.py) niezaleznie od LangSmith.
- Prompty nadal z AIPrompt (DB, edytowalne w adminie) - jedno zrodlo prawdy z legacy AIProcessor, nie hardkodowane jak w starej wersji pliku.
- Zweryfikowane na prawdziwych wywolaniach OpenRouter: kimi-k2-thinking jako model rozumujacy zjadal budzet max_tokens na niewidoczne reasoning_tokens i nigdy nie konczyl strukturyzowanego opisu (zawsze fallback) - naprawione przez extra_body={"reasoning": {"effort": "low"}} (OpenRouterowy limit budzetu rozumowania, niezalezny od max_tokens odpowiedzi); po fixie primary faktycznie odpowiada.
- tasks.py: automate_mpd_form_filling wymaga OPENROUTER_API_KEY zamiast OPENAI_API_KEY gdy USE_LANGCHAIN_AI=1 (wczesniej blednie wymagal/ przekazywal klucz OpenAI do klienta OpenRouter).
- docs/env.sample.md, docs/env.test.sample.md: dopisane USE_LANGCHAIN_AI, OPENROUTER_API_KEY, LANGSMITH_* (bez wartosci).
- Nowe testy (tests_langchain_ai_processor.py): primary sukces, primary pada->fallback przejmuje (widoczne w pop_call_log), oba padaja (opis->oryginal niezmieniony, nazwa->wyjatek), zle dane z LLM odrzucone przez walidacje Pydantic.
- Jawny pin langsmith==0.11.1 w requirements(.ci).txt (dotad tranzytywna zaleznosc przez langchain-core).

Weryfikacja: 15/15 nowych testow, 62/62 web_agent, 466/466 pelny regres (MPD matterhorn1 tabu mada web_agent prestashop). Reczny test na prawdziwym produkcie z realnym OPENROUTER_API_KEY - primary odpowiada na name/description/short_description, wymuszony blad primary (zly model) potwierdza realne przejecie przez fallback (widoczne w LangSmith i w zwroconym podsumowaniu).

Co nie weszlo w ten PR (poza zakresem, zaflagowane): DB-owy prompt product_name_system konsekwentnie pada na AIPrompt.render()/.format() (przechwycone, cichy fallback na hardkodowany prompt, dziala tak samo w legacy AIProcessor) - do naprawy osobno w tresci promptu w adminie.