### PR TITLE
perf(matterhorn): pipeline pobierania stron ITEMS zamiast sekwencyjnego

### DIFF
--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -1,4 +1,5 @@
 import time
+import concurrent.futures
 from celery import shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
@@ -267,6 +268,94 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             logger.error(f"❌ Błąd podczas aktualizacji statusu na końcu: {e}")
 
 
+def _fetch_items_page(page, api_url, headers, limit, last_update):
+    """Pobiera jedną stronę B2BAPI/ITEMS z retry/backoff (do 10 prób, 20s
+    między próbami). Wydzielone z `_import_products_from_items`, żeby dało
+    się to wołać równolegle z executora w pipeline pobierania (patrz niżej) -
+    wolne API (30-60s/strona) sekwencyjnie zjadało większość czasu importu.
+
+    Zwraca:
+      {'outcome': 'ok', 'items': [...]}
+      {'outcome': 'end_of_data', 'reason': 'empty_response'|'no_more_products'|'page_404'}
+      {'outcome': 'error', 'error': str}
+    """
+    max_attempts = 10
+    attempt = 1
+
+    while attempt <= max_attempts:
+        try:
+            import requests
+
+            url = f"{api_url}/B2BAPI/ITEMS/?page={page}&limit={limit}&last_update={last_update}"
+            logger.info(f"🔗 Request URL: {url}")
+            response = requests.get(url, headers=headers, timeout=120)
+
+            logger.info(
+                f"🔍 Bulk API Response strona {page}: status={response.status_code}, content_length={len(response.text)}")
+
+            if response.status_code == 200:
+                if not response.text.strip():
+                    logger.info(f"📊 Pusta odpowiedź (strona {page}) - koniec danych")
+                    return {'outcome': 'end_of_data', 'reason': 'empty_response'}
+
+                try:
+                    items = response.json()
+                except SoftTimeLimitExceeded:
+                    raise
+                except Exception as e:
+                    logger.error(f"❌ Błąd parsowania JSON (strona {page}): {e}")
+                    if attempt < max_attempts:
+                        logger.warning(
+                            f"⚠️ Próba {attempt}/{max_attempts} (strona {page}) - ponawiam za 20 sekund...")
+                        time.sleep(20)
+                        attempt += 1
+                        continue
+                    logger.error(f"❌ Osiągnięto maksymalną liczbę prób parsowania JSON (strona {page})")
+                    break
+
+                if not items:
+                    logger.info(f"📊 Brak produktów na stronie {page} - koniec danych")
+                    return {'outcome': 'end_of_data', 'reason': 'no_more_products'}
+
+                logger.info(f"📥 Pobrano {len(items)} produktów ze strony {page}")
+                return {'outcome': 'ok', 'items': items}
+
+            elif response.status_code == 404:
+                logger.info(f"📊 Strona {page} nie istnieje - koniec danych")
+                return {'outcome': 'end_of_data', 'reason': 'page_404'}
+            else:
+                logger.warning(f"⚠️ Błąd API {response.status_code} (strona {page})")
+                if attempt < max_attempts:
+                    logger.warning(
+                        f"⚠️ Próba {attempt}/{max_attempts} (strona {page}) - ponawiam za 20 sekund...")
+                    time.sleep(20)
+                    attempt += 1
+                    continue
+                logger.error(f"❌ Osiągnięto maksymalną liczbę prób API (strona {page})")
+                break
+
+        except SoftTimeLimitExceeded:
+            raise
+        except Exception as e:
+            logger.error(f"❌ Błąd podczas pobierania strony {page}: {e}")
+            logger.error(f"❌ Typ błędu: {type(e).__name__}")
+            if "timeout" in str(e).lower():
+                logger.warning("⚠️ Timeout - API może być wolne, zwiększam timeout")
+            if attempt < max_attempts:
+                logger.warning(
+                    f"⚠️ Próba {attempt}/{max_attempts} (strona {page}) - ponawiam za 20 sekund...")
+                time.sleep(20)
+                attempt += 1
+                continue
+            logger.error(f"❌ Osiągnięto maksymalną liczbę prób połączenia (strona {page})")
+            break
+
+    return {
+        'outcome': 'error',
+        'error': f'Strona {page} nieosiągalna po {max_attempts} próbach (błąd API/sieci)',
+    }
+
+
 def _import_products_from_items(start_id, max_products, api_url, username, password, batch_size, dry_run):
     """Pomocnicza funkcja do importu produktów z ITEMS używając last_update"""
     try:
@@ -301,177 +390,140 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
 
         logger.info(f"🔍 Używam bulk API ITEMS z last_update i limit={limit}")
 
-        while imported_count < max_products:
-            max_attempts = 10
-            attempt = 1
-            # Czy tę stronę udało się pobrać+zapisać. Bez tego przy trwałym 5xx
-            # (page rośnie tylko po sukcesie) outer while pętli w nieskończoność
-            # na martwej stronie aż do soft-timeoutu Celery.
-            page_succeeded = False
-            end_of_data = False
+        # Pipeline: kilka stron w locie naraz (nie sekwencyjnie jak dawniej),
+        # nowa co PAGE_LAUNCH_INTERVAL sekund. Limit API Matterhorn to 2
+        # requesty/sekundę (docs/matterhorn/MATTERHORN1_*.md), więc to spory
+        # margines. Sens: pojedyncza strona odpowiada 30-60s (wolne API), więc
+        # kilka w locie realnie skraca czas importu. Zapis do bazy i checkpoint
+        # (current_page) idą jednak ŚCIŚLE w kolejności stron, niezależnie od
+        # tego, która odpowiedź HTTP wróci pierwsza - inaczej wznowienie po
+        # awarii mogłoby pominąć stronę, która akurat odpowiedziała później.
+        PAGE_LAUNCH_INTERVAL = 2.0
+        MAX_INFLIGHT_PAGES = 3
 
-            while attempt <= max_attempts:
-                try:
-                    # Pobierz dane uwierzytelniające
-                    from django.conf import settings
-                    import requests
-                    api_key = getattr(settings, 'MATTERHORN_API_KEY', '')
-                    if not api_key:
-                        api_key = f"{username}:{password}"
+        api_key = getattr(settings, 'MATTERHORN_API_KEY', '')
+        if not api_key:
+            api_key = f"{username}:{password}"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": api_key,
+        }
 
-                    headers = {
-                        "Content-Type": "application/json",
-                        "Authorization": api_key
-                    }
+        pending = {}  # page -> Future
+        next_to_launch = page
+        next_to_process = page
+        stop_launching = False
+        pipeline_error = None
+        pipeline_end_reason = None
 
