### PR TITLE
fix(matterhorn): podnieś limity czasu importu na dev (1h → 4h)

### DIFF
--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -40,15 +40,17 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             'task_id': getattr(getattr(self, 'request', None), 'id', 'direct_call')
         }
 
-    # BLOKADA - zapobiega równoległemu wykonaniu (działa dla Celery i bezpośrednich wywołań)
+    # BLOKADA - zapobiega równoległemu wykonaniu (działa dla Celery i bezpośrednich wywołań).
+    # Musi pokrywać maksymalny czas trwania importu (patrz CELERY_TASK_TIME_LIMIT),
+    # inaczej blokada wygasa w trakcie i kolejny tick beat odpala drugi import równolegle.
     lock_id = 'matterhorn1_full_import_lock'
-    lock_timeout = 3600  # 1 godzina
+    lock_timeout = 14400  # 4 godziny (>= CELERY_TASK_TIME_LIMIT)
 
     # Użyj task_id jeśli dostępny (Celery), w przeciwnym razie 'direct_call'
     task_identifier = getattr(self, 'request', None)
     task_id_value = task_identifier.id if task_identifier else 'direct_call'
 
-    # CZYŚĆ STARE RUNNING REKORDY (starsze niż 2 godziny)
+    # CZYŚĆ STARE RUNNING REKORDY (starsze niż 5 godzin - backstop)
     _cleanup_old_running_imports()
 
     # CZYŚĆ WSZYSTKIE RUNNING REKORDY (rozwiązuje problem z ręcznym przerywaniem)
@@ -1360,8 +1362,11 @@ def test_periodic_task():
 
 def _cleanup_old_running_imports():
     """
-    Czyści stare rekordy 'running' starsze niż 2 godziny.
-    To zapobiega kumulowaniu się zawieszonych importów.
+    Czyści rekordy 'running' starsze niż 5 godzin (backstop dla importów, które
+    zawisły bez sprzątnięcia). Próg musi być > CELERY_TASK_TIME_LIMIT (4h),
+    inaczej ubija normalnie pracujący import po dużym backlogu. Świeższe zombie
+    łapie progressowy watchdog (brak zmiany current_page) i _cleanup_all_running_imports
+    (running w DB bez blokady Redis).
     Z retry logic dla połączenia z bazą danych.
     """
     max_retries = 5
@@ -1373,8 +1378,8 @@ def _cleanup_old_running_imports():
             from django.utils import timezone
             from datetime import timedelta
 
