### PR TITLE
fix(matterhorn): wznawiaj import ITEMS od przerwanej strony (spirala)

### DIFF
--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -1,5 +1,6 @@
 import time
 from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.cache import cache
@@ -70,6 +71,7 @@ def full_import_and_update(self, start_id=None, max_products=200000,
         }
 
     task_completed_successfully = False
+    soft_timeout_hit = False
     total_imported = 0
     total_updated = 0
     iteration = 0
@@ -197,6 +199,24 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             'task_id': task_id_value
         }
 
+    except SoftTimeLimitExceeded:
+        # Limit czasu tasku. NIE retry'ujemy i nie traktujemy jako twardego błędu:
+        # numer bieżącej strony (current_page) jest zapisywany w ApiSyncLog po
+        # każdej stronie, a dane z już przetworzonych stron są zacommitowane
+        # (każda strona to osobna transaction.atomic). Blok `finally` niżej oznaczy
+        # rekord jako 'error' zachowując current_page, a kolejny tick Celery Beat
+        # wznowi import od tej strony (patrz _get_last_items_page).
+        soft_timeout_hit = True
+        logger.warning(
+            "⏱️ Soft time limit importu ITEMS — przerywam czysto, wznowienie od "
+            "ostatniej strony przy kolejnym uruchomieniu (bez retry).")
+        return {
+            'status': 'interrupted',
+            'reason': 'soft_time_limit',
+            'total_imported': total_imported,
+            'task_id': task_id_value,
+        }
+
     except Exception as e:
         logger.error(f"❌ Błąd pełnego importu: {e}")
         # 5 minut przerwy, max 2 retry
@@ -213,7 +233,9 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             cache.delete(lock_id)
             logger.info(f"🔓 Blokada zwolniona dla {task_id_value}")
 
-        # Aktualizuj status na podstawie tego czy task się zakończył sukcesem
+        # Aktualizuj status na podstawie tego czy task się zakończył sukcesem.
+        # Przy soft-timeout zostawiamy status 'error' z zachowanym current_page —
+        # _get_last_items_page wznowi od tej strony.
         try:
             if task_completed_successfully:
                 _update_items_import_status(
@@ -222,7 +244,10 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             else:
                 _update_items_import_status(
                     'error', total_imported, updated_count=total_updated, processed_count=total_imported + total_updated)
-                logger.info("❌ Task zakończony jako 'error'")
+                if soft_timeout_hit:
+                    logger.info("⏱️ Task przerwany soft-timeoutem — status 'error', current_page zachowany do wznowienia")
+                else:
+                    logger.info("❌ Task zakończony jako 'error'")
         except Exception as e:
             logger.error(f"❌ Błąd podczas aktualizacji statusu na końcu: {e}")
 
@@ -355,6 +380,8 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                                     'running', imported_count, page, updated_count=bulk_result.get('updated_count', 0), processed_count=imported_count)
                             break  # Sukces - wyjdź z retry loop
 
+                        except SoftTimeLimitExceeded:
+                            raise
                         except Exception as e:
                             logger.error(f"❌ Błąd parsowania JSON: {e}")
                             if attempt < max_attempts:
@@ -384,6 +411,8 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                                 "❌ Osiągnięto maksymalną liczbę prób API")
                             break
 
+                except SoftTimeLimitExceeded:
+                    raise
                 except Exception as e:
                     logger.error(
                         f"❌ Błąd podczas pobierania strony {page}: {e}")
@@ -418,6 +447,10 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
             'imported_count': imported_count
         }
 
+    except SoftTimeLimitExceeded:
+        # Propaguj do full_import_and_update — tam checkpoint (current_page już
+        # zapisany per-strona) i czyste wyjście bez retry.
+        raise
     except Exception as e:
         logger.error(f"❌ Błąd importu ITEMS: {e}")
         # Zaktualizuj status na 'error' jeśli nie dry_run
@@ -516,10 +549,34 @@ def _get_last_items_update_time():
 
 
 def _get_last_items_page():
