### PR TITLE
feat(web_agent): routuj modele OpenRouter per operacja (Faza 2, #195)

### DIFF
--- a/docs/AI_STACK_PLAN.md
+++ b/docs/AI_STACK_PLAN.md
@@ -41,15 +41,23 @@ Dotyczy warstwy AI w `apps/web_agent` — wzbogacanie danych produktu
 
 ### Faza 2 — OpenRouter: routing modeli per zadanie
 
-- [ ] mapa `operacja → profil modelu`, np.:
-  - `name` → tani, szybki (np. `openai/gpt-4o-mini` / `google/gemini-flash`)
-  - `description` → mocny reasoning (np. `kimi-k2-thinking` / `anthropic/claude-*`)
-  - `attributes` → tani + structured output
-  - `short_description` → tani
-- [ ] źródło konfiguracji: rozszerzyć `AIPrompt` o `model` / `model_profile` (edycja w adminie) **albo** `settings.AI_MODEL_ROUTING`
-- [ ] per-model: `temperature`, `max_tokens`, `reasoning.effort` (hack dla kimi już jest — uogólnić)
+- [x] mapa `operacja → profil modelu` — `DEFAULT_MODEL_ROUTING` w
+  `langchain_ai_processor.py`: `name`/`attributes`/`short_description` →
+  `openai/gpt-4o-mini` (tani, szybki, structured output), `description` →
+  `moonshotai/kimi-k2-thinking` (mocny reasoning)
+- [x] źródło konfiguracji: **ani** rozszerzenie `AIPrompt`, **ani**
+  `settings.AI_MODEL_ROUTING` — env vary czytane w module
+  (`AI_MODEL_<OPERACJA>_<ROLA>`, `_resolve_model()`), zgodnie z konwencją
+  całej reszty configu AI/LLM w tym repo (zero ustawień AI w
+  `core/settings/*.py` — sprawdzone przy implementacji)
+- [ ] per-model: `temperature`, `max_tokens` per operacja (dziś: stałe
+  dla wszystkich) — `reasoning.effort` (hack dla kimi) już **uogólniony**:
+  `REASONING_EFFORT_BY_MODEL`, właściwość modelu (nie operacji/pozycji),
+  działa niezależnie od tego czy kimi jest primary czy fallback
 - [ ] OpenRouter provider preferences (`extra_body={"provider": {...}}`) — kontrola kosztu / latencji / `data_collection`
-- [ ] fallback per profil (nie jeden globalny) — `.with_fallbacks()` z listą z konfiguracji
+- [x] fallback per profil (nie jeden globalny) — `self._routing[cache_key]`
+  w `_invoke()`, reczna petla primary→fallback (nie `.with_fallbacks()` —
+  patrz #201, `.with_fallbacks()` maskował błędy walidacji Pydantic)
 - [ ] koszt per operacja z `usage` OpenRouter → `ProductProcessingLog`
 
 ### Faza 3 — Observability / śledzenie agentów

--- a/docs/env.sample.md
+++ b/docs/env.sample.md
@@ -88,15 +88,32 @@ CELERY_RESULT_BACKEND=
 
 # AI (web_agent - wzbogacanie nazwy/opisu produktu przy automatyzacji)
 # USE_LANGCHAIN_AI=1 przelacza get_ai_processor() (ai_processor.py) na
-# LangChainAIProcessor: OpenRouter, primary moonshotai/kimi-k2-thinking ->
-# fallback openai/gpt-4o-mini przez LangChain .with_fallbacks(). Wymaga
-# OPENROUTER_API_KEY (NIE OPENAI_API_KEY - inny klucz, inny provider).
-# Bez USE_LANGCHAIN_AI=1 uzywany jest legacy AIProcessor (OPENAI_API_KEY
-# albo HF_TOKEN - patrz ai_processor.py).
+# LangChainAIProcessor: OpenRouter, model routowany PER OPERACJA (name/
+# description/attributes/short_description dostaja osobna pare primary/
+# fallback - patrz DEFAULT_MODEL_ROUTING w langchain_ai_processor.py),
+# reczny fallback primary->fallback per operacja. Wymaga OPENROUTER_API_KEY
+# (NIE OPENAI_API_KEY - inny klucz, inny provider). Bez USE_LANGCHAIN_AI=1
+# uzywany jest legacy AIProcessor (OPENAI_API_KEY albo HF_TOKEN - patrz
+# ai_processor.py).
 USE_LANGCHAIN_AI=
 OPENROUTER_API_KEY=
 OPENAI_API_KEY=
 HF_TOKEN=
+
+# Nadpisanie modelu dla KONKRETNEJ operacji (opcjonalne - bez tego uzywane
+# sa domyslne z DEFAULT_MODEL_ROUTING). OPERACJA = NAME / DESCRIPTION /
+# ATTRIBUTES / SHORT_DESCRIPTION, np. AI_MODEL_DESCRIPTION_PRIMARY=... .
+# OPENAI_MODEL_PRODUCT_ENRICHMENT/LANGCHAIN_FALLBACK_MODEL to starsze,
+# nadal dzialajace nazwy - ale tylko dla DESCRIPTION (wstecznie kompatybilne
+# sprzed routingu per operacja).
+AI_MODEL_NAME_PRIMARY=
+AI_MODEL_NAME_FALLBACK=
+OPENAI_MODEL_PRODUCT_ENRICHMENT=
+LANGCHAIN_FALLBACK_MODEL=
+AI_MODEL_ATTRIBUTES_PRIMARY=
+AI_MODEL_ATTRIBUTES_FALLBACK=
+AI_MODEL_SHORT_DESCRIPTION_PRIMARY=
+AI_MODEL_SHORT_DESCRIPTION_FALLBACK=
 
 # LangSmith - tracing LangChain (ambient, samo ustawienie tych zmiennych
 # instrumentuje kazde ChatOpenAI.invoke() bez zmian w kodzie). Klucz z

--- a/src/apps/web_agent/automation/langchain_ai_processor.py
+++ b/src/apps/web_agent/automation/langchain_ai_processor.py
@@ -1,17 +1,29 @@
 """
-Procesor AI: OpenRouter (moonshotai/kimi-k2-thinking -> openai/gpt-4o-mini
-fallback) przez LangChain, tracing przez LangSmith. Ten sam publiczny
-interfejs co AIProcessor (ai_processor.py) - wołany z tych samych miejsc
-(product_processor.py, background_automation.py, browser_automation.py,
-run_automation.py) bez zadnych zmian tam. Ustaw USE_LANGCHAIN_AI=1
-(get_ai_processor w ai_processor.py), zeby z niego korzystac.
+Procesor AI: OpenRouter przez LangChain, tracing przez LangSmith. Ten sam
+publiczny interfejs co AIProcessor (ai_processor.py) - wołany z tych samych
+miejsc (product_processor.py, background_automation.py,
+browser_automation.py, run_automation.py) bez zadnych zmian tam. Ustaw
+USE_LANGCHAIN_AI=1 (get_ai_processor w ai_processor.py), zeby z niego
+korzystac.
 
-Routing = miedzy modelami (niezawodnosc), nie miedzy promptami - oba modele
-ida przez ten sam prompt/schemat. Fallback to JAWNA petla primary->fallback
-w _invoke() (nie LangChainowe .with_fallbacks()) - kazda proba to osobny
-.invoke(), wiec kazda i tak jest osobnym spanem w LangSmith (dodatkowo
-otagowanym nazwa modelu), ale sukces/blad kazdej proby liczymy z PRAWDZIWEGO
-wyniku TEGO wywolania (try/except), a nie z LLM-owych callbackow. To celowe:
+Routing = dwie rzeczy naraz:
+1. Miedzy modelami (niezawodnosc) - primary->fallback per proba, patrz
+   _invoke() nizej.
+2. Miedzy OPERACJAMI (koszt/jakosc) - DEFAULT_MODEL_ROUTING przypisuje inna
+   pare modeli kazdej operacji (name/description/attributes/
+   short_description), nie jeden globalny primary/fallback dla wszystkiego.
+   `description` dostaje mocny model rozumujacy jako primary (uzasadnione -
+   copywriting), pozostale trzy dostaja tani/szybki model jako primary z
+   tym samym mocnym modelem w odwodzie jako fallback (niezawodnosc nie
+   spada - trudniejszy model zawsze jest dostepny, tylko rzadziej
+   potrzebny). Nadpisywalne per operacja przez AI_MODEL_<OP>_<ROLE> env
+   vary bez redeployu kodu - patrz _resolve_model().
+
+Fallback (miedzy modelami) to JAWNA petla primary->fallback w _invoke() (nie
+LangChainowe .with_fallbacks()) - kazda proba to osobny .invoke(), wiec
+kazda i tak jest osobnym spanem w LangSmith (dodatkowo otagowanym nazwa
+modelu), ale sukces/blad kazdej proby liczymy z PRAWDZIWEGO wyniku TEGO
+wywolania (try/except), a nie z LLM-owych callbackow. To celowe:
 .with_structured_output() to w rzeczywistosci DWA kroki (LLM, potem parser
 Pydantic) - .with_fallbacks() + callback na poziomie LLM widzi tylko
 pierwszy krok i potrafi zaraportowac model jako "sukces", mimo ze jego JSON
@@ -33,7 +45,7 @@ Kontrola = dwa niezalezne mechanizmy, nie jeden zamiast drugiego:
 import logging
 import os
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -46,8 +58,56 @@ from .ai_processor import (
 logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-DEFAULT_PRIMARY_MODEL = "moonshotai/kimi-k2-thinking"
-DEFAULT_FALLBACK_MODEL = "openai/gpt-4o-mini"
+
+# operacja (ten sam cache_key co w _invoke()) -> (primary, fallback). Oba
+# modele juz zweryfikowane na zywym OpenRouter w tej sesji (structured i
+# nie-structured output) - swiadomie zero nowych, niesprawdzonych
+# model-slugow tutaj; dywersyfikacja o trzeci model to osobny krok, do
+# zweryfikowania na zywo przed uzyciem jako domyslny.
+DEFAULT_MODEL_ROUTING: Dict[str, Tuple[str, str]] = {
+    "name": ("openai/gpt-4o-mini", "moonshotai/kimi-k2-thinking"),
+    "description": ("moonshotai/kimi-k2-thinking", "openai/gpt-4o-mini"),
+    "attributes": ("openai/gpt-4o-mini", "moonshotai/kimi-k2-thinking"),
+    "short_description": ("openai/gpt-4o-mini", "moonshotai/kimi-k2-thinking"),
+}
+
+# reasoning.effort to wlasciwosc MODELU (kimi jest modelem rozumujacym), nie
+# operacji/pozycji - kimi moze byc primary (description) albo fallback
+# (pozostale trzy operacje), w obu przypadkach potrzebuje tego samego
+# obejscia (patrz komentarz w _get_llm o reasoning_tokens zjadajacych
+# max_tokens).
+REASONING_EFFORT_BY_MODEL: Dict[str, str] = {
+    "moonshotai/kimi-k2-thinking": "low",
+}
+
+# Wsteczna zgodnosc: te zmienne istnialy PRZED routingiem per operacja i
+# ustawialy globalny primary/fallback dla wszystkiego. Dzis maja sens tylko
+# dla description (jedynej operacji, dla ktorej kimi-k2-thinking byl i jest
+# domyslnym primary) - .env.dev juz ma OPENAI_MODEL_PRODUCT_ENRICHMENT
+# ustawione, nie chcemy zeby przestalo dzialac.
+_LEGACY_ENV_OVERRIDE: Dict[Tuple[str, str], str] = {
+    ("description", "primary"): "OPENAI_MODEL_PRODUCT_ENRICHMENT",
+    ("description", "fallback"): "LANGCHAIN_FALLBACK_MODEL",
+}
+
+
+def _resolve_model(operation: str, role: str) -> str:
+    """Wybiera model dla (operacja, rola). Kolejnosc: AI_MODEL_<OP>_<ROLE>
+    (nowy, per-operacyjny override) > legacy env (tylko description,
+    wstecznie kompatybilne z OPENAI_MODEL_PRODUCT_ENRICHMENT/
+    LANGCHAIN_FALLBACK_MODEL) > DEFAULT_MODEL_ROUTING. Pozwala zmienic model
+    per operacja bez redeployu kodu."""
+    env_key = f"AI_MODEL_{operation.upper()}_{role.upper()}"
+    value = os.getenv(env_key)
+    if value:
+        return value
+    legacy_key = _LEGACY_ENV_OVERRIDE.get((operation, role))
+    if legacy_key:
+        value = os.getenv(legacy_key)
+        if value:
+            return value
+    idx = 0 if role == "primary" else 1
+    return DEFAULT_MODEL_ROUTING[operation][idx]
 
 
 class AttributesOutput(BaseModel):
@@ -78,8 +138,8 @@ def _get_prompt(name: str, **kwargs) -> Optional[str]:
 
 
 class LangChainAIProcessor:
-    """Procesor AI: OpenRouter, dwa modele (moonshotai/kimi-k2-thinking ->
-    openai/gpt-4o-mini), reczny fallback (petla try/except w _invoke() -
+    """Procesor AI: OpenRouter, model routowany PER OPERACJA (patrz
+    DEFAULT_MODEL_ROUTING), reczny fallback (petla try/except w _invoke() -
     patrz docstring modulu), tracing przez LangSmith."""
 
     def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
@@ -88,15 +148,18 @@ class LangChainAIProcessor:
             raise ValueError(
                 "API key is required. Ustaw OPENROUTER_API_KEY w .env.dev."
             )
-        self.primary_model = model or os.getenv(
-            "OPENAI_MODEL_PRODUCT_ENRICHMENT", DEFAULT_PRIMARY_MODEL)
-        self.fallback_model = os.getenv(
-            "LANGCHAIN_FALLBACK_MODEL", DEFAULT_FALLBACK_MODEL)
+        # `model` (jesli podany) nadpisuje primary WSZYSTKICH operacji - uzyte
+        # dzis tylko w testach/debugowaniu, produkcyjnie routing jest per
+        # operacja (self._routing) i konfigurowany env-varami, nie tym argumentem.
+        self._routing: Dict[str, Tuple[str, str]] = {
+            op: (model or _resolve_model(op, "primary"), _resolve_model(op, "fallback"))
+            for op in DEFAULT_MODEL_ROUTING
+        }
         self._chains: Dict[tuple, object] = {}
         self._call_log: List[Dict] = []
         logger.info(
-            "LangChainAIProcessor zainicjalizowany (OpenRouter, primary=%s, fallback=%s)",
-            self.primary_model, self.fallback_model,
+            "LangChainAIProcessor zainicjalizowany (OpenRouter, routing=%s)",
+            self._routing,
         )
 
     def pop_call_log(self) -> List[Dict]:
@@ -109,23 +172,28 @@ class LangChainAIProcessor:
 
     def _get_llm(self, model: str):
         from langchain_openai import ChatOpenAI
-        return ChatOpenAI(
+        kwargs = dict(
             base_url=OPENROUTER_BASE_URL,
             api_key=self.api_key,
             model=model,
             temperature=0.7,
             max_tokens=1500,
-            # primary (kimi-k2-thinking) jest modelem rozumujacym - bez tego co
-            # najmniej polowa max_tokens znika w niewidocznych reasoning_tokens,
-            # zanim model zdazy dokonczyc strukturyzowany JSON (zweryfikowane na
-            # prawdziwym wywolaniu OpenRouter: max_tokens=1500 -> 989 reasoning,
-            # max_tokens=4000 -> 2467 reasoning, oba razy "length limit was
-            # reached", opis nigdy nie kończył się na primary). OpenRouter-owy
-            # `reasoning.effort` przycina budzet rozumowania niezaleznie od
-            # max_tokens odpowiedzi - z "low" primary faktycznie konczy opis.
-            # Fallback (nie-rozumujacy model) po prostu ignoruje ten parametr.
-            extra_body={"reasoning": {"effort": "low"}},
         )
+        reasoning_effort = REASONING_EFFORT_BY_MODEL.get(model)
+        if reasoning_effort:
+            # modele rozumujace (dzis: kimi-k2-thinking) bez tego zjadaja co
+            # najmniej polowe max_tokens na niewidoczne reasoning_tokens,
+            # zanim zdaza dokonczyc strukturyzowany JSON (zweryfikowane na
+            # prawdziwym wywolaniu OpenRouter: max_tokens=1500 -> 989
+            # reasoning, max_tokens=4000 -> 2467 reasoning, oba razy "length
+            # limit was reached", opis nigdy sie nie konczyl). OpenRouter-owy
+            # `reasoning.effort` przycina budzet rozumowania niezaleznie od
+            # max_tokens odpowiedzi. Modele nie-rozumujace (gpt-4o-mini) nie
+            # dostaja tego kwarga wcale - nie tylko jest im zbedny, ale nie
+            # ma pewnosci ze kazdy model na OpenRouter go ignoruje bez zmian
+            # zachowania.
+            kwargs["extra_body"] = {"reasoning": {"effort": reasoning_effort}}
+        return ChatOpenAI(**kwargs)
 
     def _get_model_chain(self, model: str, cache_key: str, pydantic_class=None):
         """Chain dla POJEDYNCZEGO modelu (opcjonalnie ze strukturyzowanym
@@ -154,7 +222,7 @@ class LangChainAIProcessor:
         messages = [SystemMessage(content=system), HumanMessage(content=user)]
         attempts: List[Dict] = []
         result = None
-        for model in (self.primary_model, self.fallback_model):
+        for model in self._routing[cache_key]:
             started = time.monotonic()
             try:
                 chain = self._get_model_chain(model, cache_key, pydantic_class)
@@ -215,9 +283,10 @@ class LangChainAIProcessor:
             "name", system, user, tags=["name"], pydantic_class=ProductNameStructure)
         if isinstance(result, ProductNameStructure):
             return result.to_final_name()
+        primary, fallback = self._routing["name"]
         raise RuntimeError(
-            f"Nie udało się ulepszyć nazwy produktu ani przez {self.primary_model}, "
-            f"ani przez {self.fallback_model}"
+            f"Nie udało się ulepszyć nazwy produktu ani przez {primary}, "
+            f"ani przez {fallback}"
         )
 
     def enhance_product_description(
@@ -285,9 +354,10 @@ class LangChainAIProcessor:
         )
         if isinstance(result, ProductDescriptionStructure):
             return result.to_formatted_text()
+        primary, fallback = self._routing["description"]
         logger.error(
             "Nie udało się ulepszyć opisu ani przez %s, ani przez %s - zwracam oryginał",
-            self.primary_model, self.fallback_model,
+            primary, fallback,
         )
         return original_description
 

--- a/src/apps/web_agent/tests_langchain_ai_processor.py
+++ b/src/apps/web_agent/tests_langchain_ai_processor.py
@@ -1,10 +1,11 @@
 """
-Testy `LangChainAIProcessor` (OpenRouter + reczny fallback primary->fallback
-+ LangSmith, patrz automation/langchain_ai_processor.py). Zero prawdziwych
-wywolan HTTP/LangSmith - `_get_model_chain()` jest podmieniane, zeby kazdy
-model (primary/fallback) mial wlasny, niezalezny fake `.invoke()`: albo
-zwraca wynik, albo rzuca wyjatek - dokladnie tak jak _invoke() to konsumuje
-(try/except wokol calego chain.invoke() per model, sukces/blad z
+Testy `LangChainAIProcessor` (OpenRouter, model routowany PER OPERACJA -
+DEFAULT_MODEL_ROUTING - + reczny fallback primary->fallback + LangSmith,
+patrz automation/langchain_ai_processor.py). Zero prawdziwych wywolan
+HTTP/LangSmith - `_get_model_chain()` jest podmieniane, zeby kazdy model
+(primary/fallback DANEJ operacji) mial wlasny, niezalezny fake `.invoke()`:
+albo zwraca wynik, albo rzuca wyjatek - dokladnie tak jak _invoke() to
+konsumuje (try/except wokol calego chain.invoke() per model, sukces/blad z
 PRAWDZIWEGO wyniku tej proby, nie z LLM-owych callbackow - patrz docstring
 modulu o tym, dlaczego to wazne dla walidacji Pydantic).
 """
@@ -19,6 +20,7 @@ from web_agent.automation.ai_processor import (
 )
 from web_agent.automation.langchain_ai_processor import (
     AttributesOutput,
+    DEFAULT_MODEL_ROUTING,
     LangChainAIProcessor,
 )
 
@@ -62,30 +64,86 @@ def _make_processor():
     return LangChainAIProcessor(api_key="test-openrouter-key")
 
 
+class LangChainAIProcessorRoutingTest(TestCase):
+    """Router per operacja - rdzen tej zmiany (Faza 2, #195)."""
+
+    def test_different_operations_get_different_default_primary(self):
+        proc = _make_processor()
+        # description dostaje mocny model rozumujacy, pozostale tanio/szybko -
+        # nie ten sam primary dla wszystkiego, jak przed routingiem per operacja.
+        self.assertNotEqual(proc._routing["name"][0], proc._routing["description"][0])
+        self.assertEqual(proc._routing["name"][0], proc._routing["attributes"][0])
+        self.assertEqual(proc._routing["name"][0], proc._routing["short_description"][0])
+
+    def test_fallback_is_the_other_model_for_every_operation(self):
+        proc = _make_processor()
+        for op, (primary, fallback) in proc._routing.items():
+            with self.subTest(operation=op):
+                self.assertNotEqual(primary, fallback)
+
+    def test_matches_default_model_routing_table(self):
+        proc = _make_processor()
+        for op, expected in DEFAULT_MODEL_ROUTING.items():
+            with self.subTest(operation=op):
+                self.assertEqual(proc._routing[op], expected)
+
+    def test_env_override_changes_only_that_operation(self):
+        with patch.dict("os.environ", {"AI_MODEL_NAME_PRIMARY": "some/override-model"}):
+            proc = LangChainAIProcessor(api_key="test-key")
+        self.assertEqual(proc._routing["name"][0], "some/override-model")
+        # inne operacje nie zostaly dotkniete przez override "name"
+        self.assertEqual(
+            proc._routing["description"], DEFAULT_MODEL_ROUTING["description"])
+
+    def test_legacy_env_vars_still_override_description(self):
+        """OPENAI_MODEL_PRODUCT_ENRICHMENT/LANGCHAIN_FALLBACK_MODEL istnialy
+        przed routingiem per operacja i sa juz ustawione w .env.dev - musza
+        dalej dzialac (tylko dla description)."""
+        with patch.dict("os.environ", {
+            "OPENAI_MODEL_PRODUCT_ENRICHMENT": "legacy/primary-model",
+            "LANGCHAIN_FALLBACK_MODEL": "legacy/fallback-model",
+        }):
+            proc = LangChainAIProcessor(api_key="test-key")
+        self.assertEqual(
+            proc._routing["description"], ("legacy/primary-model", "legacy/fallback-model"))
+        # legacy zmienne nie maja wplywu na inne operacje
+        self.assertEqual(proc._routing["name"], DEFAULT_MODEL_ROUTING["name"])
+
+    def test_per_operation_env_var_wins_over_legacy(self):
+        with patch.dict("os.environ", {
+            "AI_MODEL_DESCRIPTION_PRIMARY": "new/primary-model",
+            "OPENAI_MODEL_PRODUCT_ENRICHMENT": "legacy/primary-model",
+        }):
+            proc = LangChainAIProcessor(api_key="test-key")
+        self.assertEqual(proc._routing["description"][0], "new/primary-model")
+
+
 class LangChainAIProcessorNameTest(TestCase):
     def test_primary_success_fallback_unused(self):
         proc = _make_processor()
+        primary_model = proc._routing["name"][0]
         expected = ProductNameStructure(
             base_type="Kostium kąpielowy", model_name="Ada",
             final_name="Kostium kąpielowy Ada")
 
-        with _patch_model_chains(proc, {proc.primary_model: expected}):
+        with _patch_model_chains(proc, {primary_model: expected}):
             result = proc.enhance_product_name("Kostium kąpielowy Model Ada M-803 - Marko")
 
         self.assertEqual(result, "Kostium kąpielowy Ada")
         log = proc.pop_call_log()
         self.assertEqual(len(log), 1)
-        self.assertEqual(log[0]["model"], proc.primary_model)
+        self.assertEqual(log[0]["model"], primary_model)
         self.assertTrue(log[0]["success"])
 
     def test_primary_fails_fallback_takes_over(self):
         proc = _make_processor()
+        primary_model, fallback_model = proc._routing["name"]
         expected = ProductNameStructure(
             base_type="Figi kąpielowe", model_name="Lupo",
             final_name="Figi kąpielowe Lupo")
         outcomes = {
-            proc.primary_model: RuntimeError("primary model niedostępny"),
-            proc.fallback_model: expected,
+            primary_model: RuntimeError("primary model niedostępny"),
+            fallback_model: expected,
         }
 
         with _patch_model_chains(proc, outcomes):
@@ -94,16 +152,17 @@ class LangChainAIProcessorNameTest(TestCase):
         self.assertEqual(result, "Figi kąpielowe Lupo")
         log = proc.pop_call_log()
         self.assertEqual(len(log), 2)
-        self.assertEqual(log[0]["model"], proc.primary_model)
+        self.assertEqual(log[0]["model"], primary_model)
         self.assertFalse(log[0]["success"])
-        self.assertEqual(log[1]["model"], proc.fallback_model)
+        self.assertEqual(log[1]["model"], fallback_model)
         self.assertTrue(log[1]["success"])
 
     def test_both_models_fail_raises(self):
         proc = _make_processor()
+        primary_model, fallback_model = proc._routing["name"]
         outcomes = {
-            proc.primary_model: RuntimeError("primary padł"),
-            proc.fallback_model: RuntimeError("fallback też padł"),
+            primary_model: RuntimeError("primary padł"),
+            fallback_model: RuntimeError("fallback też padł"),
         }
 
         with _patch_model_chains(proc, outcomes):
@@ -122,6 +181,7 @@ class LangChainAIProcessorNameTest(TestCase):
         ValidationError z kroku parsera. Musi to zostac policzone jako
         PORAZKA primary (nie sukces), a fallback ma przejac."""
         proc = _make_processor()
+        primary_model, fallback_model = proc._routing["name"]
         try:
             ProductNameStructure(base_type="", model_name="", final_name="")
         except ValidationError as exc:
@@ -130,8 +190,8 @@ class LangChainAIProcessorNameTest(TestCase):
             base_type="Kostium kąpielowy", model_name="Ada",
             final_name="Kostium kąpielowy Ada")
         outcomes = {
-            proc.primary_model: malformed_error,
-            proc.fallback_model: expected,
+            primary_model: malformed_error,
+            fallback_model: expected,
         }
 
         with _patch_model_chains(proc, outcomes):
@@ -140,9 +200,9 @@ class LangChainAIProcessorNameTest(TestCase):
         self.assertEqual(result, "Kostium kąpielowy Ada")
         log = proc.pop_call_log()
         self.assertEqual(len(log), 2)
-        self.assertEqual(log[0]["model"], proc.primary_model)
+        self.assertEqual(log[0]["model"], primary_model)
         self.assertFalse(log[0]["success"], "primary z odrzuconym przez Pydantic JSON-em NIE jest sukcesem")
-        self.assertEqual(log[1]["model"], proc.fallback_model)
+        self.assertEqual(log[1]["model"], fallback_model)
         self.assertTrue(log[1]["success"])
 
     def test_empty_name_raises_before_any_call(self):
@@ -154,6 +214,7 @@ class LangChainAIProcessorNameTest(TestCase):
 class LangChainAIProcessorDescriptionTest(TestCase):
     def test_primary_success(self):
         proc = _make_processor()
+        primary_model = proc._routing["description"][0]
         expected = ProductDescriptionStructure(
             introduction="Elegancki kostium kąpielowy o klasycznym kroju i wysokiej jakości wykonaniu.",
             top_features=["Miękkie fiszbiny – wygodne dopasowanie"],
@@ -163,7 +224,7 @@ class LangChainAIProcessorDescriptionTest(TestCase):
             size_tip="Zalecamy wybór rozmiaru zgodnego z tabelą rozmiarów producenta.",
         )
 
-        with _patch_model_chains(proc, {proc.primary_model: expected}):
+        with _patch_model_chains(proc, {primary_model: expected}):
             result = proc.enhance_product_description("Kostium kąpielowy, fiszbiny, regulowane boki")
 
         self.assertIn("Regulowane boki", result)
@@ -171,9 +232,10 @@ class LangChainAIProcessorDescriptionTest(TestCase):
 
     def test_both_models_fail_returns_original_text(self):
         proc = _make_processor()
+        primary_model, fallback_model = proc._routing["description"]
         outcomes = {
-            proc.primary_model: RuntimeError("primary padł"),
-            proc.fallback_model: RuntimeError("fallback też padł"),
+            primary_model: RuntimeError("primary padł"),
+            fallback_model: RuntimeError("fallback też padł"),
         }
         original = "Oryginalny, niezmieniony opis produktu."
 
@@ -197,15 +259,17 @@ class LangChainAIProcessorDescriptionTest(TestCase):
 class LangChainAIProcessorShortDescriptionAndAttributesTest(TestCase):
     def test_create_short_description_truncates(self):
         proc = _make_processor()
-        with _patch_model_chains(proc, {proc.primary_model: _FakeMessage("x" * 300)}):
+        primary_model = proc._routing["short_description"][0]
+        with _patch_model_chains(proc, {primary_model: _FakeMessage("x" * 300)}):
             result = proc.create_short_description("opis bazowy", max_length=250)
         self.assertEqual(len(result), 250)
 
     def test_create_short_description_both_fail_truncates_original(self):
         proc = _make_processor()
+        primary_model, fallback_model = proc._routing["short_description"]
         outcomes = {
-            proc.primary_model: RuntimeError("padł"),
-            proc.fallback_model: RuntimeError("padł"),
+            primary_model: RuntimeError("padł"),
+            fallback_model: RuntimeError("padł"),
         }
         original = "y" * 300
         with _patch_model_chains(proc, outcomes):
@@ -214,22 +278,24 @@ class LangChainAIProcessorShortDescriptionAndAttributesTest(TestCase):
 
     def test_extract_attributes_maps_names_to_ids(self):
         proc = _make_processor()
+        primary_model = proc._routing["attributes"][0]
         available = [
             {"id": 1, "name": "Wysoki stan"},
             {"id": 2, "name": "Niski stan"},
             {"id": 3, "name": "Push-up"},
         ]
         outcome = AttributesOutput(attributes=["Wysoki stan", "Push-Up", "Nieznany"])
-        with _patch_model_chains(proc, {proc.primary_model: outcome}):
+        with _patch_model_chains(proc, {primary_model: outcome}):
             ids = proc.extract_attributes_from_description("opis", available)
         self.assertEqual(ids, [1, 3])
 
     def test_extract_attributes_both_fail_returns_empty_list(self):
         proc = _make_processor()
+        primary_model, fallback_model = proc._routing["attributes"]
         available = [{"id": 1, "name": "Wysoki stan"}]
         outcomes = {
-            proc.primary_model: RuntimeError("padł"),
-            proc.fallback_model: RuntimeError("padł"),
+            primary_model: RuntimeError("padł"),
+            fallback_model: RuntimeError("padł"),
         }
         with _patch_model_chains(proc, outcomes):
             ids = proc.extract_attributes_from_description("opis", available)
@@ -243,12 +309,6 @@ class LangChainAIProcessorInitTest(TestCase):
             os.environ.pop("OPENROUTER_API_KEY", None)
             with self.assertRaises(ValueError):
                 LangChainAIProcessor()
-
-    def test_default_models(self):
-        proc = LangChainAIProcessor(api_key="test-key")
-        self.assertTrue(proc.primary_model)
-        self.assertTrue(proc.fallback_model)
-        self.assertNotEqual(proc.primary_model, proc.fallback_model)
 
     def test_pop_call_log_clears_state(self):
         proc = _make_processor()


### PR DESCRIPTION
## Kontekst

Faza 2 z `docs/AI_STACK_PLAN.md` (#195). Dotychczas `LangChainAIProcessor` miał jeden globalny primary/fallback (`moonshotai/kimi-k2-thinking` → `openai/gpt-4o-mini`) używany identycznie dla wszystkich czterech operacji (`name`, `description`, `attributes`, `short_description`). `description` (copywriting) faktycznie korzysta z modelu rozumującego jako primary — pozostałe trzy operacje dostawały ten sam drogi model bez potrzeby.

## Co się zmienia

Każda operacja ma teraz własną parę primary/fallback (`DEFAULT_MODEL_ROUTING`):
- `description` → `kimi-k2-thinking` (primary, mocny reasoning) → `gpt-4o-mini` (fallback) — bez zmian.
- `name` / `attributes` / `short_description` → `gpt-4o-mini` (primary, tani/szybki/structured-output) → `kimi-k2-thinking` (fallback) — niezawodność nie spada (mocniejszy model zawsze w odwodzie), koszt/czas trzech z czterech operacji spada.

Zero nowych, niesprawdzonych model-slugów — oba modele już zweryfikowane na żywym OpenRouter w tej sesji (structured i nie-structured output), tylko zamienione rolami per operacja. Dywersyfikacja o trzeci model to świadomie osobny, przyszły krok.

`reasoning.effort="low"` (obejście na `reasoning_tokens` zjadające `max_tokens`, #201) uogólnione z hardcoded na `REASONING_EFFORT_BY_MODEL` — to właściwość **modelu** (kimi), nie operacji/pozycji, bo kimi bywa raz primary (`description`), raz fallback (pozostałe trzy).

Konfiguracja: env vary per operacja (`AI_MODEL_<OP>_<ROLA>`, `_resolve_model()`) — zgodnie ze sprawdzoną konwencją całego configu AI/LLM w tym repo (`os.getenv()` w module, nie `settings.py` — w `core/settings/*.py` nie ma ani jednej zmiennej AI/LLM). `OPENAI_MODEL_PRODUCT_ENRICHMENT`/`LANGCHAIN_FALLBACK_MODEL` (już ustawione w `.env.dev`) zostają jako legacy override, ale tylko dla `description` — działały wyłącznie dla niej już przed tym PR-em.

## Świadomie poza zakresem (zaflagowane w `docs/AI_STACK_PLAN.md`, nie przemilczane)

- Śledzenie kosztu/tokenów z `usage` OpenRouter → `ProductProcessingLog` — brak precedensu w repo, wymaga `include_raw=True` na `.with_structured_output()`.
- OpenRouter provider preferences (`extra_body={"provider": {...}}`).
- Per-model `temperature`/`max_tokens` (dziś: stałe dla wszystkich operacji).

## Weryfikacja

- 20/20 `tests_langchain_ai_processor` (6 nowych testów routingu — różne operacje dostają różne modele, fallback = drugi model dla każdej operacji, zgodność z `DEFAULT_MODEL_ROUTING`, override per-operacyjnym env-varem, legacy env nadal działa dla `description`, per-operacyjny override wygrywa z legacy)
- 67/67 `web_agent`, 471/471 pełny regres (`MPD matterhorn1 tabu mada web_agent prestashop`)
- Ręcznie na żywym `OPENROUTER_API_KEY`: wszystkie 4 operacje przez `process_product_data()`/`extract_attributes_from_description()` — potwierdzone w zwróconym `pop_call_log()`, że `name`/`attributes`/`short_description` faktycznie idą przez `gpt-4o-mini`, `description` przez `kimi-k2-thinking` z działającym `reasoning.effort` (potwierdzone bezpośrednio `extra_body` na skonstruowanym `ChatOpenAI`); wymuszony błąd primary na `name` potwierdza poprawne przejęcie przez `kimi-k2-thinking` jako fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)