### PR TITLE
fix(web_agent): popraw liczenie sukcesu/porazki fallbacku AI po niezaleznym review

### DIFF
--- a/src/apps/web_agent/automation/langchain_ai_processor.py
+++ b/src/apps/web_agent/automation/langchain_ai_processor.py
@@ -7,18 +7,26 @@ run_automation.py) bez zadnych zmian tam. Ustaw USE_LANGCHAIN_AI=1
 (get_ai_processor w ai_processor.py), zeby z niego korzystac.
 
 Routing = miedzy modelami (niezawodnosc), nie miedzy promptami - oba modele
-ida przez ten sam prompt/schemat. Fallback jest jawny po stronie LangChain
-(.with_fallbacks()), nie ukryty w OpenRouter-owym multi-model routingu -
-dzieki temu kazda proba (primary i fallback) jest osobnym spanem w
-LangSmith, widac osobno co i dlaczego padlo.
+ida przez ten sam prompt/schemat. Fallback to JAWNA petla primary->fallback
+w _invoke() (nie LangChainowe .with_fallbacks()) - kazda proba to osobny
+.invoke(), wiec kazda i tak jest osobnym spanem w LangSmith (dodatkowo
+otagowanym nazwa modelu), ale sukces/blad kazdej proby liczymy z PRAWDZIWEGO
+wyniku TEGO wywolania (try/except), a nie z LLM-owych callbackow. To celowe:
+.with_structured_output() to w rzeczywistosci DWA kroki (LLM, potem parser
+Pydantic) - .with_fallbacks() + callback na poziomie LLM widzi tylko
+pierwszy krok i potrafi zaraportowac model jako "sukces", mimo ze jego JSON
+zostal odrzucony przez walidacje Pydantic (@field_validator w
+ProductNameStructure/ProductDescriptionStructure) i wyrzucony na rzecz
+fallbacku - reczna petla z try/except wokol calego chain.invoke() (LLM +
+parser) tego nie ma, bo widzi realny wynik, nie tylko polowe.
 
 Kontrola = dwa niezalezne mechanizmy, nie jeden zamiast drugiego:
 1. LangSmith (ambient) - samo LANGSMITH_TRACING=true + LANGSMITH_API_KEY w
    .env.dev instrumentuje KAZDE wywolanie ChatOpenAI.invoke() bez zmian w
    kodzie. Tu tylko doklejamy tags/metadata (config= w .invoke()), zeby
    trace'y byly opisane, nie golym UUID.
-2. _CallLogCallback (ponizej) - lokalny, programistyczny zapis per-attempt
-   (ktory model probowal, sukces/blad, czas) NIEZALEZNY od LangSmith - zeby
+2. Lokalny, programistyczny zapis per-attempt w _invoke() (ktory model
+   probowal, sukces/blad, czas) NIEZALEZNY od LangSmith - zeby
    processing_data w Django admin (ProductProcessingLog) mial te informacje
    nawet bez otwierania LangSmith UI. pop_call_log() to eksponuje.
 """
@@ -27,7 +35,6 @@ import os
 import time
 from typing import Dict, List, Optional
 
-from langchain_core.callbacks import BaseCallbackHandler
 from pydantic import BaseModel, Field
 
 from .ai_processor import (
@@ -70,36 +77,10 @@ def _get_prompt(name: str, **kwargs) -> Optional[str]:
         return None
 
 
-class _CallLogCallback(BaseCallbackHandler):
-    """Lekki LangChain callback - zbiera per-attempt info (który model
-    faktycznie odpowiedział primary/fallback, sukces/błąd, bez polegania na
-    tym że .with_fallbacks() to gdziekolwiek wystawia w zwracanym wyniku)."""
-
-    def __init__(self):
-        super().__init__()
-        self.attempts: List[Dict] = []
-
-    def on_chat_model_start(self, serialized, messages, **kwargs):
-        params = kwargs.get("invocation_params") or {}
-        self.attempts.append({
-            "model": params.get("model", "unknown"),
-            "success": None,
-        })
-
-    def on_llm_end(self, response, **kwargs):
-        if self.attempts:
-            self.attempts[-1]["success"] = True
-
-    def on_llm_error(self, error, **kwargs):
-        if self.attempts:
-            self.attempts[-1]["success"] = False
-            self.attempts[-1]["error"] = str(error)
-
-
 class LangChainAIProcessor:
     """Procesor AI: OpenRouter, dwa modele (moonshotai/kimi-k2-thinking ->
-    openai/gpt-4o-mini) spięte przez LangChain .with_fallbacks(), tracing
-    przez LangSmith."""
+    openai/gpt-4o-mini), reczny fallback (petla try/except w _invoke() -
+    patrz docstring modulu), tracing przez LangSmith."""
 
     def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
         self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