-    """Zawsze zaczyna od strony 1 - każdy task zaczyna od początku z last_update"""
+    """Wznawianie: jeśli poprzedni import ITEMS został przerwany (error / running /
+    interrupted) na stronie > 1 i jest świeży (< 24 h), zacznij od tej strony.
+    Wszystkie przerwane runy używają tego samego `last_update` (znacznik przeskakuje
+    tylko po statusie 'completed'), więc numer strony jest spójny.
+    W przeciwnym razie strona 1.
+    """
     try:
-        logger.info(
-            "📄 Zaczynam od strony 1 - każdy task zaczyna od początku z last_update")
+        from matterhorn1.models import ApiSyncLog
+        from django.utils import timezone
+        from datetime import timedelta
+
+        last = ApiSyncLog.objects.using('matterhorn1').filter(
+            sync_type__in=['items_import', 'items_sync']
+        ).order_by('-started_at').first()
+
+        if (
+            last
+            and last.status in ('error', 'running', 'interrupted')
+            and (last.current_page or 0) > 1
+            and last.started_at
+            and last.started_at > timezone.now() - timedelta(hours=24)
+        ):
+            logger.info(
+                f"🔄 Wznawiam import od strony {last.current_page} "
+                f"(poprzedni run #{last.id} status={last.status})")
+            return last.current_page
+
+        logger.info("📄 Zaczynam od strony 1")
         return 1
     except Exception as e:
         logger.error(f"Błąd podczas pobierania ostatniej strony: {e}")
@@ -742,6 +799,10 @@ def _bulk_import_products(items):
             'imported_count': imported_count
         }
 
+    except SoftTimeLimitExceeded:
+        # Limit czasu tasku — nie połykać, nie retry'ować per-strona; propaguj wyżej,
+        # żeby full_import_and_update zrobił checkpoint i czysto wyszedł.
+        raise
     except Exception as e:
         logger.error(f"❌ Błąd bulk import: {e}")
         # Nie ma fallback - tylko bulk operations

--- a/src/apps/matterhorn1/tests_import_resume.py
+++ b/src/apps/matterhorn1/tests_import_resume.py
@@ -1,0 +1,76 @@
+"""
+Testy wznawiania importu ITEMS (fix a) i propagacji SoftTimeLimitExceeded (fix b).
+
+Kontekst: import inkrementalny wpadał w spiralę — po przekroczeniu limitu czasu
+Celery run ginął ze statusem 'error', znacznik last_update (przeskakuje tylko po
+'completed') stał w miejscu, a każdy kolejny run zaczynał od strony 1 i znów nie
+nadążał. _get_last_items_page() teraz wznawia od current_page ostatniego
+przerwanego runu.
+"""
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from celery.exceptions import SoftTimeLimitExceeded
+
+from matterhorn1.models import ApiSyncLog
+from matterhorn1.tasks import _get_last_items_page, _bulk_import_products
+
+
+def _mk_log(status, current_page, age_hours=0, sync_type='items_import'):
+    row = ApiSyncLog.objects.using('matterhorn1').create(
+        sync_type=sync_type, status=status, current_page=current_page,
+    )
+    if age_hours:
+        ApiSyncLog.objects.using('matterhorn1').filter(pk=row.pk).update(
+            started_at=timezone.now() - timedelta(hours=age_hours)
+        )
+    return ApiSyncLog.objects.using('matterhorn1').get(pk=row.pk)
+
+
+class GetLastItemsPageResumeTest(TestCase):
+    databases = {'matterhorn1', 'default'}
+
+    def test_resumes_from_last_interrupted_page(self):
+        _mk_log('completed', 22, age_hours=6)
+        _mk_log('error', 37, age_hours=1)
+        self.assertEqual(_get_last_items_page(), 37)
+
+    def test_resumes_from_running_row(self):
+        _mk_log('running', 12, age_hours=0)
+        self.assertEqual(_get_last_items_page(), 12)
+
+    def test_starts_from_one_when_last_run_completed(self):
+        _mk_log('error', 40, age_hours=3)
+        _mk_log('completed', 5, age_hours=1)
+        self.assertEqual(_get_last_items_page(), 1)
+
+    def test_starts_from_one_when_interrupted_run_is_stale(self):
+        _mk_log('error', 40, age_hours=48)
+        self.assertEqual(_get_last_items_page(), 1)
+
+    def test_starts_from_one_when_page_is_one(self):
+        _mk_log('error', 1, age_hours=1)
+        self.assertEqual(_get_last_items_page(), 1)
+
+    def test_starts_from_one_when_no_history(self):
+        self.assertEqual(_get_last_items_page(), 1)
+
+
+class BulkImportSoftTimeLimitTest(TestCase):
+    databases = {'matterhorn1', 'default'}
+
+    def test_soft_time_limit_propagates_not_swallowed(self):
+        """_bulk_import_products nie może połknąć SoftTimeLimitExceeded jako
+        'status: error' (to uruchamiało 5x retry per-strona i zjadało grace
+        między soft a hard limitem)."""
+        from unittest.mock import MagicMock, patch
+
+        mock_product = MagicMock()
+        mock_product.DoesNotExist = type('DoesNotExist', (Exception,), {})
+        mock_product.objects.using.return_value.get.side_effect = SoftTimeLimitExceeded()
+
+        with patch('matterhorn1.models.Product', mock_product):
+            with self.assertRaises(SoftTimeLimitExceeded):
+                _bulk_import_products([{'id': 1, 'creation_date': '2026-01-01'}])


