### PR TITLE
test(matterhorn1): e2e mpd_create + bulk mapping

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -200,7 +200,7 @@ jobs:
         run: >-
           pytest
           --cov=src/apps/matterhorn1 --cov-report=term-missing:skip-covered
-          --cov-fail-under=48
+          --cov-fail-under=51
 
   check-code-quality:
     name: Sprawdź jakość kodu (linting i formatowanie)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -129,28 +129,28 @@ kolejne szybko). `--create-db` wymusza odtworzenie po zmianie migracji.
 Metryka liczy tylko kod produkcyjny (`omit` w `pyproject.toml`: testy,
 migracje, `management/commands/*`, `database_utils*`, `*_example.py`).
 
-| Moduł                                | Cov       |                                                                                                |
-| ------------------------------------ | --------- | ---------------------------------------------------------------------------------------------- |
-| `models.py`                          | 93%       | ✅                                                                                             |
-| `transaction_logger.py`              | 84%       | ✅                                                                                             |
-| `saga_variants.py`                   | 83%       | ✅                                                                                             |
-| `serializers.py`                     | 77%       |                                                                                                |
-| `views_secure.py`                    | 70%       |                                                                                                |
-| `stock_tracker.py`                   | 68%       | (był 36%)                                                                                      |
-| `tasks.py`                           | 63%       |                                                                                                |
-| `saga.py`                            | 43%       | (był 18%) — `SagaService` kroki pokryte, cały `create_product_with_mapping` + upload zdjęć nie |
-| `admin.py`                           | 30%       | 903 stmt — osobny epik                                                                         |
-| `views.py`                           | 24%       | 394 stmt — legacy, osobny epik                                                                 |
-| `defs_db.py` / `bestsellers_data.py` | 27% / 14% |                                                                                                |
-| **TOTAL**                            | **51%**   | próg CI: 48% (ratchet, nie cel)                                                                |
+| Moduł                                | Cov       |                                                                                                                                                                                                                                                                                    |
+| ------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `models.py`                          | 93%       | ✅                                                                                                                                                                                                                                                                                 |
+| `transaction_logger.py`              | 84%       | ✅                                                                                                                                                                                                                                                                                 |
+| `saga_variants.py`                   | 83%       | ✅                                                                                                                                                                                                                                                                                 |
+| `serializers.py`                     | 77%       |                                                                                                                                                                                                                                                                                    |
+| `views_secure.py`                    | 70%       |                                                                                                                                                                                                                                                                                    |
+| `stock_tracker.py`                   | 68%       |                                                                                                                                                                                                                                                                                    |
+| `tasks.py`                           | 64%       |                                                                                                                                                                                                                                                                                    |
+| `saga.py`                            | 49%       | `SagaService` kroki + `mpd_create` happy path/kompensacja pokryte (był 18%)                                                                                                                                                                                                        |
+| `admin.py`                           | 40%       | 903 stmt — `mpd_create`, `assign_mapping`, `bulk_map_to_mpd`, `auto_map_variants` pokryte (był 30%); `bulk_create_mpd_action`/`views.py`-owe akcje zostają — #218                                                                                                                  |
+| `views.py`                           | 24%       | 394 stmt — **nie martwy kod**: `views.py` (legacy, mniej zabezpieczone) i `views_secure.py` (hardened) to dwa równoległe, oba routowane w `urls.py` API — do zweryfikowania, czy legacy da się wyłączyć zamiast testować (patrz `fix/lock-legacy-api-endpoints` w historii) — #218 |
+| `defs_db.py` / `bestsellers_data.py` | 27% / 14% |                                                                                                                                                                                                                                                                                    |
+| **TOTAL**                            | **54%**   | próg CI: 51% (ratchet, nie cel)                                                                                                                                                                                                                                                    |
 