@@ -111,7 +92,7 @@ class LangChainAIProcessor:
             "OPENAI_MODEL_PRODUCT_ENRICHMENT", DEFAULT_PRIMARY_MODEL)
         self.fallback_model = os.getenv(
             "LANGCHAIN_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL)
-        self._chains: Dict[str, object] = {}
+        self._chains: Dict[tuple, object] = {}
         self._call_log: List[Dict] = []
         logger.info(
             "LangChainAIProcessor zainicjalizowany (OpenRouter, primary=%s, fallback=%s)",
@@ -146,50 +127,56 @@ class LangChainAIProcessor:
             extra_body={"reasoning": {"effort": "low"}},
         )
 
-    def _get_chain(self, cache_key: str, pydantic_class=None):
-        """Chain primary->fallback (opcjonalnie ze strukturyzowanym wyjściem),
-        cache'owany per (schemat), żeby nie tworzyć nowego klienta HTTP przy
-        każdym wywołaniu."""
-        if cache_key not in self._chains:
-            primary = self._get_llm(self.primary_model)
-            fallback = self._get_llm(self.fallback_model)
+    def _get_model_chain(self, model: str, cache_key: str, pydantic_class=None):
+        """Chain dla POJEDYNCZEGO modelu (opcjonalnie ze strukturyzowanym
+        wyjściem), cache'owany per (model, operacja), żeby nie tworzyć
+        nowego klienta HTTP przy każdym wywołaniu. Fallback między modelami
+        to pętla w _invoke() (nie .with_fallbacks()) - patrz docstring
+        modułu, dlaczego."""
+        key = (model, cache_key)
+        if key not in self._chains:
+            llm = self._get_llm(model)
             if pydantic_class is not None:
-                primary = primary.with_structured_output(pydantic_class)
-                fallback = fallback.with_structured_output(pydantic_class)
-            self._chains[cache_key] = primary.with_fallbacks([fallback])
-        return self._chains[cache_key]
+                llm = llm.with_structured_output(pydantic_class)
+            self._chains[key] = llm
+        return self._chains[key]
 
     def _invoke(self, cache_key: str, system: str, user: str, *, tags: List[str],
                 pydantic_class=None):
-        """Woła chain (primary+fallback) z tagami dla LangSmith i własnym
-        callbackiem dla pop_call_log(). Zwraca wynik albo None przy błędzie
-        na obu modelach (zalogowane w _call_log jako success=False)."""
+        """Próbuje primary, potem fallback - osobny chain.invoke() na próbę
+        (osobny span w LangSmith, otagowany nazwą modelu), sukces/błąd
+        każdej próby liczony z jej PRAWDZIWEGO wyniku (try/except wokół
+        całego invoke - LLM + parser Pydantic), nie z LLM-owych callbacków
+        (patrz docstring modułu). Zwraca wynik pierwszej udanej próby albo
+        None gdy obie zawiodły (obie zalogowane w _call_log)."""
         from langchain_core.messages import HumanMessage, SystemMessage
 
-        chain = self._get_chain(cache_key, pydantic_class)
-        call_log = _CallLogCallback()
-        started = time.monotonic()
-        try:
-            result = chain.invoke(
-                [SystemMessage(content=system), HumanMessage(content=user)],
-                config={
-                    "tags": ["web_agent", "product-enrichment", *tags],
-                    "callbacks": [call_log],
-                },
-            )
-            return result
-        except Exception as e:
-            logger.error("LangChain invoke (%s) nieudane na obu modelach: %s", cache_key, e)
-            if not call_log.attempts or call_log.attempts[-1].get("success") is not False:
-                call_log.attempts.append(
-                    {"model": self.fallback_model, "success": False, "error": str(e)})
-            return None
-        finally:
-            duration_ms = round((time.monotonic() - started) * 1000)
-            for attempt in call_log.attempts:
-                attempt["duration_ms"] = duration_ms
-                attempt["operation"] = cache_key
-            self._call_log.extend(call_log.attempts)
+        messages = [SystemMessage(content=system), HumanMessage(content=user)]
+        attempts: List[Dict] = []
+        result = None
+        for model in (self.primary_model, self.fallback_model):
+            started = time.monotonic()
+            try:
+                chain = self._get_model_chain(model, cache_key, pydantic_class)
+                result = chain.invoke(
+                    messages,
+                    config={"tags": ["web_agent", "product-enrichment", *tags, model]},
+                )
+                attempts.append({
+                    "model": model, "success": True,
+                    "duration_ms": round((time.monotonic() - started) * 1000),
+                    "operation": cache_key,
+                })
+                break
+            except Exception as e:
+                logger.error("LangChain invoke (%s) %s nieudane: %s", cache_key, model, e)
+                attempts.append({
+                    "model": model, "success": False, "error": str(e),
+                    "duration_ms": round((time.monotonic() - started) * 1000),
+                    "operation": cache_key,
+                })
+        self._call_log.extend(attempts)
+        return result
 
     def enhance_product_name(
         self,

--- a/src/apps/web_agent/tests_langchain_ai_processor.py
+++ b/src/apps/web_agent/tests_langchain_ai_processor.py
@@ -1,11 +1,12 @@
 """
-Testy `LangChainAIProcessor` (OpenRouter + .with_fallbacks() + LangSmith,
-patrz automation/langchain_ai_processor.py). Zero prawdziwych wywolan
-HTTP/LangSmith - `_get_chain()` jest podmieniane na `_FakeChain`, ktora
-odtwarza dokladnie to, co widzialaby `_invoke()` od prawdziwego
-`primary.with_fallbacks([fallback])`: kolejne proby, wywolania callbacku
-(`_CallLogCallback`) per model, i albo wynik pierwszej udanej proby, albo
-ostatni wyjatek gdy wszystkie zawiedly.
+Testy `LangChainAIProcessor` (OpenRouter + reczny fallback primary->fallback
++ LangSmith, patrz automation/langchain_ai_processor.py). Zero prawdziwych
+wywolan HTTP/LangSmith - `_get_model_chain()` jest podmieniane, zeby kazdy
+model (primary/fallback) mial wlasny, niezalezny fake `.invoke()`: albo
+zwraca wynik, albo rzuca wyjatek - dokladnie tak jak _invoke() to konsumuje
+(try/except wokol calego chain.invoke() per model, sukces/blad z
+PRAWDZIWEGO wyniku tej proby, nie z LLM-owych callbackow - patrz docstring
+modulu o tym, dlaczego to wazne dla walidacji Pydantic).
 """
 from unittest.mock import patch
 
@@ -22,32 +23,31 @@ from web_agent.automation.langchain_ai_processor import (
 )
 
 
-class _FakeChain:
-    """Podmienia realny Runnable zwracany przez `_get_chain()`. `attempts`
-    to lista (model_name, wynik_albo_wyjatek) w kolejnosci prob -
-    dokladnie tak zachowuje sie `primary.with_fallbacks([fallback])`:
-    probuje po kolei, zwraca pierwszy sukces, albo rzuca ostatni wyjatek
-    gdy wszystkie zawiodly."""
+class _FakeSingleChain:
+    """Odpowiednik chaina zwracanego przez _get_model_chain() dla JEDNEGO
+    modelu - jeden fake `.invoke()`, albo zwraca `outcome`, albo (gdy
+    `outcome` jest wyjatkiem - w tym pydantic.ValidationError, dokladnie to
+    co realnie rzuca .with_structured_output() gdy LLM zwroci zly JSON) go
+    rzuca."""
 
-    def __init__(self, attempts):
-        self.attempts = attempts
+    def __init__(self, outcome):
+        self.outcome = outcome
 
     def invoke(self, messages, config=None):
-        callbacks = (config or {}).get("callbacks") or []
-        last_exc = None
-        for model_name, outcome in self.attempts:
-            for cb in callbacks:
-                cb.on_chat_model_start(
-                    {}, [messages], invocation_params={"model": model_name})
-            if isinstance(outcome, Exception):
-                last_exc = outcome
-                for cb in callbacks:
-                    cb.on_llm_error(outcome)
-                continue
-            for cb in callbacks:
-                cb.on_llm_end(outcome)
-            return outcome
-        raise last_exc
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def _patch_model_chains(proc, outcomes):
+    """outcomes: dict model_name -> wynik_albo_wyjatek. Model bez wpisu w
+    outcomes, jesli zostanie faktycznie wywolany, rzuci KeyError - to
+    celowe, ujawnia gdyby kod probowal model, ktorego test nie oczekiwal."""
+
+    def fake_get_model_chain(model, cache_key, pydantic_class=None):
+        return _FakeSingleChain(outcomes[model])
+
+    return patch.object(proc, "_get_model_chain", side_effect=fake_get_model_chain)
 
 
 class _FakeMessage:
@@ -68,9 +68,8 @@ class LangChainAIProcessorNameTest(TestCase):
         expected = ProductNameStructure(
             base_type="Kostium kąpielowy", model_name="Ada",
             final_name="Kostium kąpielowy Ada")
-        chain = _FakeChain([(proc.primary_model, expected)])
 
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, {proc.primary_model: expected}):
             result = proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
 
         self.assertEqual(result, "Kostium kąpielowy Ada")
@@ -84,12 +83,12 @@ class LangChainAIProcessorNameTest(TestCase):
         expected = ProductNameStructure(
             base_type="Figi kąpielowe", model_name="Lupo",
             final_name="Figi kąpielowe Lupo")
-        chain = _FakeChain([
-            (proc.primary_model, RuntimeError("primary model niedostępny")),
-            (proc.fallback_model, expected),
-        ])
+        outcomes = {
+            proc.primary_model: RuntimeError("primary model niedostępny"),
+            proc.fallback_model: expected,
+        }
 
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, outcomes):
             result = proc.enhance_product_name("Figi kąpielowe Lupo M-120 - Marko")
 
         self.assertEqual(result, "Figi kąpielowe Lupo")
