### PR TITLE
test(matterhorn1): integration — silnik sagi, _bulk_*, watchdog

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -120,8 +120,8 @@ kolejne szybko). `--create-db` wymusza odtworzenie po zmianie migracji.
 | **0** | Infra pytest-django (wyżej)                                                                                                                                                                                    | ✅   |
 | **1** | Pakiet `matterhorn1/tests/`: `factories.py` (buildery ładunków API), `mock_matterhorn.py` (`responses` helpery ITEMS/INVENTORY), `conftest.py` (fixture'y), pierwszy e2e importu + unit `_parse_creation_date` | ✅   |
 | **2** | Unit: `_prepare_product_create/update`, `stock_tracker`, `transaction_logger` (`database_utils` = martwy kod, pominięty)                                                                                       | ✅   |
-| **3** | Integration: `saga.py` (happy + kompensacja), admin `mpd_create`/`assign_mapping`, `_bulk_*`, watchdog                                                                                                         | ⬜   |
-| **4** | E2E: import→`mpd_create`→link po EAN, scenariusze błędów (500 na str. 2, blokada równoległa)                                                                                                                   | ⬜   |
+| **3** | Integration: silnik sagi (kompensacja / propagacja / logi), `_bulk_import_products` + `_bulk_update_inventory`, watchdog                                                                                       | ✅   |
+| **4** | E2E: import→`mpd_create`→link po EAN, scenariusze błędów (500 na str. 2, blokada równoległa), admin `mpd_create`/`assign_mapping`                                                                              | ⬜   |
 | **5** | Próg pokrycia w CI (`--cov-fail-under`), raport, białe plamy                                                                                                                                                   | ⬜   |
 
 Cel pokrycia matterhorn1: **linie ≥ 80%**, `tasks.py` i `saga.py` ≥ 75%.

--- a/src/apps/matterhorn1/tests/tests_integration_bulk_import.py
+++ b/src/apps/matterhorn1/tests/tests_integration_bulk_import.py
@@ -1,0 +1,102 @@
+"""
+Integration: `matterhorn1.tasks._bulk_import_products` / `_bulk_update_inventory`
+— zapis batcha produktów z ITEMS i aktualizacja stanów z INVENTORY.
+
+Serce pojedynczej strony importu (e2e testuje cały pipeline, tu izolujemy
+zachowania brzegowe: brak `creation_date`, ponowny import, nieznany wariant).
+"""
+from __future__ import annotations
+
+import pytest
+
+from matterhorn1.models import (
+    Brand,
+    Category,
+    Product,
+    ProductImage,
+    ProductVariant,
+    StockHistory,
+)
+from matterhorn1.tasks import _bulk_import_products, _bulk_update_inventory
+
+from .factories import api_item, api_variant
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases=["default", "matterhorn1"])]
+DB = "matterhorn1"
+
+
+class TestBulkImportProducts:
+    def test_tworzy_produkty_marke_kategorie_warianty_obrazy(self):
+        res = _bulk_import_products([
+            api_item(id=1, brand="Marko", brand_id="MARKO"),
+            api_item(id=2, brand="Self", brand_id="SELF"),
+        ])
+        assert res["status"] == "success"
+        assert res["imported_count"] == 2
+        assert Product.objects.using(DB).count() == 2
+        assert Brand.objects.using(DB).count() == 2
+        assert Category.objects.using(DB).count() >= 1
+        assert ProductVariant.objects.using(DB).count() == 2
+        assert ProductImage.objects.using(DB).count() == 2
+
+    def test_pomija_element_bez_creation_date(self):
+        item = api_item(id=10)
+        item["creation_date"] = None
+        res = _bulk_import_products([item, api_item(id=11)])
+        assert res["imported_count"] == 1
+        assert set(Product.objects.using(DB).values_list("product_uid", flat=True)) == {11}
+
+    def test_pomija_element_bez_id(self):
+        item = api_item()
+        del item["id"]
+        res = _bulk_import_products([item])
+        assert res["imported_count"] == 0
+        assert Product.objects.using(DB).count() == 0
+
+    def test_ponowny_import_aktualizuje_bez_duplikatu(self):
+        _bulk_import_products([api_item(id=42, name="Stara")])
+        res = _bulk_import_products([api_item(id=42, name="Nowa")])
+
+        assert res["status"] == "success"
+        assert Product.objects.using(DB).filter(product_uid=42).count() == 1
+        assert Product.objects.using(DB).get(product_uid=42).name == "Nowa"
+
+
+class TestBulkUpdateInventory:
+    @pytest.fixture
+    def variant(self):
+        brand = Brand.objects.using(DB).create(brand_id="B", name="B")
+        cat = Category.objects.using(DB).create(category_id="C", name="C")
+        product = Product.objects.using(DB).create(
+            product_uid=500, name="P", brand=brand, category=cat)
+        return ProductVariant.objects.using(DB).create(
+            product=product, variant_uid="8001", name="M", stock=10)
+
+    def test_aktualizuje_stan_i_pisze_historie(self, variant):
+        _bulk_update_inventory([
+            {"id": 500, "inventory": [{"variant_uid": "8001", "stock": "3"}]},
+        ])
+        variant.refresh_from_db()
+        assert variant.stock == 3
+        assert StockHistory.objects.using(DB).filter(variant_uid="8001").count() == 1
+
+    def test_brak_zmiany_stanu_nie_pisze_historii(self, variant):
+        _bulk_update_inventory([
+            {"id": 500, "inventory": [{"variant_uid": "8001", "stock": "10"}]},
+        ])
+        variant.refresh_from_db()
+        assert variant.stock == 10
+        assert StockHistory.objects.using(DB).count() == 0
+
+    def test_nieznany_wariant_jest_pomijany(self, variant):
+        _bulk_update_inventory([
+            {"id": 500, "inventory": [{"variant_uid": "99999", "stock": "0"}]},
+        ])
+        variant.refresh_from_db()
+        assert variant.stock == 10
+
+    def test_nieznany_produkt_jest_pomijany(self, db):
+        # nie rzuca mimo braku produktu 12345
+        _bulk_update_inventory([
+            {"id": 12345, "inventory": [{"variant_uid": "1", "stock": "5"}]},
+        ])