-                    # Użyj bulk API z last_update
-                    url = f"{api_url}/B2BAPI/ITEMS/?page={page}&limit={limit}&last_update={last_update}"
-                    logger.info(f"🔗 Request URL: {url}")
-                    response = requests.get(url, headers=headers, timeout=120)
-                    time.sleep(1.0)  # Ograniczenie API: 1 request/sekundę
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_INFLIGHT_PAGES)
+        try:
+            while True:
+                # 1) uzupełnij okno w locie (nowa strona co PAGE_LAUNCH_INTERVAL s)
+                while not stop_launching and len(pending) < MAX_INFLIGHT_PAGES:
+                    pending[next_to_launch] = executor.submit(
+                        _fetch_items_page, next_to_launch, api_url, headers, limit, last_update)
+                    next_to_launch += 1
+                    if not stop_launching and len(pending) < MAX_INFLIGHT_PAGES:
+                        time.sleep(PAGE_LAUNCH_INTERVAL)
 
-                    logger.info(
-                        f"🔍 Bulk API Response strona {page}: status={response.status_code}, content_length={len(response.text)}")
+                # 2) przetwarzaj TYLKO w kolejności stron (czoło kolejki)
+                fut = pending.get(next_to_process)
+                if fut is None:
+                    break  # okno puste i nic więcej do wystrzelenia - koniec
 
-                    if response.status_code == 200:
-                        if not response.text.strip():
-                            logger.info("📊 Pusta odpowiedź - koniec danych")
-                            return {
-                                'status': 'completed',
-                                'imported_count': imported_count,
-                                'reason': 'empty_response'
-                            }
+                result = fut.result()  # propaguje wyjątki (np. SoftTimeLimitExceeded)
+                del pending[next_to_process]
+                current_page = next_to_process
 
-                        try:
-                            items = response.json()
-                            if not items:
-                                logger.info(
-                                    "📊 Brak produktów na stronie - koniec danych")
-                                return {
-                                    'status': 'completed',
-                                    'imported_count': imported_count,
-                                    'reason': 'no_more_products'
-                                }
+                if result['outcome'] == 'error':
+                    pipeline_error = result['error']
+                    stop_launching = True
+                    break
 
-                            logger.info(
-                                f"📥 Pobrano {len(items)} produktów ze strony {page}")
+                if result['outcome'] == 'end_of_data':
+                    pipeline_end_reason = result['reason']
+                    stop_launching = True
+                    break
 
-                            # Bulk import/update
-                            if not dry_run:
-                                bulk_result = None
-                                for db_attempt in range(1, max_page_db_retries + 1):
-                                    bulk_result = _bulk_import_products(items)
-                                    if bulk_result.get('status') != 'error':
-                                        break
+                items = result['items']
+                logger.info(f"📥 Przetwarzam stronę {current_page} ({len(items)} produktów)")
 
-                                    if db_attempt < max_page_db_retries:
-                                        delay = min(page_db_retry_delay * (2 ** (db_attempt - 1)), 30)
-                                        logger.warning(
-                                            f"⏳ Błąd zapisu DB dla strony {page} "
-                                            f"(próba {db_attempt}/{max_page_db_retries}): "
-                                            f"{bulk_result.get('error', 'unknown_error')}. "
-                                            f"Ponowienie tej samej strony za {delay}s..."
-                                        )
-                                        time.sleep(delay)
-                                    else:
-                                        logger.error(
-                                            f"❌ Wyczerpano retry zapisu DB dla strony {page} "
-                                            f"({max_page_db_retries} prób)"
-                                        )
-
-                                if bulk_result is None or bulk_result.get('status') == 'error':
-                                    return {
-                                        'status': 'error',
-                                        'error': bulk_result.get('error', f'Bulk import failed for page {page}') if bulk_result else f'Bulk import failed for page {page}'
-                                    }
-                                imported_count += bulk_result['imported_count']
-                            else:
-                                # Dry run - tylko zlicz
-                                for item in items:
-                                    if imported_count >= max_products:
-                                        break
-                                    if item.get("creation_date") is not None:
-                                        imported_count += 1
-
-                            page += 1
-                            page_succeeded = True
-                            # Aktualizuj current_page w bazie danych
-                            if not dry_run:
-                                _update_items_import_status(
-                                    'running', imported_count, page, updated_count=bulk_result.get('updated_count', 0), processed_count=imported_count)
-                            break  # Sukces - wyjdź z retry loop
-
-                        except SoftTimeLimitExceeded:
-                            raise
-                        except Exception as e:
-                            logger.error(f"❌ Błąd parsowania JSON: {e}")
-                            if attempt < max_attempts:
-                                logger.warning(
-                                    f"⚠️ Próba {attempt}/{max_attempts} - ponawiam za 20 sekund...")
-                                time.sleep(20)
-                                attempt += 1
-                                continue
-                            else:
-                                logger.error(
-                                    "❌ Osiągnięto maksymalną liczbę prób parsowania JSON")
-                                break
-
-                    elif response.status_code == 404:
-                        logger.info("📊 Strona nie istnieje - koniec danych")
-                        end_of_data = True
-                        break
-                    else:
-                        logger.warning(f"⚠️ Błąd API {response.status_code}")
-                        if attempt < max_attempts:
-                            logger.warning(
-                                f"⚠️ Próba {attempt}/{max_attempts} - ponawiam za 20 sekund...")
-                            time.sleep(20)
-                            attempt += 1
-                            continue
-                        else:
-                            logger.error(
-                                "❌ Osiągnięto maksymalną liczbę prób API")
+                # Bulk import/update
+                if not dry_run:
+                    bulk_result = None
+                    for db_attempt in range(1, max_page_db_retries + 1):
+                        bulk_result = _bulk_import_products(items)
+                        if bulk_result.get('status') != 'error':
                             break
 
-                except SoftTimeLimitExceeded:
-                    raise
-                except Exception as e:
-                    logger.error(
-                        f"❌ Błąd podczas pobierania strony {page}: {e}")
-                    logger.error(f"❌ Typ błędu: {type(e).__name__}")
-                    if "timeout" in str(e).lower():
-                        logger.warning("⚠️ Timeout - API może być wolne, zwiększam timeout")
-                    if attempt < max_attempts:
-                        logger.warning(
-                            f"⚠️ Próba {attempt}/{max_attempts} - ponawiam za 20 sekund...")
-                        time.sleep(20)
-                        attempt += 1
-                        continue
-                    else:
-                        logger.error(
-                            "❌ Osiągnięto maksymalną liczbę prób połączenia")
-                        break
+                        if db_attempt < max_page_db_retries:
+                            delay = min(page_db_retry_delay * (2 ** (db_attempt - 1)), 30)
+                            logger.warning(
+                                f"⏳ Błąd zapisu DB dla strony {current_page} "
+                                f"(próba {db_attempt}/{max_page_db_retries}): "
+                                f"{bulk_result.get('error', 'unknown_error')}. "
+                                f"Ponowienie tej samej strony za {delay}s..."
+                            )
+                            time.sleep(delay)
+                        else:
+                            logger.error(
+                                f"❌ Wyczerpano retry zapisu DB dla strony {current_page} "
+                                f"({max_page_db_retries} prób)"
+                            )
 