@@ -102,12 +101,12 @@ class LangChainAIProcessorNameTest(TestCase):
 
     def test_both_models_fail_raises(self):
         proc = _make_processor()
-        chain = _FakeChain([
-            (proc.primary_model, RuntimeError("primary padł")),
-            (proc.fallback_model, RuntimeError("fallback też padł")),
-        ])
+        outcomes = {
+            proc.primary_model: RuntimeError("primary padł"),
+            proc.fallback_model: RuntimeError("fallback też padł"),
+        }
 
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, outcomes):
             with self.assertRaises(RuntimeError):
                 proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
 
@@ -116,11 +115,12 @@ class LangChainAIProcessorNameTest(TestCase):
         self.assertFalse(log[0]["success"])
         self.assertFalse(log[1]["success"])
 
-    def test_malformed_llm_output_rejected_by_pydantic_falls_back(self):
-        """Gdy primary zwraca cos co nie przejdzie walidacji schematu (to co
-        realnie robi .with_structured_output() gdy LLM zwroci zly JSON -
-        rzuca ValidationError), fallback ma szanse przejąć, tak samo jak przy
-        kazdym innym wyjatku primary."""
+    def test_primary_validation_error_falls_back_and_is_logged_as_failure(self):
+        """Kluczowy przypadek: primary "odpowiada" (LLM sie wywoluje), ale
+        JSON nie przechodzi walidacji Pydantic (@field_validator w
+        ProductNameStructure) - .with_structured_output() rzuca
+        ValidationError z kroku parsera. Musi to zostac policzone jako
+        PORAZKA primary (nie sukces), a fallback ma przejac."""
         proc = _make_processor()
         try:
             ProductNameStructure(base_type="", model_name="", final_name="")
