### PR TITLE
refactor(docker): kopiuj całe src/apps/ jednym COPY (zamiast listy per-app)

### DIFF
--- a/deployments/docker/Dockerfile.ml
+++ b/deployments/docker/Dockerfile.ml
@@ -34,18 +34,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Dodaj src/ do PYTHONPATH, żeby Python mógł znaleźć aplikacje
 ENV PYTHONPATH=/app:/app/apps
 
-# Skopiuj tylko potrzebne pliki.
-# UWAGA: każda nowa aplikacja Django z INSTALLED_APPS (core/settings/base.py)
-# musi mieć tu swój COPY — inaczej django.setup() w buildzie wywala
-# ModuleNotFoundError.
+# Skopiuj kod. Całe src/apps/ jednym COPY — /app/apps jest w PYTHONPATH (wyżej),
+# więc nowe aplikacje w INSTALLED_APPS nie wymagają zmiany w Dockerfile.
 COPY src/manage.py .
 COPY src/core/ ./core/
-COPY src/apps/matterhorn1/ ./matterhorn1/
-COPY src/apps/MPD/ ./MPD/
-COPY src/apps/web_agent/ ./web_agent/
-COPY src/apps/tabu/ ./tabu/
-COPY src/apps/mada/ ./mada/
-COPY src/apps/prestashop/ ./prestashop/
+COPY src/apps/ ./apps/
 COPY deployments/nginx/nginx.conf ./nginx.conf
 COPY deployments/redis.conf ./redis.conf
 COPY package.json .

--- a/deployments/docker/Dockerfile.prod
+++ b/deployments/docker/Dockerfile.prod
@@ -41,18 +41,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Dodaj src/ do PYTHONPATH, żeby Python mógł znaleźć aplikacje
 ENV PYTHONPATH=/app:/app/apps
 
-# Skopiuj tylko potrzebne pliki (bez dev).
-# UWAGA: każda nowa aplikacja Django z INSTALLED_APPS (core/settings/base.py)
-# musi mieć tu swój COPY — inaczej collectstatic/migrate w buildzie wywala
-# ModuleNotFoundError.
+# Skopiuj kod (bez dev). Całe src/apps/ jednym COPY — /app/apps jest w PYTHONPATH
+# (wyżej), więc nowe aplikacje w INSTALLED_APPS nie wymagają zmiany w Dockerfile.
+# .dockerignore odsiewa __pycache__, test_*.py, *.md itp.
 COPY src/manage.py .
 COPY src/core/ ./core/
-COPY src/apps/matterhorn1/ ./matterhorn1/
-COPY src/apps/MPD/ ./MPD/
-COPY src/apps/web_agent/ ./web_agent/
-COPY src/apps/tabu/ ./tabu/
-COPY src/apps/mada/ ./mada/
-COPY src/apps/prestashop/ ./prestashop/
+COPY src/apps/ ./apps/
 # COPY static/ ./static/  # Nie kopiujemy - zostanie utworzony przez collectstatic
 COPY deployments/nginx/nginx.conf ./nginx.conf
 COPY deployments/redis.conf ./redis.conf


### PR DESCRIPTION
Follow-up do #205. #205 dorzucił brakujący `COPY src/apps/prestashop/` — ale ten failure mode wróci przy kolejnej aplikacji. Tu usuwam źródło problemu.

## Zmiana

`Dockerfile.prod` i `Dockerfile.ml`:
```diff
-COPY src/apps/matterhorn1/ ./matterhorn1/
-COPY src/apps/MPD/ ./MPD/
-COPY src/apps/web_agent/ ./web_agent/
-COPY src/apps/tabu/ ./tabu/
-COPY src/apps/mada/ ./mada/
-COPY src/apps/prestashop/ ./prestashop/
+COPY src/apps/ ./apps/
```

`ENV PYTHONPATH=/app:/app/apps` jest już w obu obrazach, więc aplikacje pod `/app/apps/<app>` są importowalne bez zmian w kodzie. Dev (`Dockerfile.dev`: `COPY src/ .`) już używa tego układu. `.dockerignore` odsiewa `__pycache__`, `test_*.py`, `tests/`, `*.md`.

Nowa aplikacja w `INSTALLED_APPS` nie wymaga już dotykania Dockerfile.

## Weryfikacja

Lokalny build `Dockerfile.prod`:
- `collectstatic` → `243 static files copied` (był `ModuleNotFoundError: prestashop`)
- w obrazie: `import prestashop, mada, tabu, MPD, matterhorn1, web_agent` → OK
- obraz 289 MB (bez zmian względem listy per-app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)