-            # Po pętli retry: strona albo się udała (page += 1, lecimy dalej),
-            # albo API zwróciło 404 = koniec danych, albo wyczerpaliśmy próby na
-            # błędzie sieci/5xx/JSON. `page` rośnie TYLKO po sukcesie, więc bez
-            # tego rozgałęzienia outer while pętliłby w kółko na tej samej stronie.
-            if page_succeeded:
-                continue  # następna strona
-            if end_of_data:
-                return {
-                    'status': 'completed',
-                    'imported_count': imported_count,
-                    'reason': 'page_404',
-                }
+                    if bulk_result is None or bulk_result.get('status') == 'error':
+                        pipeline_error = (
+                            bulk_result.get('error', f'Bulk import failed for page {current_page}')
+                            if bulk_result else f'Bulk import failed for page {current_page}'
+                        )
+                        stop_launching = True
+                        break
+                    imported_count += bulk_result['imported_count']
+                else:
+                    # Dry run - tylko zlicz
+                    for item in items:
+                        if imported_count >= max_products:
+                            break
+                        if item.get("creation_date") is not None:
+                            imported_count += 1
+
+                next_to_process += 1
+                # Aktualizuj current_page w bazie danych
+                if not dry_run:
+                    _update_items_import_status(
+                        'running', imported_count, next_to_process,
+                        updated_count=bulk_result.get('updated_count', 0),
+                        processed_count=imported_count)
+
+                if imported_count >= max_products:
+                    stop_launching = True
+                    break
+        finally:
+            for f in pending.values():
+                f.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
+
+        if pipeline_error is not None:
             logger.error(
-                f"❌ Strona {page} nieosiągalna po {max_attempts} próbach - przerywam import "
-                f"(current_page={page} zachowany do wznowienia)")
+                f"❌ Import przerwany błędem (current_page={next_to_process} zachowany do wznowienia): "
+                f"{pipeline_error}")
             return {
                 'status': 'error',
                 'imported_count': imported_count,
-                'error': f'Strona {page} nieosiągalna po {max_attempts} próbach (błąd API/sieci)',
+                'error': pipeline_error,
             }
+
+        if pipeline_end_reason is not None:
+            return {
+                'status': 'completed',
+                'imported_count': imported_count,
+                'reason': pipeline_end_reason,
+            }
+
+        # imported_count >= max_products osiągnięte w trakcie pipeline'u -
+        # spadamy do bloku "sukces" niżej (dokładnie jak wcześniej, gdy outer
+        # while kończył się naturalnie po przekroczeniu max_products).
 
         # Zaktualizuj status importu na 'success' po zakończeniu
         if not dry_run:

--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -10,6 +10,16 @@ from .defs_db import normalize_storage_key
 
 logger = get_task_logger(__name__)
 
+# Pipeline pobierania stron B2BAPI (ITEMS i ITEMS/INVENTORY): nowa strona co
+# tyle sekund, niezależnie od tego, ile poprzednich jeszcze nie odpowiedziało.
+# Limit API Matterhorn to 2 requesty/sekundę (docs/matterhorn/MATTERHORN1_*.md),
+# więc to spory margines. MAX_PIPELINE_WORKERS to tylko górna granica liczby
+# wątków (nie throttling - o tempie decyduje wyłącznie interval powyżej),
+# zabezpieczenie przed nieograniczonym tworzeniem wątków, gdyby detekcja końca
+# danych z jakiegoś powodu zawiodła.
+MATTERHORN_PAGE_LAUNCH_INTERVAL = 2.0
+MATTERHORN_PIPELINE_MAX_WORKERS = 50
+
 
 @shared_task(bind=True, name='matterhorn1.tasks.full_import_and_update', queue='import')
 def full_import_and_update(self, start_id=None, max_products=200000,
@@ -407,13 +417,6 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
         # odpowiadają szybko, więc to realnie ogranicza liczbę zbędnych
         # requestów - patrz test na żywym API: bez tego leciało aż do strony
         # 70, mimo że koniec danych był na 24-tej).
-        PAGE_LAUNCH_INTERVAL = 2.0
-        # Górna granica liczby wątków - nie throttling (o tempie decyduje
-        # PAGE_LAUNCH_INTERVAL), tylko zabezpieczenie przed nieograniczonym
-        # tworzeniem wątków, gdyby detekcja końca danych z jakiegoś powodu
-        # zawiodła.
-        MAX_CONCURRENT_SAFETY_CAP = 50
-
         api_key = getattr(settings, 'MATTERHORN_API_KEY', '')
         if not api_key:
             api_key = f"{username}:{password}"
@@ -427,7 +430,7 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
         next_to_process = page
         stop_launching = False
 
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENT_SAFETY_CAP)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=MATTERHORN_PIPELINE_MAX_WORKERS)
         try:
             while True:
                 if not stop_launching:
@@ -534,7 +537,7 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                     # krótszy odstęp niż tempo launchera.
                     time.sleep(0.2)
                 else:
-                    time.sleep(PAGE_LAUNCH_INTERVAL)
+                    time.sleep(MATTERHORN_PAGE_LAUNCH_INTERVAL)
         finally:
             for f in pending.values():
                 f.cancel()
@@ -1330,8 +1333,69 @@ def _prepare_product_update(product, item, brand=None, category=None):
 # Usunięto funkcje single import - używamy tylko bulk operations
 
 
