### PR TITLE
test(matterhorn1): e2e scenariuszy błędów importu + admin assign_mapping

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -115,14 +115,14 @@ kolejne szybko). `--create-db` wymusza odtworzenie po zmianie migracji.
 
 ## Fazy realizacji
 
-| Faza  | Zakres                                                                                                                                                                                                         | Stan |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| **0** | Infra pytest-django (wyżej)                                                                                                                                                                                    | ✅   |
-| **1** | Pakiet `matterhorn1/tests/`: `factories.py` (buildery ładunków API), `mock_matterhorn.py` (`responses` helpery ITEMS/INVENTORY), `conftest.py` (fixture'y), pierwszy e2e importu + unit `_parse_creation_date` | ✅   |
-| **2** | Unit: `_prepare_product_create/update`, `stock_tracker`, `transaction_logger` (`database_utils` = martwy kod, pominięty)                                                                                       | ✅   |
-| **3** | Integration: silnik sagi (kompensacja / propagacja / logi), `_bulk_import_products` + `_bulk_update_inventory`, watchdog                                                                                       | ✅   |
-| **4** | E2E: import→`mpd_create`→link po EAN, scenariusze błędów (500 na str. 2, blokada równoległa), admin `mpd_create`/`assign_mapping`                                                                              | ⬜   |
-| **5** | Próg pokrycia w CI (`--cov-fail-under`), raport, białe plamy                                                                                                                                                   | ⬜   |
+| Faza  | Zakres                                                                                                                                                                                                                          | Stan |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| **0** | Infra pytest-django (wyżej)                                                                                                                                                                                                     | ✅   |
+| **1** | Pakiet `matterhorn1/tests/`: `factories.py` (buildery ładunków API), `mock_matterhorn.py` (`responses` helpery ITEMS/INVENTORY), `conftest.py` (fixture'y), pierwszy e2e importu + unit `_parse_creation_date`                  | ✅   |
+| **2** | Unit: `_prepare_product_create/update`, `stock_tracker`, `transaction_logger` (`database_utils` = martwy kod, pominięty)                                                                                                        | ✅   |
+| **3** | Integration: silnik sagi (kompensacja / propagacja / logi), `_bulk_import_products` + `_bulk_update_inventory`, watchdog                                                                                                        | ✅   |
+| **4** | E2E błędów: chwilowy 500 na str. 2, blokada równoległa, wznowienie od strony, pusta odpowiedź, produkt bez wariantów; admin `assign_mapping`. `mpd_create` (7-krokowa saga + upload + HTTP kompensacja) — do osobnego podejścia | ✅   |
+| **5** | Próg pokrycia w CI (`--cov-fail-under`), raport, białe plamy                                                                                                                                                                    | ⬜   |
 
 Cel pokrycia matterhorn1: **linie ≥ 80%**, `tasks.py` i `saga.py` ≥ 75%.
 

--- a/src/apps/matterhorn1/tests/mock_matterhorn.py
+++ b/src/apps/matterhorn1/tests/mock_matterhorn.py
@@ -30,24 +30,32 @@ def _base_url() -> str:
     return getattr(settings, "MATTERHORN_API_URL", "https://matterhorn.pl").rstrip("/")
 
 
-def _paginated_callback(pages: list[list[dict]]):
+def _paginated_callback(pages: list[list[dict]], transient_errors: dict[int, list[int]] | None = None):
+    """`transient_errors` = {numer_strony: [status, status, ...]} — kolejne
+    trafienia w tę stronę zwracają te statusy (po wyczerpaniu: normalna treść).
+    Do symulacji chwilowego błędu API, po którym import się dogania."""
+    errors = {p: list(codes) for p, codes in (transient_errors or {}).items()}
+
     def _cb(request):
         try:
             page = int(request.params.get("page", "1"))
         except (TypeError, ValueError):
             page = 1
+        if errors.get(page):
+            return (errors[page].pop(0), {}, "")
         idx = page - 1  # API 1-indeksowane
         body = pages[idx] if 0 <= idx < len(pages) else []
         return (200, {"Content-Type": "application/json"}, json.dumps(body))
     return _cb
 
 
-def mock_items(rsps, pages: list[list[dict]]) -> None:
-    """`pages` = lista stron, każda to lista elementów ITEMS."""
+def mock_items(rsps, pages: list[list[dict]], transient_errors: dict[int, list[int]] | None = None) -> None:
+    """`pages` = lista stron, każda to lista elementów ITEMS.
+    `transient_errors` — patrz `_paginated_callback`."""
     rsps.add_callback(
         responses.GET,
         f"{_base_url()}{ITEMS_PATH}",
-        callback=_paginated_callback(pages),
+        callback=_paginated_callback(pages, transient_errors),
         content_type="application/json",
     )
 

--- a/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
+++ b/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
@@ -1,0 +1,87 @@
+"""
+E2E: przypadki brzegowe / błędy pipeline'u importu Matterhorn.
+
+Bazuje na infrastrukturze z tests_e2e_import.py (mock `responses`,
+`prior_items_sync`, `no_sleep`).
+"""
+from __future__ import annotations
+
+import pytest
+
+from matterhorn1.models import ApiSyncLog, Product, ProductVariant
+from matterhorn1.tasks import full_import_and_update
+
+from .mock_matterhorn import mock_inventory, mock_items
+
+pytestmark = [pytest.mark.e2e, pytest.mark.django_db(databases=["default", "matterhorn1"])]
+
+
+def test_chwilowy_500_na_stronie_2_odzyskuje_bez_duplikatu(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    # strona 1: 1 produkt; strona 2: 500 raz, potem pusto (koniec)
+    mock_items(mocked_responses, [[api_item(id=3001)], []],
+               transient_errors={2: [500]})
+    mock_inventory(mocked_responses, [[]])
+
+    result = full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert result["status"] == "success"
+    assert Product.objects.using("matterhorn1").filter(product_uid=3001).count() == 1
+
+
+def test_blokada_rownoleglego_importu_zwraca_skipped(
+    matterhorn_api, prior_items_sync, monkeypatch
+):
+    monkeypatch.setattr("matterhorn1.tasks.cache.add", lambda *a, **k: False)
+
+    result = full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "already_running"
+    assert Product.objects.using("matterhorn1").count() == 0
+
+
+def test_wznowienie_od_przerwanej_strony(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    # poprzedni przerwany import ITEMS zatrzymał się na stronie 3 (świeży, < 24 h)
+    interrupted = ApiSyncLog.objects.using("matterhorn1").create(
+        sync_type="items_import", status="error")
+    ApiSyncLog.objects.using("matterhorn1").filter(pk=interrupted.pk).update(current_page=3)
+
+    # strona 3 (idx 2) ma produkt, strona 4 pusta = koniec
+    mock_items(mocked_responses, [[], [], [api_item(id=4001)], []])
+    mock_inventory(mocked_responses, [[]])
+
+    full_import_and_update(auto_continue=False, dry_run=False)
+
+    item_pages = [int(c.request.params["page"]) for c in mocked_responses.calls
+                  if "/B2BAPI/ITEMS/?" in c.request.url]
+    assert item_pages[0] == 3  # start od przerwanej strony, nie od 1
+    assert Product.objects.using("matterhorn1").filter(product_uid=4001).exists()
+
+
+def test_pusta_odpowiedz_na_stronie_1_konczy_bez_produktow(
+    matterhorn_api, mocked_responses, prior_items_sync
+):
+    mock_items(mocked_responses, [[]])
+    mock_inventory(mocked_responses, [[]])
+
+    result = full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert result["status"] == "success"
+    assert Product.objects.using("matterhorn1").count() == 0
+
+
+def test_produkt_bez_wariantow_i_obrazow_importuje_sie(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    item = api_item(id=5501, variants=[], images=[])
+    mock_items(mocked_responses, [[item], []])
+    mock_inventory(mocked_responses, [[]])
+
+    full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert Product.objects.using("matterhorn1").filter(product_uid=5501).exists()
+    assert ProductVariant.objects.using("matterhorn1").filter(product__product_uid=5501).count() == 0

--- a/src/apps/matterhorn1/tests/tests_integration_admin.py
+++ b/src/apps/matterhorn1/tests/tests_integration_admin.py
@@ -1,0 +1,65 @@
+"""
+Integration: akcje admina `matterhorn1.ProductAdmin` łączące produkt
+matterhorn1 z MPD.
+
+`mpd_create` (nowy produkt MPD przez sagę) jest ciężki — 7-krokowa saga
++ upload zdjęć + kompensacja przez HTTP; e2e tego zostaje do osobnego
+podejścia. Tu lżejsze `assign_mapping` (podpięcie istniejącego produktu MPD).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib import admin
+from django.test import RequestFactory
+
+from matterhorn1.admin import ProductAdmin
+from matterhorn1.models import Brand, Product
+from MPD.models import Products as MpdProducts
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases="__all__")]
+
+
+@pytest.fixture
+def product_admin():
+    return ProductAdmin(Product, admin.site)
+
+
+@pytest.fixture
+def mh_product():
+    brand = Brand.objects.using("matterhorn1").create(brand_id="B", name="Marko")
+    return Product.objects.using("matterhorn1").create(
+        product_uid=990001, name="Produkt MH", brand=brand)
+
+
+@pytest.fixture
+def mpd_product():
+    return MpdProducts.objects.using(
+        _mpd_db()).create(name="Produkt MPD do podpięcia")
+
+
+def _mpd_db():
+    from django.conf import settings
+    return "zzz_MPD" if "zzz_MPD" in settings.DATABASES else "MPD"
+
+
+class TestAssignMapping:
+    def test_ustawia_mapowanie_na_produkcie_matterhorn(self, product_admin, mh_product, mpd_product):
+        request = RequestFactory().post("/", data={})
+
+        response = product_admin.assign_mapping(request, mh_product.id, mpd_product.id)
+
+        payload = json.loads(response.content)
+        assert payload["success"] is True
+
+        mh_product.refresh_from_db()
+        assert mh_product.mapped_product_uid == mpd_product.id
+        assert mh_product.is_mapped is True
+
+    def test_get_zwraca_blad_metody(self, product_admin, mh_product, mpd_product):
+        request = RequestFactory().get("/")
+
+        response = product_admin.assign_mapping(request, mh_product.id, mpd_product.id)
+
+        assert json.loads(response.content)["success"] is False


### PR DESCRIPTION
**Faza 4** planu `docs/TESTING.md` (tracking #208). Bazuje na #213.

**167 passed** lokalnie (160 + 7 nowych).

## Nowe pliki (`matterhorn1/tests/`)
| Plik | Testów | Zakres |
|---|---|---|
| `tests_e2e_import_errors.py` | 5 | chwilowy 500 na str. 2 → odzyskanie bez duplikatu · blokada równoległego importu → `skipped` · wznowienie od przerwanej strony (`current_page`) · pusta odpowiedź na str. 1 · produkt bez wariantów/obrazów |
| `tests_integration_admin.py` | 2 | `ProductAdmin.assign_mapping` — ustawia `mapped_product_uid` / `is_mapped`; GET → błąd metody |

`mock_matterhorn._paginated_callback` dostał `transient_errors={strona: [statusy]}` do symulacji chwilowego błędu API.

`mpd_create` (7-krokowa saga + upload zdjęć + kompensacja przez HTTP) świadomie poza zakresem — do osobnego podejścia.

## Znalezisko → #214
Trwały 5xx na jednej stronie ITEMS = **nieskończona pętla** w `_import_products_from_items`: `page` rośnie tylko przy sukcesie, po wyczerpaniu 10 prób `break` wraca do `while imported_count < max_products`, `attempt` resetuje się → ta sama martwa strona w kółko (do soft-timeoutu Celery). 404 ma jawną obsługę, 5xx nie.

## Stan planu #208
Faza 0–4 ✅. Zostaje **Faza 5** — `--cov-fail-under` w CI + raport pokrycia + uzupełnienie białych plam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)