@@ -129,17 +129,20 @@ class LangChainAIProcessorNameTest(TestCase):
         expected = ProductNameStructure(
             base_type="Kostium kąpielowy", model_name="Ada",
             final_name="Kostium kąpielowy Ada")
-        chain = _FakeChain([
-            (proc.primary_model, malformed_error),
-            (proc.fallback_model, expected),
-        ])
+        outcomes = {
+            proc.primary_model: malformed_error,
+            proc.fallback_model: expected,
+        }
 
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, outcomes):
             result = proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
 
         self.assertEqual(result, "Kostium kąpielowy Ada")
         log = proc.pop_call_log()
-        self.assertFalse(log[0]["success"])
+        self.assertEqual(len(log), 2)
+        self.assertEqual(log[0]["model"], proc.primary_model)
+        self.assertFalse(log[0]["success"], "primary z odrzuconym przez Pydantic JSON-em NIE jest sukcesem")
+        self.assertEqual(log[1]["model"], proc.fallback_model)
         self.assertTrue(log[1]["success"])
 
     def test_empty_name_raises_before_any_call(self):
@@ -159,9 +162,8 @@ class LangChainAIProcessorDescriptionTest(TestCase):
             packaging="Produkt pakowany w ekologiczną torebkę z logo marki.",
             size_tip="Zalecamy wybór rozmiaru zgodnego z tabelą rozmiarów producenta.",
         )