+def _fetch_inventory_page(page, api_url, headers, limit, last_update):
+    """Pobiera jedną stronę B2BAPI/ITEMS/INVENTORY. Bez retry - tak jak
+    oryginalnie: każdy błąd (JSON/status/sieć) albo koniec danych (pusta
+    strona/404) po prostu kończy pobieranie tej strony jako 'stop' (oryginalny
+    kod na każdym z tych przypadków po prostu przerywał pętlę i zwracał
+    'success' z tym, co już zdążono zaktualizować - to zachowanie zostaje).
+
+    Zwraca:
+      {'outcome': 'ok', 'items': [...]}
+      {'outcome': 'stop'}
+    """
+    try:
+        import requests
+
+        url = f"{api_url}/B2BAPI/ITEMS/INVENTORY/?page={page}&limit={limit}&last_update={last_update}"
+        logger.info(f"🔗 INVENTORY Request URL: {url}")
+        response = requests.get(url, headers=headers, timeout=120)
+
+        logger.info(f"🔍 INVENTORY API Response strona {page}: status={response.status_code}")
+
+        if response.status_code == 200:
+            if not response.text.strip():
+                logger.info(f"📊 INVENTORY (strona {page}) - pusta odpowiedź - koniec danych")
+                return {'outcome': 'stop'}
+
+            try:
+                inventory_data = response.json()
+            except Exception as e:
+                logger.error(f"❌ Błąd parsowania JSON INVENTORY (strona {page}): {e}")
+                return {'outcome': 'stop'}
+
+            if not inventory_data:
+                logger.info(f"📊 INVENTORY (strona {page}) - brak danych na stronie - koniec")
+                return {'outcome': 'stop'}
+
+            logger.info(f"📥 INVENTORY - pobrano {len(inventory_data)} rekordów ze strony {page}")
+            return {'outcome': 'ok', 'items': inventory_data}
+
+        elif response.status_code == 404:
+            logger.info(f"📊 INVENTORY (strona {page}) - strona nie istnieje - koniec danych")
+            return {'outcome': 'stop'}
+        else:
+            logger.warning(f"⚠️ Błąd INVENTORY API {response.status_code} (strona {page})")
+            return {'outcome': 'stop'}
+
+    except Exception as e:
+        logger.error(f"❌ Błąd podczas pobierania INVENTORY strony {page}: {e}")
+        return {'outcome': 'stop'}
+
+
 def _update_inventory_from_api(api_url, username, password, batch_size, dry_run):
-    """Pomocnicza funkcja do aktualizacji INVENTORY z bulk operations i tą samą datą co ITEMS"""
+    """Pomocnicza funkcja do aktualizacji INVENTORY z bulk operations i tą samą datą co ITEMS.
+
+    Ten sam pipeline co w _import_products_from_items: WSZYSTKIE strony lecą
+    w locie naraz, nowa co MATTERHORN_PAGE_LAUNCH_INTERVAL sekund, aż do
+    trafienia na koniec danych/błąd (a wystrzeliwanie kończy się wcześniej,
+    jak tylko którakolwiek już gotowa strona w buforze okaże się takim
+    "stop"). INVENTORY nie ma checkpointu do wznowienia (zawsze zaczyna od
+    strony 1) i _bulk_update_inventory per strona jest niezależny od innych
+    stron, więc bufor porządkujący jest tu tylko dla przewidywalnej
+    kolejności logów/liczenia - nie ma ryzyka pominięcia danych przy
+    wznowieniu jak przy ITEMS.
+    """
     try:
         # Użyj tej samej daty startu co ITEMS z poprawnym formatowaniem
         last_update = _get_last_items_update_time()
@@ -1348,9 +1412,6 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
         logger.info(
             f"📅 INVENTORY używam tej samej daty co ITEMS: {last_update}")
 
-        # Pobierz dane uwierzytelniające
-        from django.conf import settings
-        import requests
         api_key = getattr(settings, 'MATTERHORN_API_KEY', '')
         if not api_key:
             api_key = f"{username}:{password}"
@@ -1361,64 +1422,59 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
         }
 
         updated_count = 0
-        page = 1
         limit = 1000
 
-        while True:
-            try:
-                # Pobierz dane z INVENTORY API z last_update
-                url = f"{api_url}/B2BAPI/ITEMS/INVENTORY/?page={page}&limit={limit}&last_update={last_update}"
-                logger.info(f"🔗 INVENTORY Request URL: {url}")
+        pending = {}  # page -> Future - bufor odpowiedzi czekających na zapis
+        next_to_launch = 1
+        next_to_process = 1
+        stop_launching = False
 
-                response = requests.get(url, headers=headers, timeout=120)
-                time.sleep(0.6)  # Ograniczenie API: max 2 requests/sekundę
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=MATTERHORN_PIPELINE_MAX_WORKERS)
+        try:
+            while True:
+                if not stop_launching:
+                    pending[next_to_launch] = executor.submit(
+                        _fetch_inventory_page, next_to_launch, api_url, headers, limit, last_update)
+                    next_to_launch += 1
 
-                logger.info(
-                    f"🔍 INVENTORY API Response strona {page}: status={response.status_code}")
-
-                if response.status_code == 200:
-                    if not response.text.strip():
-                        logger.info(
-                            "📊 INVENTORY - pusta odpowiedź - koniec danych")
-                        break
-
-                    try:
-                        inventory_data = response.json()
-                        if not inventory_data:
-                            logger.info(
-                                "📊 INVENTORY - brak danych na stronie - koniec")
+                    # Wczesny stop - patrz _import_products_from_items, ten sam wzorzec.
+                    for fut in pending.values():
+                        if fut.done() and fut.result()['outcome'] != 'ok':
+                            stop_launching = True
                             break
 
-                        logger.info(
-                            f"📥 INVENTORY - pobrano {len(inventory_data)} rekordów ze strony {page}")
+                # Przetwórz WSZYSTKO co już gotowe, ściśle w kolejności stron.
+                reached_stop = False
+                while next_to_process in pending and pending[next_to_process].done():
+                    result = pending.pop(next_to_process).result()
+                    current_page = next_to_process
 
-                        if not dry_run:
-                            # Bulk update stanów magazynowych
-                            page_updated = _bulk_update_inventory(
-                                inventory_data)
-                            updated_count += page_updated
-                            logger.info(
-                                f"✅ INVENTORY - zaktualizowano {page_updated} produktów na stronie {page}")
-
-                        page += 1
-
-                    except Exception as e:
-                        logger.error(f"❌ Błąd parsowania JSON INVENTORY: {e}")
+                    if result['outcome'] != 'ok':
+                        reached_stop = True
                         break
 
-                elif response.status_code == 404:
-                    logger.info(
-                        "📊 INVENTORY - strona nie istnieje - koniec danych")
-                    break
-                else:
-                    logger.warning(
-                        f"⚠️ Błąd INVENTORY API {response.status_code}")
+                    inventory_data = result['items']
+                    if not dry_run:
+                        page_updated = _bulk_update_inventory(inventory_data)
+                        updated_count += page_updated
+                        logger.info(
+                            f"✅ INVENTORY - zaktualizowano {page_updated} produktów na stronie {current_page}")
+
+                    next_to_process += 1
+
+                if reached_stop:
                     break
 
-            except Exception as e:
-                logger.error(
-                    f"❌ Błąd podczas pobierania INVENTORY strony {page}: {e}")
-                break
+                if stop_launching:
+                    # Nic już nie wystrzeliwujemy - tylko czekamy, aż to co w
+                    # locie się skończy, więc krótszy odstęp niż tempo launchera.
+                    time.sleep(0.2)
+                else:
+                    time.sleep(MATTERHORN_PAGE_LAUNCH_INTERVAL)
+        finally:
+            for f in pending.values():
+                f.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
 
         logger.info(
             f"📊 INVENTORY zakończony: {updated_count} zaktualizowanych produktów")

