### PR TITLE
perf(matterhorn): przyspiesz changelist admina StockHistory

### DIFF
--- a/src/apps/matterhorn1/admin.py
+++ b/src/apps/matterhorn1/admin.py
@@ -20,8 +20,8 @@ from .defs_db import resolve_image_url
 from . import bestsellers_data
 from core.db_routers import _get_mpd_db, _get_matterhorn1_db
 from core.wholesaler_admin import (
-    make_scoped_filter, render_product_thumbnail, fuzzy_suggest_mpd_products,
-    build_mpd_change_context, StockHistoryAdminBase,
+    make_scoped_filter, make_input_filter, render_product_thumbnail,
+    fuzzy_suggest_mpd_products, build_mpd_change_context, StockHistoryAdminBase,
     ReadOnlyLogAdminMixin, RouterScopedQuerysetMixin,
 )
 
@@ -1846,20 +1846,39 @@ class StockHistoryAdmin(RouterScopedQuerysetMixin, ReadOnlyLogAdminMixin, StockH
     ]
     list_display_links = ['product_uid_link']
 
+    # Tabela historii ma setki tysięcy wierszy - domyślny COUNT(*) całości przy
+    # aktywnym filtrze to zbędny full scan.
+    show_full_result_count = False
+
+    def get_queryset(self, request):
+        """Adnotacja `_product_pk` (pk produktu po `product_uid`) jednym
+        skorelowanym podzapytaniem, zamiast query per wiersz w
+        `product_uid_link` - `product_uid` to zwykły IntegerField, nie FK, więc
+        `select_related` nie zadziała, a bez tego changelist robił N+1."""
+        qs = super().get_queryset(request)
+        product_pk = Product.objects.filter(
+            product_uid=OuterRef('product_uid')).values('pk')[:1]
+        return qs.annotate(_product_pk=Subquery(product_pk))
+
     def product_uid_link(self, obj):
-        """Renderuje product_uid jako link do produktu"""
-        if obj.product_uid:
-            product_url = obj.get_product_url()
-            if product_url:
-                return format_html(
-                    '<a href="{}" target="_blank">{}</a>',
-                    product_url,
-                    obj.product_uid
-                )
+        """Renderuje product_uid jako link do produktu (pk z adnotacji, bez query)"""
+        product_pk = getattr(obj, '_product_pk', None)
+        if obj.product_uid and product_pk:
+            from django.urls import reverse
+            return format_html(
+                '<a href="{}" target="_blank">{}</a>',
+                reverse('admin:matterhorn1_product_change', args=[product_pk]),
+                obj.product_uid
+            )
         return obj.product_uid
     product_uid_link.short_description = 'Product UID'
     product_uid_link.admin_order_field = 'product_uid'
-    list_filter = ['change_type', 'timestamp', 'product_uid']
+    # `product_uid` przez pole tekstowe zamiast listy ~38 tys. wartości w pasku
+    # bocznym (to zabijało czas ładowania strony).
+    list_filter = [
+        'change_type', 'timestamp',
+        make_input_filter(title='Product UID', parameter_name='product_uid', cast=int),
+    ]
     search_fields = [
         'product_uid', 'product_name', 'variant_uid', 'variant_name'
     ]

--- a/src/apps/matterhorn1/models.py
+++ b/src/apps/matterhorn1/models.py
@@ -255,14 +255,7 @@ class StockHistory(models.Model):
     def __str__(self):
         return f"{self.product_name} - {self.variant_name}: {self.old_stock} → {self.new_stock} ({self.timestamp})"
 
-    def get_product_url(self):
-        """Zwraca URL do produktu w admin na podstawie product_uid"""
-        from django.urls import reverse
-        try:
-            # Znajdź produkt po product_uid
-            from .models import Product
-            product = Product.objects.using('matterhorn1').get(
-                product_uid=self.product_uid)
-            return reverse('admin:matterhorn1_product_change', args=[product.pk])
-        except Product.DoesNotExist:
-            return None
+    # Uwaga: nie dodawać tu metody robiącej Product.objects.get(product_uid=...) -
+    # `product_uid` nie jest FK, więc w changelist admina to było N+1 (query na
+    # każdy wiersz). Link do produktu buduje StockHistoryAdmin z adnotacji
+    # `_product_pk` (jedno skorelowane podzapytanie).