-**Cel „linie ≥ 80%" jest poza zakresem tego planu** — wymaga pokrycia
-`admin.py` (2085 LOC akcji admina) i `views.py` (legacy widoki), co jest
-osobnym, dużym zadaniem. Logika krytyczna (import, saga engine, stock
-tracking, serializery, modele) jest w przedziale 63–93%.
+**Cel „linie ≥ 80%" jest poza zakresem tego planu** — wymaga pokrycia reszty
+`admin.py` i decyzji o `views.py` (legacy vs `views_secure.py`) — [#218](https://github.com/pawlo884/nc/issues/218).
+Logika krytyczna (import, saga engine, stock tracking, serializery, modele)
+jest w przedziale 64–93%.
 
 **Podnoszenie progu / dalej:** dopisać ścieżki innych apek do `--cov` w
-`check-branch.yml` gdy dostaną testy; osobny epik na `admin.py` + `views.py`.
+`check-branch.yml` gdy dostaną testy; reszta `admin.py` + decyzja o `views.py` w #218.
 
 ### Struktura `matterhorn1/tests/`
 

--- a/src/apps/matterhorn1/tests/tests_e2e_admin_mpd_create.py
+++ b/src/apps/matterhorn1/tests/tests_e2e_admin_mpd_create.py
@@ -1,0 +1,122 @@
+"""
+E2E: `ProductAdmin.mpd_create` — tworzenie produktu MPD z formularza przez
+7-krokową `SagaService.create_product_with_mapping`.
+
+`transaction=True`: kod pod testem miesza konwencje dostępu do baz — bare
+`Product.objects.get()` (matterhorn1) idzie w testach do aliasu `default`
+(routery wyłączone), ale krok uploadu zdjęć czyta `connections['matterhorn1']`
+raw SQL. Bez prawdziwych commitów (`transaction=True`) te dwie strony nie
+widziałyby nawzajem swoich zapisów — patrz `docs/TESTING.md` (gotcha
+multi-DB) i notatka w PR #216. Wolniejsze niż zwykły `django_db`, ale to
+jedyny sposób na realny e2e tego przepływu bez mockowania połowy sagi.
+
+Produkt matterhorn bez zdjęć → krok 7 (`_upload_product_images`) jest
+no-opem, nie trzeba mockować S3/MinIO. Bez `mpd_size_category` w POST kroki
+4–6 (paths/fabric/warianty) są pomijane przez samą sagę (warunkowe
+`saga.add_step`) — warianty mają już pokrycie w `tests_saga_variants.py`.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from django.contrib import admin
+from django.test import RequestFactory
+
+from matterhorn1.admin import ProductAdmin
+from matterhorn1.models import Brand, Product
+from MPD.models import Attributes, ProductAttribute
+from MPD.models import Products as MpdProducts
+
+pytestmark = [pytest.mark.e2e, pytest.mark.django_db(transaction=True, databases="__all__")]
+MPD_DB = "MPD"
+
+
+@pytest.fixture
+def product_admin():
+    return ProductAdmin(Product, admin.site)
+
+
+@pytest.fixture
+def mh_product():
+    brand = Brand.objects.using("matterhorn1").create(brand_id="MPDC", name="Marko")
+    return Product.objects.using("matterhorn1").create(
+        product_uid=800001, name="Produkt do mpd_create", brand=brand)
+
+
+class TestMpdCreateHappyPath:
+    def test_tworzy_produkt_mpd_i_ustawia_mapping(self, product_admin, mh_product):
+        request = RequestFactory().post("/", data={
+            "mpd_name": "Kostium z formularza",
+            "mpd_description": "Opis",
+            "mpd_brand": "Marko",
+        })
+
+        response = product_admin.mpd_create(request, mh_product.id)
+
+        payload = json.loads(response.content)
+        assert payload["success"] is True, payload
+
+        product = MpdProducts.objects.using(MPD_DB).get(name="Kostium z formularza")
+        assert product.brand.name == "Marko"
+        mh_product.refresh_from_db()
+        assert mh_product.mapped_product_uid == product.id
+        assert mh_product.is_mapped is True
+
+    def test_dodaje_atrybuty(self, product_admin, mh_product):
+        attr = Attributes.objects.using(MPD_DB).create(name="usztywniane miseczki")
+        request = RequestFactory().post("/", data={
+            "mpd_name": "Z atrybutem",
+            "mpd_attributes": [str(attr.id)],
+        })
+
+        response = product_admin.mpd_create(request, mh_product.id)
+        assert json.loads(response.content)["success"] is True
+
+        product = MpdProducts.objects.using(MPD_DB).get(name="Z atrybutem")
+        assert ProductAttribute.objects.using(MPD_DB).filter(
+            product_id=product.id, attribute_id=attr.id).exists()
+
+
+class TestMpdCreateValidation:
+    def test_brak_nazwy_zwraca_blad_bez_efektow(self, product_admin, mh_product):
+        request = RequestFactory().post("/", data={})
+
+        response = product_admin.mpd_create(request, mh_product.id)
+
+        assert json.loads(response.content)["success"] is False
+        mh_product.refresh_from_db()
+        assert mh_product.mapped_product_uid is None
+
+    def test_get_zwraca_blad_metody(self, product_admin, mh_product):
+        request = RequestFactory().get("/")
+        response = product_admin.mpd_create(request, mh_product.id)
+        assert json.loads(response.content)["success"] is False
+
+
+class TestMpdCreateCompensation:
+    def test_blad_w_kroku_atrybutow_cofa_mapping_ale_nie_produkt_mpd(
+        self, product_admin, mh_product
+    ):
+        """Krok 3 (atrybuty) rzuca -> saga kompensuje krok 2 (mapping, przez
+        ORM - działa) i krok 1 (produkt MPD, przez HTTP `requests.delete` -
+        w testach nie ma dokąd polecieć, fail-open łyka wyjątek). Produkt MPD
+        zostaje osierocony - to udokumentowane zachowanie z PR #213, nie cel
+        tego testu, tylko dowód że saga faktycznie próbuje kompensować."""
+        attr = Attributes.objects.using(MPD_DB).create(name="cecha")
+        request = RequestFactory().post("/", data={
+            "mpd_name": "Ma się nie udać",
+            "mpd_attributes": [str(attr.id)],
+        })
+
+        with patch("matterhorn1.saga.SagaService._add_mpd_attributes",
+                   side_effect=RuntimeError("boom")), \
+             patch("requests.delete", side_effect=RuntimeError("brak sieci w testach")):
+            response = product_admin.mpd_create(request, mh_product.id)
+
+        assert json.loads(response.content)["success"] is False
+
+        mh_product.refresh_from_db()
+        assert mh_product.mapped_product_uid is None  # krok 2 skompensowany
+        assert MpdProducts.objects.using(MPD_DB).filter(name="Ma się nie udać").exists()

--- a/src/apps/matterhorn1/tests/tests_integration_admin_bulk.py
+++ b/src/apps/matterhorn1/tests/tests_integration_admin_bulk.py
@@ -1,0 +1,110 @@
+"""
+Integration: `ProductAdmin.bulk_map_to_mpd` / `auto_map_variants` (endpointy
+JSON). `_auto_map_variants` (rzeczywiste tworzenie wariantów w MPD) jest
+zamockowane — jego własna logika ma osobne pokrycie w
+`tests_admin_linking.py` (dispatch taska linkowania po commicie). Tu
+testujemy warstwę widoku: walidację, kształt odpowiedzi, obsługę błędów.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from django.contrib import admin
+from django.test import RequestFactory
+
+from matterhorn1.admin import ProductAdmin
+from matterhorn1.models import Brand, Product
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases=["default", "matterhorn1"])]
+
+
+@pytest.fixture
+def product_admin():
+    return ProductAdmin(Product, admin.site)
+
+
+@pytest.fixture
+def mh_product():
+    brand = Brand.objects.create(brand_id="BULK", name="Bulk Brand")
+    return Product.objects.create(product_uid=810001, name="Bulk product", brand=brand)
+
+
+class TestAutoMapVariantsView:
+    def test_produkt_niezmapowany_zwraca_blad(self, product_admin, mh_product):
+        request = RequestFactory().post("/")
+
+        response = product_admin.auto_map_variants(request, mh_product.id)
+
+        payload = json.loads(response.content)
+        assert payload["success"] is False
+        assert "zmapowany" in payload["error"]
+
+    def test_produkt_zmapowany_woła_auto_map_i_zwraca_liste(self, product_admin, mh_product):
+        mh_product.mapped_product_uid = 999
+        mh_product.is_mapped = True
+        mh_product.save()
+
+        request = RequestFactory().post("/")
+        with patch.object(ProductAdmin, "_auto_map_variants", return_value=[1, 2, 3]) as mocked:
+            response = product_admin.auto_map_variants(request, mh_product.id)
+
+        mocked.assert_called_once_with(mh_product, 999)
+        payload = json.loads(response.content)
+        assert payload["success"] is True
+        assert payload["variants"] == [1, 2, 3]
+
+    def test_get_zwraca_blad_metody(self, product_admin, mh_product):
+        response = product_admin.auto_map_variants(RequestFactory().get("/"), mh_product.id)
+        assert json.loads(response.content)["success"] is False
+
+
+class TestBulkMapToMpd:
+    def test_mapuje_i_liczy_sukcesy(self, product_admin, mh_product):
+        body = json.dumps({"mappings": [{"product_id": mh_product.id, "mpd_product_id": 42}]})
+        request = RequestFactory().post("/", data=body, content_type="application/json")
+
+        with patch.object(ProductAdmin, "_auto_map_variants", return_value=[]):
+            response = product_admin.bulk_map_to_mpd(request)
+
+        payload = json.loads(response.content)
+        assert payload["success"] is True
+        assert "1" in payload["message"]
+
+        mh_product.refresh_from_db()
+        assert mh_product.mapped_product_uid == 42
+        assert mh_product.is_mapped is True
+
+    def test_pomija_mapowanie_bez_id(self, product_admin, mh_product):
+        body = json.dumps({"mappings": [{"product_id": None, "mpd_product_id": 42}]})
+        request = RequestFactory().post("/", data=body, content_type="application/json")
+
+        with patch.object(ProductAdmin, "_auto_map_variants") as mocked:
+            response = product_admin.bulk_map_to_mpd(request)
+
+        mocked.assert_not_called()
+        assert json.loads(response.content)["success"] is True
+        mh_product.refresh_from_db()
+        assert mh_product.mapped_product_uid is None
+
+    def test_blad_pojedynczego_mapowania_nie_przerywa_reszty(self, product_admin, mh_product):
+        other = Product.objects.create(product_uid=810002, name="Drugi")
+        body = json.dumps({"mappings": [
+            {"product_id": 99999999, "mpd_product_id": 1},   # nie istnieje -> błąd
+            {"product_id": other.id, "mpd_product_id": 2},   # ten ma się udać
+        ]})
+        request = RequestFactory().post("/", data=body, content_type="application/json")
+
+        with patch.object(ProductAdmin, "_auto_map_variants", return_value=[]):
+            response = product_admin.bulk_map_to_mpd(request)
+
+        payload = json.loads(response.content)
+        assert payload["success"] is True
+        assert len(payload["errors"]) == 1
+        other.refresh_from_db()
+        assert other.mapped_product_uid == 2
+
+    def test_get_zwraca_blad_metody(self, product_admin):
+        response = product_admin.bulk_map_to_mpd(RequestFactory().get("/"))
+        assert json.loads(response.content)["success"] is False