--- a/src/apps/matterhorn1/tests/tests_integration_saga_orchestrator.py
+++ b/src/apps/matterhorn1/tests/tests_integration_saga_orchestrator.py
@@ -1,0 +1,135 @@
+"""
+Integration: `core.saga.BaseSagaOrchestrator` przez `matterhorn1.saga.SagaOrchestrator`.
+
+Wspólny silnik sagi (używany też przez tabu / mada). Kluczowe własności:
+kompensacja cofa zapisy w bazie w odwrotnej kolejności, wynik kroku
+propaguje się do `data` kolejnych kroków, status końcowy = COMPENSATED
+przy błędzie.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.db_routers import _get_matterhorn1_db
+from core.saga import SagaStatus
+from matterhorn1.models import Brand, Saga
+from matterhorn1.saga import SagaOrchestrator
+
+SAGA_DB = _get_matterhorn1_db()  # 'zzz_matterhorn1' w trybie testów
+
+# '__all__' bo core.saga pisze log do aliasu z `_get_matterhorn1_db()`
+# (`zzz_matterhorn1` w trybie testów) — jak legacy tests_saga.py.
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases="__all__")]
+DB = "matterhorn1"
+
+
+def _make_brand(brand_id, **_):
+    b = Brand.objects.using(DB).create(brand_id=brand_id, name=f"B-{brand_id}")
+    return {"created_brand_pk": b.pk}
+
+
+def _delete_brand(brand_id, **_):
+    # matterhorn1.SagaOrchestrator ma merge_result_into_own_step_data=False,
+    # więc compensate dostaje tylko oryginalne `data` kroku (brand_id), nie wynik.
+    Brand.objects.using(DB).filter(brand_id=brand_id).delete()
+
+
+def _noop(**_):
+    return {}
+
+
+def _boom(**_):
+    raise RuntimeError("krok celowo pada")
+
+
+class TestHappyPath:
+    def test_wszystkie_kroki_completed(self):
+        saga = SagaOrchestrator(saga_type="test_ok")
+        saga.add_step("a", _noop, _noop)
+        saga.add_step("b", _noop, _noop)
+
+        result = saga.execute()
+
+        assert result.status == SagaStatus.COMPLETED
+        assert [s.status for s in result.steps] == [SagaStatus.COMPLETED, SagaStatus.COMPLETED]
+
+    def test_log_sagi_zapisany_jako_completed(self):
+        saga = SagaOrchestrator(saga_type="test_log")
+        saga.add_step("a", _noop, _noop)
+        saga.execute()
+
+        row = Saga.objects.using(SAGA_DB).get(saga_id=saga.saga_id)
+        assert row.status == SagaStatus.COMPLETED.value
+
+
+class TestKompensacja:
+    def test_blad_kroku_cofa_wczesniejszy_zapis(self):
+        saga = SagaOrchestrator(saga_type="test_compensate")
+        saga.add_step("create_brand", _make_brand, _delete_brand, {"brand_id": "SAGA1"})
+        saga.add_step("fail", _boom, _noop)
+
+        result = saga.execute()
+
+        assert result.status == SagaStatus.COMPENSATED
+        assert result.error and "celowo pada" in result.error
+        # krok 1 skompensowany → marka usunięta
+        assert not Brand.objects.using(DB).filter(brand_id="SAGA1").exists()
+
+    def test_kompensacja_w_odwrotnej_kolejnosci(self):
+        order = []
+        saga = SagaOrchestrator(saga_type="test_order")
+        saga.add_step("s1", lambda **_: order.append("exec1") or {},
+                      lambda **_: order.append("comp1"))
+        saga.add_step("s2", lambda **_: order.append("exec2") or {},
+                      lambda **_: order.append("comp2"))
+        saga.add_step("s3", _boom, _noop)
+
+        saga.execute()
+
+        assert order == ["exec1", "exec2", "comp2", "comp1"]
+
+    def test_kompensacja_kontynuuje_mimo_bledu_w_compensate(self):
+        saga = SagaOrchestrator(saga_type="test_comp_err")
+        saga.add_step("create_brand", _make_brand, _delete_brand, {"brand_id": "SAGA2"})
+        saga.add_step("bad_comp", _noop, _boom)   # compensate rzuca
+        saga.add_step("fail", _boom, _noop)
+
+        result = saga.execute()
+
+        assert result.status == SagaStatus.COMPENSATED
+        # mimo wyjątku w kompensacji kroku "bad_comp", krok 1 i tak skompensowany
+        assert not Brand.objects.using(DB).filter(brand_id="SAGA2").exists()
+
+    def test_log_sagi_zapisany_jako_compensated(self):
+        saga = SagaOrchestrator(saga_type="test_comp_log")
+        saga.add_step("a", _noop, _noop)
+        saga.add_step("fail", _boom, _noop)
+        saga.execute()
+
+        row = Saga.objects.using(SAGA_DB).get(saga_id=saga.saga_id)
+        assert row.status == SagaStatus.COMPENSATED.value
+        assert row.failed_step == "fail"
+
+
+class TestPropagacjaWyniku:
+    def test_wynik_kroku_wypelnia_none_w_data_kolejnego(self):
+        seen = {}
+        saga = SagaOrchestrator(saga_type="test_propagate")
+        saga.add_step("s1", lambda **_: {"mpd_product_id": 777}, _noop)
+        saga.add_step("s2", lambda **d: seen.update(d) or {}, _noop,
+                      {"mpd_product_id": None})
+
+        saga.execute()
+
+        assert seen["mpd_product_id"] == 777
+
+    def test_nie_nadpisuje_juz_ustawionej_wartosci(self):
+        seen = {}
+        saga = SagaOrchestrator(saga_type="test_no_override")
+        saga.add_step("s1", lambda **_: {"mpd_product_id": 777}, _noop)
+        saga.add_step("s2", lambda **d: seen.update(d) or {}, _noop,
+                      {"mpd_product_id": 5})
+
+        saga.execute()
+
+        assert seen["mpd_product_id"] == 5

--- a/src/apps/matterhorn1/tests/tests_integration_watchdog.py
+++ b/src/apps/matterhorn1/tests/tests_integration_watchdog.py
@@ -1,0 +1,54 @@
+"""
+Integration: `matterhorn1.tasks.watchdog_import_healthcheck` — sprząta
+zawieszone importy ITEMS (status `running` bez postępu > 15 min → `error`).
+
+Celery Beat woła to co 5 min.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from matterhorn1.models import ApiSyncLog
+from matterhorn1.tasks import watchdog_import_healthcheck
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases=["default", "matterhorn1"])]
+
+
+def _running_import(minutes_ago: int, **fields) -> ApiSyncLog:
+    row = ApiSyncLog.objects.create(sync_type="items_import", status="running", **fields)
+    ApiSyncLog.objects.filter(pk=row.pk).update(
+        started_at=timezone.now() - timedelta(minutes=minutes_ago))
+    row.refresh_from_db()
+    return row
+
+
+def test_ghost_task_bez_postepu_oznaczony_jako_error():
+    ghost = _running_import(20)  # 20 min, zero postępu
+
+    watchdog_import_healthcheck.apply()
+
+    ghost.refresh_from_db()
+    assert ghost.status == "error"
+    assert "Ghost" in (ghost.error_details or "")
+
+
+def test_swiezy_running_nie_jest_ruszany():
+    fresh = _running_import(5)  # < 15 min
+
+    watchdog_import_healthcheck.apply()
+
+    fresh.refresh_from_db()
+    assert fresh.status == "running"
+
+
+def test_stary_running_z_postepem_nie_jest_ghostem():
+    working = _running_import(20, records_created=120, current_page=3)
+
+    watchdog_import_healthcheck.apply()
+
+    working.refresh_from_db()
+    # ma postęp → nie jest oznaczany jako ghost (brak wartości)
+    assert working.error_details != "Ghost task - brak postępu przez 15 minut"