--- a/src/apps/matterhorn1/tests/tests_integration_admin_stock_history.py
+++ b/src/apps/matterhorn1/tests/tests_integration_admin_stock_history.py
@@ -1,0 +1,86 @@
+"""
+Integration: `StockHistoryAdmin` changelist — regresja wydajności (N+1 przy
+budowaniu linków do produktów, bo `product_uid` nie jest FK) i filtr
+`product_uid` przez pole tekstowe zamiast listy ~dziesiątek tysięcy wartości.
+"""
+from __future__ import annotations
+
+import pytest
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from core.db_routers import _get_matterhorn1_db
+from matterhorn1.models import Brand, Product, StockHistory
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases="__all__")]
+
+DB = _get_matterhorn1_db()
+
+
+def _mk_history(n, *, with_product=True):
+    brand = Brand.objects.using(DB).create(brand_id="B", name="B")
+    rows = []
+    for i in range(n):
+        uid = 700000 + i
+        if with_product:
+            Product.objects.using(DB).create(product_uid=uid, name=f"P{i}", brand=brand)
+        rows.append(StockHistory(
+            variant_uid=str(800000 + i), product_uid=uid, product_name=f"P{i}",
+            variant_name="M", old_stock=5, new_stock=3, stock_change=-2,
+            change_type="decrease"))
+    StockHistory.objects.using(DB).bulk_create(rows)
+
+
+def test_changelist_liczba_zapytan_nie_rosnie_z_liczba_wierszy(admin_client):
+    _mk_history(30)
+    url = reverse("admin:matterhorn1_stockhistory_changelist")
+
+    with CaptureQueriesContext(connections[DB]) as ctx:
+        resp = admin_client.get(url)
+
+    assert resp.status_code == 200
+    # Przed fixem: ~1 zapytanie na wiersz (product_uid_link -> Product.objects.get).
+    # Po fixie: pk produktu z adnotacji (jedno skorelowane podzapytanie),
+    # reszta to stały narzut changelist/auth.
+    assert len(ctx.captured_queries) < 10, (
+        f"{len(ctx.captured_queries)} zapytań (matterhorn1) na changelist z 30 wierszami — podejrzenie N+1"
+    )
+
+
+def test_link_do_produktu_gdy_produkt_istnieje(admin_client):
+    _mk_history(1, with_product=True)
+    url = reverse("admin:matterhorn1_stockhistory_changelist")
+    resp = admin_client.get(url)
+    assert resp.status_code == 200
+    product = Product.objects.using(DB).get(product_uid=700000)
+    expected = reverse("admin:matterhorn1_product_change", args=[product.pk])
+    assert expected.encode() in resp.content
+
+
+def test_bez_produktu_link_to_sam_uid_bez_query(admin_client):
+    _mk_history(1, with_product=False)
+    url = reverse("admin:matterhorn1_stockhistory_changelist")
+    resp = admin_client.get(url)
+    assert resp.status_code == 200
+    assert b"700000" in resp.content
+
+
+def test_filtr_product_uid_zaweza_do_dokladnej_wartosci(admin_client):
+    _mk_history(5)
+    url = reverse("admin:matterhorn1_stockhistory_changelist")
+
+    resp = admin_client.get(url, {"product_uid": "700002"})
+
+    assert resp.status_code == 200
+    cl = resp.context["cl"]
+    assert cl.result_count == 1
+    assert cl.result_list[0].product_uid == 700002
+
+
+def test_filtr_product_uid_niepoprawna_wartosc_daje_pusto(admin_client):
+    _mk_history(3)
+    url = reverse("admin:matterhorn1_stockhistory_changelist")
+    resp = admin_client.get(url, {"product_uid": "abc"})
+    assert resp.status_code == 200
+    assert resp.context["cl"].result_count == 0

--- a/src/core/wholesaler_admin/__init__.py
+++ b/src/core/wholesaler_admin/__init__.py
@@ -1,4 +1,4 @@
-from .filters import make_scoped_filter
+from .filters import InputFilter, make_input_filter, make_scoped_filter
 from .fuzzy import fuzzy_suggest_mpd_products
 from .mpd_context import build_mpd_change_context
 from .permissions import ReadOnlyLogAdminMixin, RouterScopedQuerysetMixin