-            # Znajdź stare running rekordy (starsze niż 2 godziny)
-            cutoff_time = timezone.now() - timedelta(hours=2)
+            # Znajdź stare running rekordy (starsze niż 5 godzin, > task time limit)
+            cutoff_time = timezone.now() - timedelta(hours=5)
             old_running = ApiSyncLog.objects.using('matterhorn1').filter(
                 sync_type='items_import',
                 status='running',
@@ -1390,7 +1395,7 @@ def _cleanup_old_running_imports():
                 old_running.update(
                     status='error',
                     completed_at=timezone.now(),
-                    error_details='Zawieszone - automatycznie oznaczone jako błąd po 2 godzinach'
+                    error_details='Zawieszone - automatycznie oznaczone jako błąd po 5 godzinach'
                 )
                 logger.info(
                     f"✅ Oznaczono {count} starych rekordów jako 'error'")

--- a/src/core/settings/dev.py
+++ b/src/core/settings/dev.py
@@ -189,7 +189,10 @@ CELERY_REDIS_MAX_CONNECTIONS = 50
 
 # Celery Redis transport options - uproszczona konfiguracja keepalive
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    'visibility_timeout': 3600,
+    # Musi być >= najdłuższego task time limit (patrz CELERY_TASK_TIME_LIMIT
+    # niżej), inaczej przy acks_late broker uzna wiadomość za zgubioną w trakcie
+    # importu i drugi worker odpali go równolegle.
+    'visibility_timeout': 14400,
     'max_connections': 50,
     'socket_keepalive': True,
     'socket_timeout': 120,  # Socket timeout (2 minuty)
@@ -207,9 +210,13 @@ CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_TASK_ACKS_LATE = True
 CELERY_TASK_REJECT_ON_WORKER_LOST = False  # Zmieniony na False dla development
 CELERY_WORKER_DISABLE_RATE_LIMITS = True  # Wyłącz limity dla development
-# Zwiększone limity dla długotrwałych tasków importu (3600s = 1 godzina)
-CELERY_TASK_TIME_LIMIT = 3600  # 1 godzina hard limit dla tasków
-CELERY_TASK_SOFT_TIME_LIMIT = 3300  # 55 minut soft limit
+# Limity dla długotrwałych tasków importu Matterhorn. Import inkrementalny po
+# dużym backlogu (znacznik last_update potrafi cofnąć się o dobę+) paginuje
+# kilkadziesiąt stron × ~1000 pozycji, a baza dev jest za tunelem SSH — 1h nie
+# wystarczało i task ginął z TimeLimitExceeded, przez co znacznik nigdy nie
+# przeskakiwał (spirala). 4h daje zapas na jednorazowe nadgonienie.
+CELERY_TASK_TIME_LIMIT = 14400  # 4 godziny hard limit
+CELERY_TASK_SOFT_TIME_LIMIT = 13800  # 3h50 soft limit
 
 # Static files configuration for development with Nginx
 # Nginx obsługuje pliki statyczne, nie WhiteNoise


### PR DESCRIPTION
## Kontekst

Job `items_import` (Matterhorn) na **dev** wpadł w spiralę od nocy 2026‑09‑01 → 02: każdy hourly run padał po równo 1 h z `TimeLimitExceeded(3600)`.

Mechanizm:
1. `_get_last_items_update_time()` bierze `last_update` = czas startu ostatniego importu ze statusem `completed`. Ostatni taki: 2026‑09‑01 19:32.
2. Od tego czasu żaden run nie kończy się `completed` (twardy limit `CELERY_TASK_TIME_LIMIT=3600` tylko w `dev.py`), więc znacznik stoi.
3. Okno „zmienione od 2026‑09‑01 19:32" rośnie ~1,5 tys. poz./h → ~20 tys. poz. / 42+ stron → nie mieści się w godzinie → `error` → znacznik dalej stoi. Death spiral.
4. Na dev każda strona ~80 s (HTTP + zapis 1000 poz. przez tunel SSH do bazy).

**Tylko dev** — prod nie ustawia `CELERY_TASK_TIME_LIMIT` i ma bazę lokalnie.

## Zmiany (fix „d" — sam limit, bez refaktoru resume/N+1)

| co | było | jest |
|---|---|---|
| `CELERY_TASK_TIME_LIMIT` | 3600 | 14400 (4 h) |
| `CELERY_TASK_SOFT_TIME_LIMIT` | 3300 | 13800 |
| `CELERY_BROKER_TRANSPORT_OPTIONS.visibility_timeout` | 3600 | 14400 |
| `matterhorn1_full_import_lock` `lock_timeout` | 3600 | 14400 |
| `_cleanup_old_running_imports` próg | 2 h | 5 h |

Trzy ostatnie **muszą** iść razem z limitem:
- `visibility_timeout < time_limit` przy `acks_late` → broker uzna wiadomość za zgubioną i drugi worker odpali import równolegle.
- `lock_timeout` wygasa w trakcie → kolejny tick beat startuje drugi import.
- `_cleanup_old_running_imports` (flat cutoff `started_at < now-2h`, bez sprawdzania blokady) ubiłby normalnie pracujący 3‑godzinny import. Próg 5 h > time limit; świeże zombie i tak łapie progressowy watchdog (brak zmiany `current_page`) oraz `_cleanup_all_running_imports` (running w DB bez blokady Redis).

## Po deployu

Pierwszy scheduled run powinien nadgonić backlog w jednym przebiegu (~4 h zapasu) i ustawić `completed` → znacznik ruszy, hourly wróci do normy. Alternatywnie ręcznie: `python manage.py celery_import --action import`.

Nie ruszam tu spirali u źródła (resume od `current_page`, `partial` na soft‑timeout, N+1 w `_bulk_import_products`) — to osobny PR jeśli zdecydujesz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)