### PR TITLE
fix(matterhorn): przerwij import ITEMS zamiast pętlić na trwałym 5xx

### DIFF
--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -75,6 +75,7 @@ def full_import_and_update(self, start_id=None, max_products=200000,
     total_imported = 0
     total_updated = 0
     iteration = 0
+    items_error = None  # ustawiane gdy _import_products_from_items zwróci błąd
 
     try:
         logger.info(
@@ -137,6 +138,7 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             elif items_result['status'] != 'success':
                 logger.error(
                     f"❌ Błąd importu ITEMS w iteracji {iteration}: {items_result.get('error')}")
+                items_error = items_result.get('error') or 'items import failed'
                 break
 
             logger.info(
@@ -188,6 +190,19 @@ def full_import_and_update(self, start_id=None, max_products=200000,
                         total_imported)
             logger.info(
                 "📊 Łącznie zaktualizowano: %s produktów w INVENTORY", total_updated)
+
+        if items_error:
+            # import ITEMS padł na którejś stronie (5xx/sieć po wyczerpaniu prób).
+            # NIE oznaczamy jako 'completed' — current_page zostaje, kolejny tick
+            # Celery Beat wznowi od tej strony (patrz _get_last_items_page).
+            return {
+                'status': 'error',
+                'error': items_error,
+                'total_imported': total_imported,
+                'total_updated': total_updated,
+                'iterations': iteration,
+                'task_id': task_id_value,
+            }
 
         task_completed_successfully = True
 
@@ -289,6 +304,11 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
         while imported_count < max_products:
             max_attempts = 10
             attempt = 1
+            # Czy tę stronę udało się pobrać+zapisać. Bez tego przy trwałym 5xx
+            # (page rośnie tylko po sukcesie) outer while pętli w nieskończoność
+            # na martwej stronie aż do soft-timeoutu Celery.
+            page_succeeded = False
+            end_of_data = False
 
             while attempt <= max_attempts:
                 try:
@@ -374,6 +394,7 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                                         imported_count += 1
 
                             page += 1
+                            page_succeeded = True
                             # Aktualizuj current_page w bazie danych
                             if not dry_run:
                                 _update_items_import_status(
@@ -397,6 +418,7 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
 
                     elif response.status_code == 404:
                         logger.info("📊 Strona nie istnieje - koniec danych")
+                        end_of_data = True
                         break
                     else:
                         logger.warning(f"⚠️ Błąd API {response.status_code}")
@@ -430,9 +452,26 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                             "❌ Osiągnięto maksymalną liczbę prób połączenia")
                         break
 
-            # Jeśli osiągnięto maksymalną liczbę prób, przerwij główną pętlę
-            if attempt > max_attempts:
-                break
+            # Po pętli retry: strona albo się udała (page += 1, lecimy dalej),
+            # albo API zwróciło 404 = koniec danych, albo wyczerpaliśmy próby na
+            # błędzie sieci/5xx/JSON. `page` rośnie TYLKO po sukcesie, więc bez
+            # tego rozgałęzienia outer while pętliłby w kółko na tej samej stronie.
+            if page_succeeded:
+                continue  # następna strona
+            if end_of_data:
+                return {
+                    'status': 'completed',
+                    'imported_count': imported_count,
+                    'reason': 'page_404',
+                }
+            logger.error(
+                f"❌ Strona {page} nieosiągalna po {max_attempts} próbach - przerywam import "
+                f"(current_page={page} zachowany do wznowienia)")
+            return {
+                'status': 'error',
+                'imported_count': imported_count,
+                'error': f'Strona {page} nieosiągalna po {max_attempts} próbach (błąd API/sieci)',
+            }
 
         # Zaktualizuj status importu na 'success' po zakończeniu
         if not dry_run:

--- a/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
+++ b/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
@@ -30,6 +30,28 @@ def test_chwilowy_500_na_stronie_2_odzyskuje_bez_duplikatu(
     assert Product.objects.using("matterhorn1").filter(product_uid=3001).count() == 1
 
 
+def test_trwaly_500_na_stronie_przerywa_import_zamiast_petlic(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    """#214: przed fixem `page` rosło tylko po sukcesie, więc trwały 5xx =
+    nieskończona pętla aż do soft-timeoutu Celery. Teraz: po wyczerpaniu
+    prób na stronie import kończy się błędem, current_page zachowany."""
+    # strona 1 OK, strona 2 zawsze 500 (więcej niż 10 prób retry).
+    # INVENTORY nie jest wołane — błąd ITEMS przerywa przed tym krokiem.
+    mock_items(mocked_responses, [[api_item(id=3100)], []],
+               transient_errors={2: [500] * 15})
+
+    result = full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert result["status"] == "error"
+
+    assert Product.objects.using("matterhorn1").filter(product_uid=3100).count() == 1
+    last = ApiSyncLog.objects.using("matterhorn1").filter(
+        sync_type="items_import").order_by("-started_at").first()
+    assert last.status == "error"
+    assert last.current_page == 2  # zachowane do wznowienia
+
+
 def test_blokada_rownoleglego_importu_zwraca_skipped(
     matterhorn_api, prior_items_sync, monkeypatch
 ):


### PR DESCRIPTION
Fixes #214.

## Problem
`_import_products_from_items`: numer strony rośnie **tylko po sukcesie**. Po wyczerpaniu 10 prób retry na stronie (trwały 5xx / błąd sieci / błąd JSON) `break` z inner loop, a outer `while imported_count < max_products` wraca na tę samą martwą stronę — **w nieskończoność**, aż do soft-timeoutu Celery (55 min). Warunek `if attempt > max_attempts` był martwy (nieosiągalny — przy `attempt == max_attempts` jest `else: break`, nie inkrementacja).

Dodatkowo `full_import_and_update` na `items_result['status'] == 'error'` robił `break` i mimo to `return {'status': 'success'}` → `ApiSyncLog` oznaczany jako `completed`.

## Fix
`_import_products_from_items` — flagi `page_succeeded` / `end_of_data` po pętli retry:
| wynik strony | akcja |
|---|---|
| sukces | `continue` (następna strona) |
| 404 | `return completed` (reason `page_404`) |
| wyczerpane próby (5xx/sieć/JSON) | `return error` — `current_page` zachowany, kolejny tick Celery Beat wznawia od tej strony |

`full_import_and_update` — `items_error` propagowane na poziom taska (`return {'status': 'error'}`, `ApiSyncLog` = `error` z `current_page`).

## Test
`tests_e2e_import_errors.test_trwaly_500_na_stronie_przerywa_import_zamiast_petlic` — strona 2 zawsze 500 → import kończy się `error`, produkt ze strony 1 zapisany, `current_page == 2`. **187 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)