### PR TITLE
fix(docker): brakujący COPY aplikacji prestashop w obrazie prod

### DIFF
--- a/deployments/docker/Dockerfile.ml
+++ b/deployments/docker/Dockerfile.ml
@@ -34,13 +34,18 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Dodaj src/ do PYTHONPATH, żeby Python mógł znaleźć aplikacje
 ENV PYTHONPATH=/app:/app/apps
 
-# Skopiuj tylko potrzebne pliki
+# Skopiuj tylko potrzebne pliki.
+# UWAGA: każda nowa aplikacja Django z INSTALLED_APPS (core/settings/base.py)
+# musi mieć tu swój COPY — inaczej django.setup() w buildzie wywala
+# ModuleNotFoundError.
 COPY src/manage.py .
 COPY src/core/ ./core/
 COPY src/apps/matterhorn1/ ./matterhorn1/
 COPY src/apps/MPD/ ./MPD/
 COPY src/apps/web_agent/ ./web_agent/
 COPY src/apps/tabu/ ./tabu/
+COPY src/apps/mada/ ./mada/
+COPY src/apps/prestashop/ ./prestashop/
 COPY deployments/nginx/nginx.conf ./nginx.conf
 COPY deployments/redis.conf ./redis.conf
 COPY package.json .

--- a/deployments/docker/Dockerfile.prod
+++ b/deployments/docker/Dockerfile.prod
@@ -41,7 +41,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Dodaj src/ do PYTHONPATH, żeby Python mógł znaleźć aplikacje
 ENV PYTHONPATH=/app:/app/apps
 
-# Skopiuj tylko potrzebne pliki (bez dev)
+# Skopiuj tylko potrzebne pliki (bez dev).
+# UWAGA: każda nowa aplikacja Django z INSTALLED_APPS (core/settings/base.py)
+# musi mieć tu swój COPY — inaczej collectstatic/migrate w buildzie wywala
+# ModuleNotFoundError.
 COPY src/manage.py .
 COPY src/core/ ./core/
 COPY src/apps/matterhorn1/ ./matterhorn1/
@@ -49,6 +52,7 @@ COPY src/apps/MPD/ ./MPD/
 COPY src/apps/web_agent/ ./web_agent/
 COPY src/apps/tabu/ ./tabu/
 COPY src/apps/mada/ ./mada/
+COPY src/apps/prestashop/ ./prestashop/
 # COPY static/ ./static/  # Nie kopiujemy - zostanie utworzony przez collectstatic
 COPY deployments/nginx/nginx.conf ./nginx.conf
 COPY deployments/redis.conf ./redis.conf


### PR DESCRIPTION
## Problem

Deploy VPS padł w buildzie na `manage.py collectstatic`:

```
ModuleNotFoundError: No module named 'prestashop'
  ...
  File ".../django/apps/config.py", line 193, in create
    import_module(entry)          # entry = 'prestashop' z INSTALLED_APPS
```

`Dockerfile.prod` kopiuje aplikacje Django **pojedynczo** (`COPY src/apps/<app>/ ./<app>/`) i lista nie została uzupełniona po dodaniu `prestashop` do `INSTALLED_APPS` (`core/settings/base.py`). Katalog aplikacji nie trafiał do obrazu → `import prestashop` w `django.setup()` się wywala.

CI (`check-django`) tego nie łapie, bo tam testy lecą przez `pip install` + `manage.py`, nie przez `Dockerfile.prod`.

## Fix

- `Dockerfile.prod`: `+ COPY src/apps/prestashop/`
- `Dockerfile.ml`: `+ COPY src/apps/mada/` (też brakowało — stary obraz) `+ COPY src/apps/prestashop/`
- komentarz-ostrzeżenie przy liście COPY

`prestashop` ciągnie tylko `django`, `MPD.models`, stdlib i `requests` (już w requirements) — po skopiowaniu katalogu build przechodzi.

## Docelowo (nie w tym PR)

Warto rozważyć `COPY src/apps/ ./apps/` (+ `manage.py` już dodaje `/app/apps` do `sys.path`) zamiast listy per-app — ten failure mode wróci przy kolejnej aplikacji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)