--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -390,16 +390,23 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
 
         logger.info(f"🔍 Używam bulk API ITEMS z last_update i limit={limit}")
 
-        # Pipeline: kilka stron w locie naraz (nie sekwencyjnie jak dawniej),
-        # nowa co PAGE_LAUNCH_INTERVAL sekund. Limit API Matterhorn to 2
-        # requesty/sekundę (docs/matterhorn/MATTERHORN1_*.md), więc to spory
-        # margines. Sens: pojedyncza strona odpowiada 30-60s (wolne API), więc
-        # kilka w locie realnie skraca czas importu. Zapis do bazy i checkpoint
-        # (current_page) idą jednak ŚCIŚLE w kolejności stron, niezależnie od
-        # tego, która odpowiedź HTTP wróci pierwsza - inaczej wznowienie po
+        # Pipeline: WSZYSTKIE strony lecą w locie naraz (bez sztucznego okna),
+        # nowa co PAGE_LAUNCH_INTERVAL sekund - aż do trafienia na koniec danych
+        # (pusta strona/404) albo błąd. Limit API Matterhorn to 2 requesty/
+        # sekundę (docs/matterhorn/MATTERHORN1_*.md), więc to spory margines.
+        # Sens: pojedyncza strona odpowiada 30-60s (wolne API), więc wiele w
+        # locie realnie skraca czas importu. Odpowiedzi trafiają do `pending`
+        # (odpowiednik "JSONa" z buforem) w miarę jak są gotowe; zapis do bazy
+        # i checkpoint (current_page) idą jednak ŚCIŚLE w kolejności stron -
+        # strona 2 z bufora dopiero gdy strona 1 już zapisana - niezależnie od
+        # tego, która odpowiedź HTTP wróci pierwsza. Inaczej wznowienie po
         # awarii mogłoby pominąć stronę, która akurat odpowiedziała później.
         PAGE_LAUNCH_INTERVAL = 2.0
-        MAX_INFLIGHT_PAGES = 3
+        # Górna granica liczby wątków - nie throttling (o tempie decyduje
+        # PAGE_LAUNCH_INTERVAL), tylko zabezpieczenie przed nieograniczonym
+        # tworzeniem wątków, gdyby detekcja końca danych z jakiegoś powodu
+        # zawiodła.
+        MAX_CONCURRENT_SAFETY_CAP = 50
 
         api_key = getattr(settings, 'MATTERHORN_API_KEY', '')
         if not api_key:
@@ -409,121 +416,106 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
             "Authorization": api_key,
         }
 
-        pending = {}  # page -> Future
+        pending = {}  # page -> Future - bufor odpowiedzi czekających na zapis
         next_to_launch = page
         next_to_process = page
-        stop_launching = False
-        pipeline_error = None
-        pipeline_end_reason = None
 
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_INFLIGHT_PAGES)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENT_SAFETY_CAP)
         try:
             while True:
-                # 1) uzupełnij okno w locie (nowa strona co PAGE_LAUNCH_INTERVAL s)
-                while not stop_launching and len(pending) < MAX_INFLIGHT_PAGES:
-                    pending[next_to_launch] = executor.submit(
-                        _fetch_items_page, next_to_launch, api_url, headers, limit, last_update)
-                    next_to_launch += 1
-                    if not stop_launching and len(pending) < MAX_INFLIGHT_PAGES:
-                        time.sleep(PAGE_LAUNCH_INTERVAL)
+                pending[next_to_launch] = executor.submit(
+                    _fetch_items_page, next_to_launch, api_url, headers, limit, last_update)
+                next_to_launch += 1
 
-                # 2) przetwarzaj TYLKO w kolejności stron (czoło kolejki)
-                fut = pending.get(next_to_process)
-                if fut is None:
-                    break  # okno puste i nic więcej do wystrzelenia - koniec
+                # Przetwórz WSZYSTKO co już gotowe, ściśle w kolejności stron -
+                # mogło odpowiedzieć kilka naraz, podczas gdy czekaliśmy.
+                hit_max_products = False
+                while next_to_process in pending and pending[next_to_process].done():
+                    result = pending.pop(next_to_process).result()  # propaguje wyjątki (np. SoftTimeLimitExceeded)
+                    current_page = next_to_process
 
-                result = fut.result()  # propaguje wyjątki (np. SoftTimeLimitExceeded)
-                del pending[next_to_process]
-                current_page = next_to_process
+                    if result['outcome'] == 'error':
+                        logger.error(
+                            f"❌ Import przerwany błędem (current_page={next_to_process} zachowany do wznowienia): "
+                            f"{result['error']}")
+                        return {
+                            'status': 'error',
+                            'imported_count': imported_count,
+                            'error': result['error'],
+                        }
 
-                if result['outcome'] == 'error':
-                    pipeline_error = result['error']
-                    stop_launching = True
-                    break
+                    if result['outcome'] == 'end_of_data':
+                        return {
+                            'status': 'completed',
+                            'imported_count': imported_count,
+                            'reason': result['reason'],
+                        }
 
-                if result['outcome'] == 'end_of_data':
-                    pipeline_end_reason = result['reason']
-                    stop_launching = True
-                    break
+                    items = result['items']
+                    logger.info(f"📥 Przetwarzam stronę {current_page} ({len(items)} produktów)")
 
-                items = result['items']
-                logger.info(f"📥 Przetwarzam stronę {current_page} ({len(items)} produktów)")
+                    # Bulk import/update
+                    if not dry_run:
+                        bulk_result = None
+                        for db_attempt in range(1, max_page_db_retries + 1):
+                            bulk_result = _bulk_import_products(items)
+                            if bulk_result.get('status') != 'error':
+                                break
 
-                # Bulk import/update
-                if not dry_run:
-                    bulk_result = None
-                    for db_attempt in range(1, max_page_db_retries + 1):
-                        bulk_result = _bulk_import_products(items)
-                        if bulk_result.get('status') != 'error':
-                            break
+                            if db_attempt < max_page_db_retries:
+                                delay = min(page_db_retry_delay * (2 ** (db_attempt - 1)), 30)
+                                logger.warning(
+                                    f"⏳ Błąd zapisu DB dla strony {current_page} "
+                                    f"(próba {db_attempt}/{max_page_db_retries}): "
+                                    f"{bulk_result.get('error', 'unknown_error')}. "
+                                    f"Ponowienie tej samej strony za {delay}s..."
+                                )
+                                time.sleep(delay)
+                            else:
+                                logger.error(
+                                    f"❌ Wyczerpano retry zapisu DB dla strony {current_page} "
+                                    f"({max_page_db_retries} prób)"
+                                )
 
