### PR TITLE
test: migracja runnera na pytest-django (Faza 0) + plan testów matterhorn1

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -192,15 +192,13 @@ jobs:
           }
           echo "✅ Migracje spójne z modelami"
 
-      - name: Testy Django
-        working-directory: src
-        # Jawna lista aplikacji — dyskryminacja z korzenia myli tożsamość modeli
-        # (web_agent vs apps.web_agent). pattern tests*.py pomija komendy
-        # management test_*_connection.py.
+      - name: Testy (pytest)
+        # Konfiguracja w pyproject.toml [tool.pytest.ini_options]:
+        # DJANGO_SETTINGS_MODULE, pythonpath, python_files=tests*.py
+        # (pomija management/commands/test_*_connection.py), testpaths=src/apps.
         run: >-
-          python manage.py test
-          MPD matterhorn1 web_agent tabu mada
-          --noinput --pattern "tests*.py"
+          pytest
+          --cov=src/apps --cov-report=term-missing:skip-covered
 
   check-code-quality:
     name: Sprawdź jakość kodu (linting i formatowanie)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,48 @@
+"""
+Wspólne fixture'y pytest dla całego projektu.
+
+Migracja z `manage.py test` na pytest-django — istniejące klasy
+`unittest.TestCase` / `APITestCase` działają bez zmian (pytest uruchamia je
+natywnie). Nowe testy piszemy w stylu pytest z tych fixture'ów.
+
+Tryb testów: `core.settings.dev` z `RUNNING_TESTS=True` (patrz dev.py) —
+routery baz wyłączone, wszystko idzie do `default`, pozostałe aliasy to
+`MIRROR: default`, `CELERY_TASK_ALWAYS_EAGER=True`, `DummyCache`.
+"""
+import pytest
+
+# Bazy widoczne dla testów pytest-style (odpowiednik `databases = {...}`
+# na klasach TestCase). Wszystkie i tak mirrorują `default` w trybie testów.
+ALL_DATABASES = ["default", "MPD", "matterhorn1", "web_agent", "tabu", "mada"]
+
+
+@pytest.fixture
+def api_client():
+    from rest_framework.test import APIClient
+    return APIClient()
+
+
+@pytest.fixture
+def admin_user(db, django_user_model):
+    return django_user_model.objects.create_superuser(
+        username="admin_test",
+        email="admin_test@example.com",
+        password="pass-test-12345",
+    )
+
+
+@pytest.fixture
+def auth_client(api_client, admin_user):
+    """APIClient uwierzytelniony tokenem superusera."""
+    from rest_framework.authtoken.models import Token
+    token, _ = Token.objects.get_or_create(user=admin_user)
+    api_client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return api_client
+
+
+@pytest.fixture
+def all_dbs(db):
+    """Dla testów cross-DB (matterhorn1 <-> MPD) w stylu pytest — użyj razem z
+    `@pytest.mark.django_db(databases=conftest.ALL_DATABASES)` na teście albo
+    tego fixture'u, gdy potrzebny jest dostęp do wielu aliasów."""
+    return ALL_DATABASES

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,138 @@
+# Testy — plan i konwencje
+
+Punkt startowy: **kompleksowe pokrycie `matterhorn1`** (unit + integration + e2e),
+przy okazji migracja całego projektu na `pytest-django`.
+
+Tracking: #208. Stan wyjściowy matterhorn1: ~98 testów w 7 plikach
+`tests*.py` — dobrze pokryte modele / serializery / REST API, **niepokryte**:
+`tasks.py` (pipeline importu, 1850 LOC), `saga.py` (główna saga produktu),
+`admin.py` (mpd_create / assign_mapping / auto_map), `views*.py`,
+`stock_tracker.py`, komendy `sync_*`.
+
+## Decyzje
+
+| Temat            | Ustalenie                                                                                                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Istniejące testy | **Zachować** — pytest uruchamia `unittest.TestCase` natywnie; reorganizacja w warstwy, nie przepisywanie                                                                                      |
+| „e2e"            | **Pełny pipeline importu z zamockowanym HTTP** (`responses`): `full_import_and_update` od API → asercje stanu w matterhorn1 + MPD, z sagą i linkowaniem po EAN. Deterministyczne, działa w CI |
+| Runner           | **Migracja na `pytest-django`** + `responses` + `pytest-cov`                                                                                                                                  |
+
+---
+
+## Faza 0 — migracja na pytest-django (infra) ✅
+
+Bez nowych testów logiki — przełączenie runnera tak, żeby istniejące ~98
+testów przechodziło 1:1.
+
+- [x] `requirements.ci.txt`: `pytest`, `pytest-django`, `pytest-cov`, `coverage`, `responses`
+- [x] `pyproject.toml` → `[tool.pytest.ini_options]`:
+  - `DJANGO_SETTINGS_MODULE = "core.settings.dev"`
+  - `python_files = ["tests*.py"]` — **tylko** `tests*.py`, żeby nie zbierać
+    `management/commands/test_*_connection.py` (jak stary `--pattern`)
+  - `testpaths = ["src/apps"]`, `pythonpath = ["src/apps", "src"]`
+  - `addopts = "--reuse-db --strict-markers -ra"`
+  - markery: `unit`, `integration`, `e2e`
+- [x] **`core/settings/dev.py`**: `if 'test' in sys.argv` (2 miejsca) → wspólny flag
+  ```python
+  RUNNING_TESTS = 'test' in sys.argv or 'pytest' in sys.modules
+  ```
+  Inaczej pod pytest nie zadziała: wyłączony routing baz, `DummyCache`,
+  wyłączony throttling, `CELERY_TASK_ALWAYS_EAGER`.
+- [x] **usunięty pusty `src/apps/__init__.py`** — z nim pytest importował moduły
+      jako `apps.matterhorn1.*` (≠ `matterhorn1` z `INSTALLED_APPS`) i wywalał
+      `RuntimeError: Model ... doesn't declare an explicit app_label`. Bez niego
+      `matterhorn1` jest top-level (jak w `manage.py`, gdzie `src/apps` jest w `sys.path`).
+- [x] `conftest.py` (root): fixture'y `api_client`, `admin_user`, `auth_client`, `all_dbs`
+- [x] `.github/workflows/check-branch.yml`: krok „Testy Django" → `pytest --cov=src/apps`
+- [ ] pozostałe docs (`HOW_TO_FIX_TESTS.md`, `DJANGO_6_COMPATIBILITY.md` …) — komenda `manage.py test` → `pytest` (osobno)
+- [x] weryfikacja: `pytest src/apps/matterhorn1` = 98 pass (tyle samo co `manage.py test`)
+
+> Uwaga o bazach: `dev.py` w trybie testów wyłącza routery (`DATABASE_ROUTERS = []`)
+> — wszystkie modele idą do `default`, pozostałe bazy to `MIRROR: default`.
+> Wywołania `.using('MPD')` w kodzie nadal działają (alias → ta sama baza testowa).
+> Klasy testów cross-DB deklarują `databases = {'default', 'MPD', ...}` (TestCase)
+> lub `@pytest.mark.django_db(databases=conftest.ALL_DATABASES)` (pytest-style).
+
+### Uruchamianie
+
+```bash
+pip install -r src/requirements.ci.txt        # pytest + wtyczki
+
+pytest                                         # wszystko
+pytest src/apps/matterhorn1                     # jedna apka
+pytest src/apps/matterhorn1/tests_saga.py -q    # jeden plik
+pytest -m "not e2e"                             # szybki cykl
+pytest -k "saga and compensat"                  # po nazwie
+pytest --cov=src/apps --cov-report=term-missing # z pokryciem
+```
+
+`--reuse-db` trzyma testową bazę między uruchomieniami (pierwszy raz wolno,
+kolejne szybko). `--create-db` wymusza odtworzenie po zmianie migracji.
+
+---
+
+## Warstwy testów matterhorn1
+
+### Unit (izolowane, bez DB gdy się da)
+
+| Cel                                                                            | Moduł                           |
+| ------------------------------------------------------------------------------ | ------------------------------- |
+| `_parse_creation_date`, parsowanie pól API, mapowanie item→model               | `tasks.py` (helpery)            |
+| `_prepare_product_create` / `_prepare_product_update` — budowa obiektu z itemu | `tasks.py`                      |
+| normalizacja EAN / kodów, fallback SKU                                         | `defs_db.py`, `source_adapters` |
+| `stock_tracker` — wykrywanie zmiany stanu, próg, brak zmiany                   | `stock_tracker.py`              |
+| `transaction_logger` — format wpisu, fail-open                                 | `transaction_logger.py`         |
+| `database_utils` — buildery zapytań / bulk helpers                             | `database_utils.py`             |
+| serializery walidacja (uzupełnić braki)                                        | `serializers.py`                |
+
+### Integration (z DB, komponenty razem)
+
+| Cel                                                                            | Zakres                                |
+| ------------------------------------------------------------------------------ | ------------------------------------- |
+| `SagaOrchestrator` + `SagaService.create_product_with_mapping` — happy path    | `saga.py`                             |
+| **kompensacja**: krok 2 rzuca → krok 1 cofnięty, brak sieroty w MPD            | `saga.py`                             |
+| logowanie sagi fail-open (błąd zapisu logu nie przerywa sagi)                  | `core/saga.py` + `saga.py`            |
+| admin `mpd_create` — POST formularza → produkt w MPD + mapping w matterhorn1   | `admin.py`                            |
+| admin `assign_mapping` — podpięcie istniejącego produktu MPD                   | `admin.py`                            |
+| admin `auto_map` / akcja linkowania → dispatch taska (jest 1 test, rozszerzyć) | `admin.py` + `tests_admin_linking.py` |
+| bulk API (`import_products_bulk`, `bulk-map`) — walidacja + zapis              | `views.py`, komendy                   |
+| `_bulk_import_products` / `_bulk_update_inventory` — batch, konflikt, dedup    | `tasks.py`                            |
+| watchdog `watchdog_import_healthcheck` — wykrycie zawieszonego importu         | `tasks.py`                            |
+| komendy `sync_products` / `sync_inventory` / `sync_variants` z mockiem API     | `management/commands`                 |
+
+### E2E (pełny pipeline, HTTP mockowany `responses`)
+
+| Scenariusz                                                                             | Asercje                                                                                        |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `full_import_and_update` — ITEMS 2 strony + INVENTORY, `responses` zwraca fixture JSON | Brand/Category/Product/Variant/Image w matterhorn1, `ApiSyncLog` OK, znacznik ostatniej strony |
+| wznowienie importu od przerwanej strony (rozszerzyć `tests_import_resume`)             | start od zapisanej strony, nie od 1                                                            |
+| import → `mpd_create` → linkowanie po EAN                                              | produkt w MPD, `ProductvariantsSources` dopięte, warianty bez trafienia w panelu „orphaned"    |
+| import z częściowym błędem API (500 na stronie 2)                                      | strona 1 zapisana, retry/log, brak duplikatów po ponowieniu                                    |
+| blokada równoległego importu (`matterhorn1_full_import_lock`)                          | drugi start → `skipped`                                                                        |
+| aktualizacja INVENTORY zmienia stan → `StockHistory` + `track_stock_changes`           | wpis historii, event                                                                           |
+
+---
+
+## Fazy realizacji
+
+| Faza  | Zakres                                                                                                                     | PR          |
+| ----- | -------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **0** | Infra pytest-django (wyżej)                                                                                                | 1           |
+| **1** | Fixtures + `responses` helpers dla API Matterhorn (`tests/fixtures/matterhorn/*.json`), reorganizacja plików w `tests/unit | integration | e2e` | 1   |
+| **2** | Unit: `tasks.py` helpery, `stock_tracker`, `transaction_logger`, `database_utils`, braki w serializerach                   | 1–2         |
+| **3** | Integration: `saga.py` (happy + kompensacja), admin `mpd_create`/`assign_mapping`, `_bulk_*`, watchdog                     | 2–3         |
+| **4** | E2E: `full_import_and_update` z `responses`, import→map→link, scenariusze błędów                                           | 2           |
+| **5** | Próg pokrycia w CI (`--cov-fail-under`), raport, uzupełnienie białych plam                                                 | 1           |
+
+Cel pokrycia matterhorn1: **linie ≥ 80%**, `tasks.py` i `saga.py` ≥ 75%.
+
+---
+
+## Konwencje (po migracji)
+
+- nowe testy: plik `tests_<obszar>.py` (collector zbiera `tests*.py`, **nie** `test_*.py` — to koliduje z komendami `test_*_connection.py`), styl pytest (funkcje + fixture, `@pytest.mark.django_db`)
+- markery: `@pytest.mark.unit` / `integration` / `e2e`; `pytest -m "not e2e"` do szybkiego cyklu
+- HTTP: **zawsze** `@responses.activate` — żaden test nie dzwoni po sieci
+- Celery: `CELERY_TASK_ALWAYS_EAGER` (już włączone w trybie testów) — taski wołane synchronicznie
+- fixtures API w `src/apps/matterhorn1/tests/fixtures/` (prawdziwe kształty odpowiedzi, zanonimizowane)
+- jeden `assert` logiczny na test gdy się da; nazwy `test_<co>_<warunek>_<oczekiwanie>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.pytest.ini_options]
+# Runner testów projektu. Uruchamianie:
+#   pytest                       # wszystko
+#   pytest src/apps/matterhorn1  # jedna apka
+#   pytest -m "not e2e"          # szybki cykl
+DJANGO_SETTINGS_MODULE = "core.settings.dev"
+# tylko tests*.py — NIE test_*.py, żeby nie zbierać komend
+# management/commands/test_*_connection.py (jak w check-branch.yml)
+python_files = ["tests*.py"]
+python_classes = ["Test*", "*Test", "*Tests"]
+testpaths = ["src/apps"]
+pythonpath = ["src/apps", "src"]
+addopts = "--reuse-db --strict-markers -ra"
+markers = [
+  "unit: szybki test jednostkowy, bez DB/HTTP",
+  "integration: test z DB lub wieloma komponentami",
+  "e2e: pełny przepływ (np. pipeline importu z zamockowanym HTTP)",
+]

--- a/src/core/settings/dev.py
+++ b/src/core/settings/dev.py
@@ -3,6 +3,11 @@ import sys
 from .base import *
 from core.middleware import get_debug
 
+# True gdy trwają testy — `manage.py test` (stare) ORAZ pytest-django (nowe).
+# pytest nie wkłada 'test' do sys.argv, ale importuje moduł `pytest` zanim
+# Django wczyta settings, więc `'pytest' in sys.modules` łapie ten przypadek.
+RUNNING_TESTS = 'test' in sys.argv or 'pytest' in sys.modules
+
 # Development rozszerza DATABASES z base.py o wersje z zzz_
 # Dodajemy bazy z przedrostkiem zzz_ (routery wybiorą je automatycznie)
 DATABASES['zzz_default'] = DATABASES['default'].copy()
@@ -134,7 +139,7 @@ INTERNAL_IPS = ['127.0.0.1', 'localhost', '192.168.50.63'] + \
 def show_debug_toolbar(request):
     """Callback dla debug toolbar - pokazuje się tylko dla localhost (nie w testach)."""
     # django-debug-toolbar 7.x psuje reverse('djdt') w APIClient jeśli toolbar jest aktywny w testach
-    if 'test' in sys.argv:
+    if RUNNING_TESTS:
         return False
     return get_debug() and request.META.get('REMOTE_ADDR') in INTERNAL_IPS
 
@@ -248,7 +253,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # Wyłącz database routers podczas testów - używamy tylko bazy default
 # To rozwiązuje problemy z tworzeniem wielu testowych baz jednocześnie
-if 'test' in sys.argv:
+if RUNNING_TESTS:
     DATABASE_ROUTERS = []  # Wyłącz routing podczas testów - wszystkie modele idą do default
 
     # Wyłącz cache/throttling dla testów - użyj dummy cache zamiast DatabaseCache

--- a/src/requirements.ci.txt
+++ b/src/requirements.ci.txt
@@ -19,6 +19,7 @@ click-plugins==1.1.1
 click-repl==0.3.0
 colorama==0.4.6
 comm==0.2.3
+coverage==7.16.0
 cron-descriptor==1.4.5
 decorator==5.2.1
 distro==1.9.0
@@ -73,6 +74,9 @@ pycparser==3.0
 pydantic==2.13.5
 Pygments==2.20.0
 PySocks==1.7.1
+pytest==9.0.2
+pytest-cov==7.1.0
+pytest-django==4.14.0
 python-crontab==3.4.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.3
@@ -85,6 +89,7 @@ RapidFuzz==3.13.0
 redis==5.2.1
 referencing==0.36.2
 requests==2.33.0
+responses==0.26.3
 rpds-py==0.26.0
 s3transfer==0.12.0
 selenium==4.39.0


### PR DESCRIPTION
**Faza 0** planu `docs/TESTING.md` (który też tu wchodzi — zastępuje #209).

Bez nowych testów logiki — tylko przełączenie runnera. Istniejące **98 testów matterhorn1 przechodzi 1:1** pod pytest (238s, tyle samo co `manage.py test`).

## Zmiany
| Plik | Co |
|---|---|
| `pyproject.toml` (nowy) | `[tool.pytest.ini_options]` — `DJANGO_SETTINGS_MODULE`, `pythonpath`, `python_files=tests*.py` (pomija `management/commands/test_*_connection.py`), markery `unit`/`integration`/`e2e`, `--reuse-db` |
| `conftest.py` (nowy) | fixture'y `api_client`, `admin_user`, `auth_client`, `all_dbs` |
| `core/settings/dev.py` | `RUNNING_TESTS = 'test' in sys.argv or 'pytest' in sys.modules` (2× `'test' in sys.argv` → to). Bez tego pod pytest nie działa: wyłączony routing baz, `DummyCache`, `CELERY_TASK_ALWAYS_EAGER` |
| `src/apps/__init__.py` | **usunięty** — pusty `__init__` → import jako `apps.matterhorn1.*` (≠ `matterhorn1` z `INSTALLED_APPS`) → `RuntimeError: ... explicit app_label`. `manage.py check` po usunięciu: OK |
| `src/requirements.ci.txt` | `pytest 9.0.2`, `pytest-django 4.14.0`, `pytest-cov 7.1.0`, `coverage 7.16.0`, `responses 0.26.3` |
| `.github/workflows/check-branch.yml` | krok „Testy Django" → `pytest --cov=src/apps --cov-report=term-missing:skip-covered` |
| `docs/TESTING.md` (nowy) | pełny plan (Faza 0 odhaczona) + fazy 1–5 dla matterhorn1 (unit/integration/e2e) |

## Do zrobienia osobno (nie blokuje)
- pozostałe docs (`HOW_TO_FIX_TESTS.md`, `DJANGO_6_COMPATIBILITY.md`, `FIX_TEST_DATABASES.md`) — komenda `manage.py test` → `pytest`

Tracking: #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)