### PR DESCRIPTION
Zastępuje #203 (odrzucony bump limitów). Diagnoza spirali — patrz wcześniejszy wątek / #203.

## Problem

`items_import` na dev: od 2026‑09‑01 19:32 każdy run ginie po limicie czasu Celery ze statusem `error`. `_get_last_items_update_time()` bierze `last_update` = start ostatniego **`completed`** runu → znacznik zamrożony → okno „zmienione od 19:32" rośnie ~1,5 tys. poz./h → run nie nadąża → `error` → znacznik dalej stoi. Death spiral. `_get_last_items_page()` zawsze zwracał `1`, więc każdy retry powtarzał całą robotę.

## Fix a — wznawianie

`_get_last_items_page()` wznawia od `current_page` ostatniego przerwanego runu (status `error`/`running`, strona > 1, młodszy niż 24 h). `current_page` jest zapisywane w `ApiSyncLog` po każdej stronie. Wszystkie przerwane runy dzielą ten sam `last_update` (przeskakuje tylko po `completed`), więc numer strony jest spójny — wznowienie pobiera dokładnie te strony, których zabrakło.

## Fix b — SoftTimeLimitExceeded nie jest połykany

Dotąd soft‑timeout wpadał w `except Exception` w `_bulk_import_products` → `status:'error'` → pętla retry per‑strona (5× ze `sleep` do 30 s) → zjadała 5‑min grace między soft (3300 s) a hard (3600 s) → SIGKILL, rekord zostaje `running`. Teraz `SoftTimeLimitExceeded` jest re‑raise'owany przez wszystkie handlery w ścieżce importu i łapany na poziomie `full_import_and_update` — czyste wyjście bez retry, `finally` oznacza rekord `error` z zachowanym `current_page`.

## Efekt

Pierwszy run po deployu wznawia od ~strony 42, kończy ostatnie kilka stron → `completed` → znacznik przeskakuje → kolejny run ma małe okno. Spirala pęka **bez** ruszania limitów czasu.

## Nie w tym PR

- fix c (N+1 w `_bulk_import_products` — per‑wierszowe `.get()`) — osobno, jeśli zdecydujesz.
- `current_page` w adminie `ApiSyncLog` — drobiazg, mogę dorzucić.

Testy: `matterhorn1/tests_import_resume.py` (7), pełne `matterhorn1` → 98 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)