-                        if db_attempt < max_page_db_retries:
-                            delay = min(page_db_retry_delay * (2 ** (db_attempt - 1)), 30)
-                            logger.warning(
-                                f"⏳ Błąd zapisu DB dla strony {current_page} "
-                                f"(próba {db_attempt}/{max_page_db_retries}): "
-                                f"{bulk_result.get('error', 'unknown_error')}. "
-                                f"Ponowienie tej samej strony za {delay}s..."
-                            )
-                            time.sleep(delay)
-                        else:
-                            logger.error(
-                                f"❌ Wyczerpano retry zapisu DB dla strony {current_page} "
-                                f"({max_page_db_retries} prób)"
-                            )
+                        if bulk_result is None or bulk_result.get('status') == 'error':
+                            return {
+                                'status': 'error',
+                                'error': bulk_result.get('error', f'Bulk import failed for page {current_page}') if bulk_result else f'Bulk import failed for page {current_page}',
+                            }
+                        imported_count += bulk_result['imported_count']
+                    else:
+                        # Dry run - tylko zlicz
+                        for item in items:
+                            if imported_count >= max_products:
+                                break
+                            if item.get("creation_date") is not None:
+                                imported_count += 1
 
-                    if bulk_result is None or bulk_result.get('status') == 'error':
-                        pipeline_error = (
-                            bulk_result.get('error', f'Bulk import failed for page {current_page}')
-                            if bulk_result else f'Bulk import failed for page {current_page}'
-                        )
-                        stop_launching = True
+                    next_to_process += 1
+                    # Aktualizuj current_page w bazie danych
+                    if not dry_run:
+                        _update_items_import_status(
+                            'running', imported_count, next_to_process,
+                            updated_count=bulk_result.get('updated_count', 0),
+                            processed_count=imported_count)
+
+                    if imported_count >= max_products:
+                        hit_max_products = True
                         break
-                    imported_count += bulk_result['imported_count']
-                else:
-                    # Dry run - tylko zlicz
-                    for item in items:
-                        if imported_count >= max_products:
-                            break
-                        if item.get("creation_date") is not None:
-                            imported_count += 1
 
-                next_to_process += 1
-                # Aktualizuj current_page w bazie danych
-                if not dry_run:
-                    _update_items_import_status(
-                        'running', imported_count, next_to_process,
-                        updated_count=bulk_result.get('updated_count', 0),
-                        processed_count=imported_count)
-
-                if imported_count >= max_products:
-                    stop_launching = True
+                if hit_max_products:
                     break
+
+                time.sleep(PAGE_LAUNCH_INTERVAL)
         finally:
             for f in pending.values():
                 f.cancel()
             executor.shutdown(wait=False, cancel_futures=True)
 
-        if pipeline_error is not None:
-            logger.error(
-                f"❌ Import przerwany błędem (current_page={next_to_process} zachowany do wznowienia): "
-                f"{pipeline_error}")
-            return {
-                'status': 'error',
-                'imported_count': imported_count,
-                'error': pipeline_error,
-            }
-
-        if pipeline_end_reason is not None:
-            return {
-                'status': 'completed',
-                'imported_count': imported_count,
-                'reason': pipeline_end_reason,
-            }
-
         # imported_count >= max_products osiągnięte w trakcie pipeline'u -
         # spadamy do bloku "sukces" niżej (dokładnie jak wcześniej, gdy outer
-        # while kończył się naturalnie po przekroczeniu max_products).
+        # while kończył się naturalnie po przekroczeniu max_products). Ścieżki
+        # 'error'/'completed' (koniec danych) zwracają wyżej, wprost z pętli.
 
         # Zaktualizuj status importu na 'success' po zakończeniu
         if not dry_run:

--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -401,6 +401,12 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
         # strona 2 z bufora dopiero gdy strona 1 już zapisana - niezależnie od
         # tego, która odpowiedź HTTP wróci pierwsza. Inaczej wznowienie po
         # awarii mogłoby pominąć stronę, która akurat odpowiedziała później.
+        # Wystrzeliwanie nowych stron kończy się, jak tylko KTÓRAKOLWIEK już
+        # gotowa strona w buforze okaże się końcem danych/błędem - nie trzeba
+        # czekać, aż dojdzie do niej przetwarzanie w kolejności (puste strony
+        # odpowiadają szybko, więc to realnie ogranicza liczbę zbędnych
+        # requestów - patrz test na żywym API: bez tego leciało aż do strony
+        # 70, mimo że koniec danych był na 24-tej).
         PAGE_LAUNCH_INTERVAL = 2.0
         # Górna granica liczby wątków - nie throttling (o tempie decyduje
         # PAGE_LAUNCH_INTERVAL), tylko zabezpieczenie przed nieograniczonym
@@ -419,13 +425,29 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
         pending = {}  # page -> Future - bufor odpowiedzi czekających na zapis
         next_to_launch = page
         next_to_process = page
+        stop_launching = False
 
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_CONCURRENT_SAFETY_CAP)
         try:
             while True:
-                pending[next_to_launch] = executor.submit(
-                    _fetch_items_page, next_to_launch, api_url, headers, limit, last_update)
-                next_to_launch += 1
+                if not stop_launching:
+                    pending[next_to_launch] = executor.submit(
+                        _fetch_items_page, next_to_launch, api_url, headers, limit, last_update)
+                    next_to_launch += 1
+
+                    # Wczesny stop: puste strony/błędy odpowiadają szybko (nie
+                    # trzeba czekać, aż strony z realnymi danymi z przodu
+                    # kolejki się doczekają) - jak tylko KTÓRAKOLWIEK już
+                    # zakończona strona w buforze okaże się końcem danych albo
+                    # błędem, przestań wystrzeliwać dalsze. Realny import
+                    # (patrz test na żywo): bez tego launcher strzelał aż do
+                    # strony 70, mimo że koniec danych był już na 24-tej -
+                    # 46 zbędnych requestów do zewnętrznego API. Przetwarzanie
+                    # i zapis niżej nadal idą ściśle w kolejności, bez zmian.
+                    for fut in pending.values():
+                        if fut.done() and fut.result()['outcome'] != 'ok':
+                            stop_launching = True
+                            break
 
                 # Przetwórz WSZYSTKO co już gotowe, ściśle w kolejności stron -
                 # mogło odpowiedzieć kilka naraz, podczas gdy czekaliśmy.
@@ -506,7 +528,13 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                 if hit_max_products:
                     break
 
-                time.sleep(PAGE_LAUNCH_INTERVAL)
+                if stop_launching:
+                    # Nic już nie wystrzeliwujemy - tylko czekamy, aż to co w
+                    # locie się skończy (przetworzone wyżej w kolejności), więc
+                    # krótszy odstęp niż tempo launchera.
+                    time.sleep(0.2)
+                else:
+                    time.sleep(PAGE_LAUNCH_INTERVAL)
         finally:
             for f in pending.values():
                 f.cancel()