### PR DESCRIPTION
**Faza 3** planu `docs/TESTING.md` (tracking #208). Bazuje na #212.

**160 passed** lokalnie (141 + 19 nowych).

## Nowe pliki (`matterhorn1/tests/`)
| Plik | Testów | Zakres |
|---|---|---|
| `tests_integration_saga_orchestrator.py` | 8 | `core.saga` przez `matterhorn1.SagaOrchestrator`: happy path, **kompensacja cofa realny zapis w bazie**, odwrotna kolejność, kontynuacja mimo błędu w `compensate_func`, propagacja wyniku kroku do `data` kolejnych, log `Saga` (COMPLETED / COMPENSATED / `failed_step`) |
| `tests_integration_bulk_import.py` | 8 | `_bulk_import_products` (marka/kategoria/warianty/obrazy, pomija bez `creation_date` / bez `id`, ponowny import = update bez duplikatu); `_bulk_update_inventory` (stan + `StockHistory`, brak zmiany = brak historii, nieznany wariant/produkt pomijany) |
| `tests_integration_watchdog.py` | 3 | `watchdog_import_healthcheck` — ghost `running` (>15 min, zero postępu) → `error`; świeży i z postępem nietknięty |

## Znalezisko (nie w zakresie)
`SagaService._delete_mpd_product` (kompensacja kroku 1 „utwórz produkt MPD") usuwa produkt przez **HTTP `requests.delete(MPD_API_URL/...)`**, mimo że krok tworzący pisze bezpośrednio przez ORM. Jeśli API MPD jest niedostępne w trakcie kompensacji → produkt MPD zostaje osierocony (funkcja łyka wyjątek i zwraca `{}`). Dlatego integration `saga.py` testuje **silnik** na czystych krokach, a nie `create_product_with_mapping` end-to-end.

## Dalej
Faza 4 (e2e: import→`mpd_create`→link po EAN, błędy: 500 na str. 2, blokada równoległa, admin `mpd_create`/`assign_mapping`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)