-        chain = _FakeChain([(proc.primary_model, expected)])
 
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, {proc.primary_model: expected}):
             result = proc.enhance_product_description("Kostium kąpielowy, fiszbiny, regulowane boki")
 
         self.assertIn("Regulowane boki", result)
@@ -169,13 +171,13 @@ class LangChainAIProcessorDescriptionTest(TestCase):
 
     def test_both_models_fail_returns_original_text(self):
         proc = _make_processor()
-        chain = _FakeChain([
-            (proc.primary_model, RuntimeError("primary padł")),
-            (proc.fallback_model, RuntimeError("fallback też padł")),
-        ])
+        outcomes = {
+            proc.primary_model: RuntimeError("primary padł"),
+            proc.fallback_model: RuntimeError("fallback też padł"),
+        }
         original = "Oryginalny, niezmieniony opis produktu."
 
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, outcomes):
             result = proc.enhance_product_description(original)
 
         self.assertEqual(result, original)
@@ -186,7 +188,7 @@ class LangChainAIProcessorDescriptionTest(TestCase):
 
     def test_empty_description_returns_empty_without_calling_model(self):
         proc = _make_processor()
-        with patch.object(proc, "_get_chain") as get_chain:
+        with patch.object(proc, "_get_model_chain") as get_chain:
             result = proc.enhance_product_description("")
         self.assertEqual(result, "")
         get_chain.assert_not_called()
@@ -195,21 +197,18 @@ class LangChainAIProcessorDescriptionTest(TestCase):
 class LangChainAIProcessorShortDescriptionAndAttributesTest(TestCase):
     def test_create_short_description_truncates(self):
         proc = _make_processor()
-        chain = _FakeChain([
-            (proc.primary_model, _FakeMessage("x" * 300)),
-        ])
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, {proc.primary_model: _FakeMessage("x" * 300)}):
             result = proc.create_short_description("opis bazowy", max_length=250)
         self.assertEqual(len(result), 250)
 
     def test_create_short_description_both_fail_truncates_original(self):
         proc = _make_processor()
-        chain = _FakeChain([
-            (proc.primary_model, RuntimeError("padł")),
-            (proc.fallback_model, RuntimeError("padł")),
-        ])
+        outcomes = {
+            proc.primary_model: RuntimeError("padł"),
+            proc.fallback_model: RuntimeError("padł"),
+        }
         original = "y" * 300
-        with patch.object(proc, "_get_chain", return_value=chain):
+        with _patch_model_chains(proc, outcomes):
             result = proc.create_short_description(original, max_length=250)
         self.assertEqual(result, original[:250])
 
@@ -220,21 +219,19 @@ class LangChainAIProcessorShortDescriptionAndAttributesTest(TestCase):
             {"id": 2, "name": "Niski stan"},
             {"id": 3, "name": "Push-up"},
         ]
-        chain = _FakeChain([
-            (proc.primary_model, AttributesOutput(attributes=["Wysoki stan", "Push-Up", "Nieznany"])),
-        ])
-        with patch.object(proc, "_get_chain", return_value=chain):
+        outcome = AttributesOutput(attributes=["Wysoki stan", "Push-Up", "Nieznany"])
+        with _patch_model_chains(proc, {proc.primary_model: outcome}):
             ids = proc.extract_attributes_from_description("opis", available)
         self.assertEqual(ids, [1, 3])
 
     def test_extract_attributes_both_fail_returns_empty_list(self):
         proc = _make_processor()
         available = [{"id": 1, "name": "Wysoki stan"}]