@@ -6,6 +6,8 @@ from .stock_history import StockHistoryAdminBase
 from .thumbnails import render_product_thumbnail, resolve_thumbnail_url
 
 __all__ = [
+    'InputFilter',
+    'make_input_filter',
     'make_scoped_filter',
     'fuzzy_suggest_mpd_products',
     'build_mpd_change_context',

--- a/src/core/wholesaler_admin/filters.py
+++ b/src/core/wholesaler_admin/filters.py
@@ -1,6 +1,59 @@
 from django.contrib.admin import SimpleListFilter
 
 
+class InputFilter(SimpleListFilter):
+    """Filtr admina z polem tekstowym zamiast listy wszystkich wartości.
+
+    Do pól o dużej kardynalności (np. `product_uid` w historii stanów - dziesiątki
+    tysięcy unikalnych wartości), gdzie zwykły `list_filter` renderuje w bocznym
+    pasku link na każdą wartość i strona ładuje się wieczność. Podklasa ustawia
+    `parameter_name`, `title` i implementuje `queryset()`.
+    """
+
+    template = 'admin/input_filter.html'
+
+    def lookups(self, request, model_admin):
+        # Musi zwrócić cokolwiek niepustego, żeby filtr się w ogóle pokazał;
+        # realne renderowanie robi szablon input_filter.html.
+        return ((),)
+
+    def choices(self, changelist):
+        all_choice = next(super().choices(changelist))
+        all_choice['query_parts'] = (
+            (k, v)
+            for k, v in changelist.get_filters_params().items()
+            if k != self.parameter_name
+        )
+        yield all_choice
+
+
+def make_input_filter(*, title, parameter_name, field_name=None, cast=None):
+    """Fabryka `InputFilter` filtrującego po dokładnej wartości wpisanej w pole.
+
+    `field_name` - pole modelu (domyślnie = `parameter_name`).
+    `cast` - opcjonalna konwersja wpisanego tekstu (np. `int`); przy błędzie
+    konwersji filtr zwraca pusty queryset.
+    """
+    _field = field_name or parameter_name
+
+    class _InputFilter(InputFilter):
+        def queryset(self, request, queryset):
+            value = self.value()
+            if not value:
+                return queryset
+            if cast is not None:
+                try:
+                    value = cast(value)
+                except (TypeError, ValueError):
+                    return queryset.none()
+            return queryset.filter(**{_field: value})
+
+    _InputFilter.title = title
+    _InputFilter.parameter_name = parameter_name
+    _InputFilter.__name__ = f'{parameter_name.title().replace("_", "")}InputFilter'
+    return _InputFilter
+
+
 def make_scoped_filter(*, title, parameter_name, counterpart_parameter_name,
                         related_model, related_label_field='name'):
     """Fabryka pary krzyżowo filtrujących się SimpleListFilter (np. Brand <-> Category),

--- a/src/templates/admin/input_filter.html
+++ b/src/templates/admin/input_filter.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<h3>{{ title }}</h3>
+<ul class="admin-filter-{{ title|cut:' '|lower }}">
+    <li>
+        <form method="GET" action="">
+            {% for k, v in choices.0.query_parts %}
+                <input type="hidden" name="{{ k }}" value="{{ v }}">
+            {% endfor %}
+            <input type="text" name="{{ spec.parameter_name }}"
+                   value="{{ spec.value|default_if_none:'' }}"
+                   placeholder="{{ spec.title }}" style="width: 100%; box-sizing: border-box;"/>
+        </form>
+    </li>
+</ul>

--- a/templates/admin/input_filter.html
+++ b/templates/admin/input_filter.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<h3>{{ title }}</h3>
+<ul class="admin-filter-{{ title|cut:' '|lower }}">
+    <li>
+        <form method="GET" action="">
+            {% for k, v in choices.0.query_parts %}
+                <input type="hidden" name="{{ k }}" value="{{ v }}">
+            {% endfor %}
+            <input type="text" name="{{ spec.parameter_name }}"
+                   value="{{ spec.value|default_if_none:'' }}"
+                   placeholder="{{ spec.title }}" style="width: 100%; box-sizing: border-box;"/>
+        </form>
+    </li>
+</ul>


### PR DESCRIPTION
## Problem

`/admin/matterhorn1/stockhistory/` ładował się kilka sekund. Tabela:
**~456 tys. wierszy**, **~38 tys. unikalnych `product_uid`**.

## Przyczyny i fix

### 1. `'product_uid'` w `list_filter` (główny winowajca)

`product_uid` to zwykły `IntegerField` (nie FK) → admin użył
`AllValuesFieldListFilter` i renderował w bocznym pasku link na **każdą
z ~38 tys. wartości**. Zapytanie `DISTINCT` jest szybkie (~0.1s), ale
wygenerowanie i wysłanie kilku MB HTML + render w przeglądarce = wieczność.

→ Nowy `InputFilter` / `make_input_filter` w `core.wholesaler_admin` —
filtr z polem tekstowym, wpisujesz konkretny `uid`. (Wyszukiwarka i tak
już obejmuje `product_uid` przez `search_fields`.)

### 2. N+1 w kolumnie `product_uid_link`

`obj.get_product_url()` robił `Product.objects.get(product_uid=...)`
**per wiersz** — 50 zapytań na stronę, każde jako round-trip przez tunel
SSH do bazy dev. → pk produktu z adnotacji `_product_pk` (jedno
skorelowane podzapytanie w głównym SELECT, po indeksie). Metoda
`StockHistory.get_product_url()` **usunięta** (była tylko źródłem N+1).

### 3. `show_full_result_count = False`

Bez zbędnego `COUNT(*)` całej tabeli przy aktywnym filtrze.

## Pomiary (realna baza dev, ~456k wierszy)

| | zapytań | czas (warm) | HTML |
|---|---|---|---|
| po fixie | 15 (było ~33 przez N+1) | ~0.3s | 69 KB |

W teście: changelist z 30 wierszami → **3 zapytania do matterhorn1**
(było ~33). Nowy `tests_integration_admin_stock_history.py`: regresja
liczby zapytań + działanie filtra `product_uid`. Pełen zestaw
`matterhorn1` (226) i `tabu` (31) bez regresji, `django check` czysty.

> Uwaga poboczna: reszta odczuwalnego opóźnienia na nc-dev to
> `django-debug-toolbar` renderujący się na każdej stronie admina (gdy
> wchodzisz z IP w `INTERNAL_IPS` przy `DEBUG=True`) — osobna sprawa, nie
> dotyczy tylko stockhistory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)