### PR DESCRIPTION
Part of #218. **199 passed** (187 + 12). Pokrycie matterhorn1: 51% → **54%**, próg CI 48 → **51**.

## `tests_e2e_admin_mpd_create.py` — `ProductAdmin.mpd_create` end-to-end
Przez prawdziwą `SagaService.create_product_with_mapping`, `transaction=True` (jedyny sposób żeby bare `Product.objects.get()` [matterhorn, alias `default` w testach] i `connections['matterhorn1']` raw SQL [krok uploadu zdjęć] widziały tę samą fizyczną bazę — patrz gotcha w `docs/TESTING.md`).

- happy path (+ z atrybutami)
- walidacja: brak nazwy → błąd bez efektów
- **kompensacja**: krok atrybutów pada → mapping w matterhorn1 cofnięty (przez ORM, działa); produkt MPD **zostaje** — `_delete_mpd_product` kompensuje przez HTTP, w testach nie ma dokąd polecieć (fail-open), udokumentowane zachowanie z notatki w #213

`saga.py` 43% → 49%, `admin.py` 30% → ~35%.

## `tests_integration_admin_bulk.py` — `auto_map_variants` (widok) + `bulk_map_to_mpd`
Walidacja, kształt odpowiedzi, błąd pojedynczego mapowania nie przerywa reszty. `_auto_map_variants` zamockowane (własna logika ma pokrycie w `tests_admin_linking.py`). `admin.py` → 40%.

## Znalezisko o `views.py` (#218 — „przegląd co jeszcze używane")
**Nie jest martwym kodem.** `views.py` (legacy) i `views_secure.py` (hardened) to dwa **równoległe** zestawy endpointów bulk, oba routowane w `urls.py` (`.../bulk/create/` vs `.../bulk/create-secure/`). W historii jest branch `fix/lock-legacy-api-endpoints` — sugeruje że legacy miał być zablokowany. Decyzja (wyłączyć legacy vs testować) zostaje w #218, nie testowałem dalej `views.py` w tym PR.

## Zostaje w #218
- `bulk_create_mpd_action` (głównie render szablonu confirm, niski priorytet)
- decyzja + ew. testy `views.py` legacy vs `views_secure.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)