-        chain = _FakeChain([
-            (proc.primary_model, RuntimeError("padł")),
-            (proc.fallback_model, RuntimeError("padł")),
-        ])
-        with patch.object(proc, "_get_chain", return_value=chain):
+        outcomes = {
+            proc.primary_model: RuntimeError("padł"),
+            proc.fallback_model: RuntimeError("padł"),
+        }
+        with _patch_model_chains(proc, outcomes):
             ids = proc.extract_attributes_from_description("opis", available)
         self.assertEqual(ids, [])
 


### PR DESCRIPTION
## Kontekst

Follow-up do #197 (już zmergowany, na `main` od v1.44.0). Zgodnie z ustaleniem z użytkownikiem, po wdrożeniu AI pipeline odpaliłem niezależnego agenta (świeży kontekst, izolowany worktree) do przeglądu zmiany zanim uznam zadanie za zamknięte. **Ten PR merge'ował się szybciej niż recenzja zdążyła się skończyć** — recenzja znalazła realny bug, który już jest na `main`. Ten PR go naprawia.

## Bug (High, znaleziony przez niezależny review)

`.with_structured_output()` to w rzeczywistości **dwa kroki**: wywołanie LLM, potem parser Pydantic. Poprzedni `_CallLogCallback` (LangChain `BaseCallbackHandler`) liczył sukces/błąd z callbacków `on_chat_model_start`/`on_llm_end`/`on_llm_error`, które widzą **tylko pierwszy krok**.

Skutek: gdy primary (`kimi-k2-thinking`) odpowiedział (LLM call OK), ale jego JSON **nie przeszedł** walidacji Pydantic (`@field_validator` w `ProductNameStructure`/`ProductDescriptionStructure`) i fallback faktycznie przejął — log i tak pokazywał primary jako `success: true`, mimo że jego output został po cichu odrzucony. To podważało cały sens `pop_call_log()`/`processing_data["_ai_pipeline"]` — czyli dokładnie ten mechanizm obserwowalności, o który chodziło w #197.

Recenzja wykazała też, że mój własny test tego scenariusza (`test_malformed_llm_output_rejected_by_pydantic_falls_back`) fakował błąd walidacji przez `on_llm_error` — czyli symulował coś, co w rzeczywistości nie tak się dzieje — więc nie łapał buga mimo że wyglądał na pokrycie tego przypadku.

## Naprawa

Usunięte `.with_fallbacks()` + `_CallLogCallback`, zastąpione ręczną pętlą primary→fallback w `_invoke()` z `try/except` **wokół całego** `chain.invoke()` (LLM + parser) na każdą próbę. Każda próba to dalej osobny `chain.invoke()` = osobny span w LangSmith (dodatkowo otagowany nazwą modelu), ale sukces/błąd jest teraz prawdziwym wynikiem tej próby, nie wnioskowaniem z callbacków.

Przy okazji naprawia dwa mniejsze znaleziska z tego samego review:
- **`duration_ms`** był jeden, wspólny dla całego wywołania (primary+fallback razem), stemplowany identycznie na obie próby. Teraz każda próba ma własny, prawdziwy czas (zweryfikowane na realnym OpenRouter: 35ms natychmiastowy błąd primary vs 2681ms realny fallback).
- Budowa chaina (`ChatOpenAI()`, `.with_structured_output()`) była **poza** `try/except` w `_invoke()` — regresja vs. przedpremierowy kod. Teraz jest w tym samym `try`, per próba.

## Weryfikacja

- 15/15 testów (przebudowane fakes pod nową architekturę — `_get_model_chain` per model zamiast jednego `_get_chain` z `.with_fallbacks()`; dopisany `test_primary_validation_error_falls_back_and_is_logged_as_failure`, który tym razem realnie odzwierciedla, jak `.with_structured_output()` się zachowuje)
- 62/62 `web_agent`
- Ręczny retest na prawdziwym `OPENROUTER_API_KEY` po rewrite — primary nadal odpowiada na wszystkie 3 operacje, wymuszony błąd primary nadal poprawnie przechodzi na fallback, teraz z poprawnymi, różnymi `duration_ms` per próba

## Skala ryzyka na produkcji

Sama automatyzacja (nazwa/opis produktu) działała poprawnie przez cały czas — bug dotyczył wyłącznie **danych obserwowalności** (`ProductProcessingLog.processing_data["_ai_pipeline"]`), nie funkcjonalności. Nic nie wymaga awaryjnej interwencji poza standardowym mergem tego PR-a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)