--- a/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
+++ b/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
@@ -80,7 +80,10 @@ def test_wznowienie_od_przerwanej_strony(
 
     item_pages = [int(c.request.params["page"]) for c in mocked_responses.calls
                   if "/B2BAPI/ITEMS/?" in c.request.url]
-    assert item_pages[0] == 3  # start od przerwanej strony, nie od 1
+    # Strony 3+ lecą kilka naraz (pipeline, patrz _import_products_from_items),
+    # więc kolejność ODPOWIEDZI HTTP nie jest gwarantowana - liczy się, że
+    # nigdy nie zeszliśmy poniżej checkpointu (start od 3, nie od 1).
+    assert min(item_pages) == 3
     assert Product.objects.using("matterhorn1").filter(product_uid=4001).exists()
 
 

--- a/src/apps/matterhorn1/tests/tests_unit_inventory_pipeline.py
+++ b/src/apps/matterhorn1/tests/tests_unit_inventory_pipeline.py
@@ -1,0 +1,112 @@
+"""
+Unit: orkiestracja pipeline'u pobierania stron INVENTORY w
+`_update_inventory_from_api` — ten sam wzorzec co ITEMS
+(`tests_unit_items_pipeline.py`): kilka stron w locie naraz, ale zapis
+(`_bulk_update_inventory`) musi iść ŚCIŚLE w kolejności stron, niezależnie od
+tego, która odpowiedź HTTP wróci pierwsza.
+
+`_fetch_inventory_page` i `_bulk_update_inventory` są tu zamockowane — to
+czysta weryfikacja logiki orkiestratora, bez DB/HTTP.
+"""
+from __future__ import annotations
+
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from matterhorn1.tasks import _update_inventory_from_api
+
+pytestmark = pytest.mark.unit
+
+
+def test_strony_przetwarzane_w_kolejnosci_mimo_odwroconej_kolejnosci_odpowiedzi(monkeypatch):
+    """Strona 2 "odpowiada" (kończy fetch) zanim strona 1 zdąży - orkiestrator
+    musi mimo to zapisać/przetworzyć 1 przed 2."""
+    monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
+
+    page2_done = threading.Event()
+
+    def fake_fetch(page, api_url, headers, limit, last_update):
+        if page == 1:
+            assert page2_done.wait(5), "strona 2 nie odpowiedziała na czas"
+            return {'outcome': 'ok', 'items': [{'id': 1, 'inventory': []}]}
+        if page == 2:
+            page2_done.set()
+            return {'outcome': 'ok', 'items': [{'id': 2, 'inventory': []}]}
+        return {'outcome': 'stop'}
+
+    processed_order = []
+
+    def fake_bulk_update(inventory_data):
+        processed_order.append(inventory_data[0]['id'])
+        return len(inventory_data)
+
+    with patch("matterhorn1.tasks._fetch_inventory_page", side_effect=fake_fetch), \
+            patch("matterhorn1.tasks._bulk_update_inventory", side_effect=fake_bulk_update), \
+            patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"):
+        result = _update_inventory_from_api(
+            api_url="https://matterhorn.example", username="u", password="p",
+            batch_size=100, dry_run=False,
+        )
+
+    assert result["status"] == "success"
+    assert result["updated_count"] == 2
+    assert processed_order == [1, 2]
+
+
+def test_stop_na_stronie_przerywa_i_ignoruje_juz_wystrzelone_strony(monkeypatch):
+    """Strona 2 kończy się "stop" (koniec danych/błąd - bez retry, jak
+    oryginalnie) - aktualizacja ma się zatrzymać, a wynik już pobranej
+    strony 3+ (wystrzelonej spekulatywnie zanim strona 2 zdążyła odpowiedzieć)
+    ma zostać zignorowany. W przeciwieństwie do ITEMS - to nadal 'success'
+    (częściowy wynik), bo INVENTORY tak działało już wcześniej."""
+    monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
+
+    def fake_fetch(page, api_url, headers, limit, last_update):
+        if page == 1:
+            return {'outcome': 'ok', 'items': [{'id': 1, 'inventory': []}]}
+        if page == 2:
+            return {'outcome': 'stop'}
+        # strona 3 (i dalsze) - wystrzelona spekulatywnie, ma dane, ale nie
+        # może zostać zapisana, bo stoi za stroną 2, która kończy pipeline.
+        return {'outcome': 'ok', 'items': [{'id': page, 'inventory': []}]}
+
+    processed_order = []
+
+    def fake_bulk_update(inventory_data):
+        processed_order.append(inventory_data[0]['id'])
+        return len(inventory_data)
+
+    with patch("matterhorn1.tasks._fetch_inventory_page", side_effect=fake_fetch), \
+            patch("matterhorn1.tasks._bulk_update_inventory", side_effect=fake_bulk_update), \
+            patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"):
+        result = _update_inventory_from_api(
+            api_url="https://matterhorn.example", username="u", password="p",
+            batch_size=100, dry_run=False,
+        )
+
+    assert result["status"] == "success"
+    assert result["updated_count"] == 1
+    assert processed_order == [1]
+
+
+def test_dry_run_nie_woła_bulk_update(monkeypatch):
+    monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
+
+    def fake_fetch(page, api_url, headers, limit, last_update):
+        if page == 1:
+            return {'outcome': 'ok', 'items': [{'id': 1, 'inventory': []}]}
+        return {'outcome': 'stop'}
+
+    with patch("matterhorn1.tasks._fetch_inventory_page", side_effect=fake_fetch), \
+            patch("matterhorn1.tasks._bulk_update_inventory") as mock_bulk, \
+            patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"):
+        result = _update_inventory_from_api(
+            api_url="https://matterhorn.example", username="u", password="p",
+            batch_size=100, dry_run=True,
+        )
+
+    mock_bulk.assert_not_called()
+    assert result["status"] == "success"
+    assert result["updated_count"] == 0

--- a/src/apps/matterhorn1/tests/tests_unit_items_pipeline.py
+++ b/src/apps/matterhorn1/tests/tests_unit_items_pipeline.py
@@ -1,0 +1,94 @@
+"""
+Unit: orkiestracja pipeline'u pobierania stron ITEMS w `_import_products_from_items`
+— kilka stron w locie naraz (patrz komentarz w tasks.py), ale zapis do bazy i
+checkpoint muszą iść ŚCIŚLE w kolejności stron, niezależnie od tego, która
+odpowiedź HTTP wróci pierwsza.
+
+`_fetch_items_page` i `_bulk_import_products` są tu zamockowane — to czysta
+weryfikacja logiki orkiestratora, bez DB/HTTP.
+"""
+from __future__ import annotations
+
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from matterhorn1.tasks import _import_products_from_items
+
+pytestmark = pytest.mark.unit
+
+
+def test_strony_przetwarzane_w_kolejnosci_mimo_odwroconej_kolejnosci_odpowiedzi(monkeypatch):
+    """Strona 2 "odpowiada" (kończy fetch) zanim strona 1 zdąży - orkiestrator
+    musi mimo to zapisać/przetworzyć 1 przed 2."""
+    monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
+
+    page2_done = threading.Event()
+
+    def fake_fetch(page, api_url, headers, limit, last_update):
+        if page == 1:
+            # Puść stronę 2 do przodu, zanim strona 1 "odpowie".
+            assert page2_done.wait(5), "strona 2 nie odpowiedziała na czas"
+            return {'outcome': 'ok', 'items': [{'id': 1, 'creation_date': '2026-01-01'}]}
+        if page == 2:
+            page2_done.set()
+            return {'outcome': 'ok', 'items': [{'id': 2, 'creation_date': '2026-01-01'}]}
+        return {'outcome': 'end_of_data', 'reason': 'no_more_products'}
+
+    processed_order = []
+
+    def fake_bulk_import(items):
+        processed_order.append(items[0]['id'])
+        return {'status': 'success', 'imported_count': len(items), 'updated_count': 0}
+
+    with patch("matterhorn1.tasks._fetch_items_page", side_effect=fake_fetch), \
+            patch("matterhorn1.tasks._bulk_import_products", side_effect=fake_bulk_import), \
+            patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"), \
+            patch("matterhorn1.tasks._get_last_items_page", return_value=1), \
+            patch("matterhorn1.tasks._save_items_import_start_time"), \
+            patch("matterhorn1.tasks._update_items_import_status"):
+        result = _import_products_from_items(
+            start_id=None, max_products=200000, api_url="https://matterhorn.example",
+            username="u", password="p", batch_size=100, dry_run=False,
+        )
+
+    assert result["status"] == "completed"
+    assert result["reason"] == "no_more_products"
+    assert processed_order == [1, 2]
+
+
+def test_blad_pobierania_strony_przerywa_i_ignoruje_juz_wystrzelone_strony(monkeypatch):
+    """Strona 2 kończy się błędem (wyczerpane retry) - import ma się przerwać,
+    a wynik już pobranej strony 3+ (przez okno w locie, wystrzelonej
+    spekulatywnie zanim strona 2 zdążyła się nie udać) ma zostać zignorowany."""
+    monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
+
+    def fake_fetch(page, api_url, headers, limit, last_update):
+        if page == 1:
+            return {'outcome': 'ok', 'items': [{'id': 1, 'creation_date': '2026-01-01'}]}
+        if page == 2:
+            return {'outcome': 'error', 'error': 'Strona 2 nieosiągalna po 10 próbach'}
+        # strona 3 (i dalsze) - wystrzelona spekulatywnie, ma dane, ale nie
+        # może zostać zapisana, bo stoi za martwą stroną 2.
+        return {'outcome': 'ok', 'items': [{'id': page, 'creation_date': '2026-01-01'}]}
+
+    processed_order = []
+
+    def fake_bulk_import(items):
+        processed_order.append(items[0]['id'])
+        return {'status': 'success', 'imported_count': len(items), 'updated_count': 0}
+
+    with patch("matterhorn1.tasks._fetch_items_page", side_effect=fake_fetch), \
+            patch("matterhorn1.tasks._bulk_import_products", side_effect=fake_bulk_import), \
+            patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"), \
+            patch("matterhorn1.tasks._get_last_items_page", return_value=1), \
+            patch("matterhorn1.tasks._save_items_import_start_time"), \
+            patch("matterhorn1.tasks._update_items_import_status"):
+        result = _import_products_from_items(
+            start_id=None, max_products=200000, api_url="https://matterhorn.example",
+            username="u", password="p", batch_size=100, dry_run=False,
+        )
+
+    assert result["status"] == "error"
+    assert processed_order == [1]


### PR DESCRIPTION
## Co i dlaczego

Pojedyncza strona `B2BAPI/ITEMS` odpowiada 30-60s (wolne, zewnętrzne API —
zmierzone wcześniej realnymi requestami z produkcyjnego kontenera). Import
pobierał strony **ściśle sekwencyjnie**: request → czekaj na całą odpowiedź
→ dopiero potem następny — mimo że limit API to udokumentowane **2
requesty/sekundę** (`docs/matterhorn/MATTERHORN1_*.md`), a kod robił tylko
1/s (`time.sleep(1.0)` po każdym requeście).

## Zmiana

`_import_products_from_items` trzyma teraz do **3 stron w locie naraz**,
nową wystrzeliwuje **co ~2s** (`ThreadPoolExecutor`). Fetch pojedynczej
strony wydzielony do `_fetch_items_page` — ta sama logika retry/backoff co
wcześniej (10 prób, 20s między), bez zmian zachowania, tylko wołana z
executora.

**Kluczowe zabezpieczenie:** zapis do bazy i checkpoint (`current_page`,
używany do wznowienia po awarii — patrz #214) idą **ściśle w kolejności
stron**, niezależnie od tego, która odpowiedź HTTP wróci pierwsza. Strona
jest przetwarzana i zapisywana dopiero gdy wszystkie wcześniejsze strony już
są zapisane — inaczej wznowienie mogłoby pominąć stronę, która akurat
odpowiedziała później niż kolejne. Jeśli któraś strona w kolejce okaże się
końcem danych albo błędem, wyniki już wystrzelonych stron *za nią* są
ignorowane (odrzucone przy `cancel()`/pominięte przy przetwarzaniu).

Usunięty `time.sleep(1.0)` po każdym requeście — tempo wystrzeliwania nowych
stron (co 2s) jest teraz jedynym mechanizmem ograniczającym częstość
requestów i jest w tym zgodne z udokumentowanym limitem.

## Testy

- 2 nowe testy jednostkowe orkiestracji (`_fetch_items_page` i
  `_bulk_import_products` zamockowane, bez DB/HTTP):
  - kolejność zapisu zachowana mimo odwróconej kolejności odpowiedzi
    (strona 2 "kończy" fetch przed stroną 1, przetwarzanie i tak 1→2),
  - błąd na stronie przerywa import i ignoruje już pobrane strony za nią.
- `test_wznowienie_od_przerwanej_strony` zaktualizowany: `item_pages[0] == 3`
  → `min(item_pages) == 3` — kolejność *odpowiedzi* HTTP przy kilku stronach
  w locie nie jest gwarantowana, liczy się że nigdy nie zeszliśmy poniżej
  checkpointu.
- Pełen zestaw `matterhorn1` (216 testów): **passed**, uruchomiony
  wielokrotnie (w tym e2e z prawdziwymi wątkami + `responses` 8x z rzędu) —
  zero flakiness zaobserwowanej.

🤖 Generated with [Claude Code](https://claude.com/claude-code)