### PR TITLE
fix(matterhorn): idempotentny _bulk_update_inventory (duplikaty w StockHistory)

### DIFF
--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -1571,17 +1571,19 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
 
 
 def _bulk_update_inventory(inventory_data):
-    """Bulk update stanów magazynowych z INVENTORY API.
+    """Aktualizacja stanów magazynowych z INVENTORY API.
 
-    Batch pre-fetch produktów/wariantów + bulk_create dla StockHistory
-    zamiast query per produkt/wariant + create() per zmieniony wariant (ten
-    sam wzorzec N+1 co w _bulk_import_products, patrz #223). Nazwy dla
-    historii mamy zawsze z batcha, więc budujemy wiersze wprost zamiast
-    wołać track_stock_change() (ta ma własny per-wywołanie create() +
-    opcjonalny raw-SQL fallback na nazwy, którego tu nie potrzebujemy)."""
+    Batch pre-fetch produktów/wariantów (zamiast query per element, wzorzec
+    N+1 jak w _bulk_import_products, patrz #223). Sam zapis stanu robimy
+    warunkowym UPDATE-em per zmieniony wariant (`filter(pk=..., stock=old)
+    .update(...)`), a wiersz StockHistory zapisujemy TYLKO gdy ten UPDATE
+    faktycznie zmienił rząd - to jednocześnie idempotencja (re-run widzi już
+    nowy stan) i ochrona przed wyścigiem nakładających się runów importu,
+    które inaczej powielały wpisy historii dla tej samej zmiany. Nazwy do
+    historii mamy z batcha, więc budujemy wiersze wprost zamiast wołać
+    track_stock_change()."""
     try:
         from matterhorn1.models import Product, ProductVariant, StockHistory
-        from django.db import transaction
         from django.utils import timezone
 
         # Sprawdź czy dane są dostępne
@@ -1590,7 +1592,6 @@ def _bulk_update_inventory(inventory_data):
             return 0
 
         updated_count = 0
-        variants_to_update = []
         history_to_create = []
 
         # Batch pre-fetch: produkty po product_uid, warianty po variant_uid
@@ -1663,46 +1664,51 @@ def _bulk_update_inventory(inventory_data):
                 # Aktualizuj stan magazynowy
                 new_stock = int(variant_data.get('stock', 0)) if variant_data.get(
                     'stock', '0').isdigit() else 0
-                if variant.stock != new_stock:
-                    # Śledź zmianę stanu przed aktualizacją
-                    stock_change = new_stock - variant.stock
-                    change_type = (
-                        'increase' if stock_change > 0
-                        else 'decrease' if stock_change < 0 else 'no_change'
-                    )
-                    history_to_create.append(StockHistory(
-                        variant_uid=variant.variant_uid,
-                        product_uid=product.product_uid,
-                        product_name=product.name,
-                        variant_name=variant.name,
-                        old_stock=variant.stock,
-                        new_stock=new_stock,
-                        stock_change=stock_change,
-                        change_type=change_type,
-                    ))
+                if variant.stock == new_stock:
+                    continue
 
-                    variant.stock = new_stock
-                    # bulk_update() nie wywołuje save(), więc auto_now na
-                    # updated_at się nie odpali - trzeba ustawić ręcznie,
-                    # bo bridge MPD.tasks.update_stock_from_matterhorn1
-                    # filtruje warianty właśnie po updated_at.
-                    variant.updated_at = timezone.now()
-                    variants_to_update.append(variant)
+                old_stock = variant.stock
+                # Warunkowy UPDATE: zmieni rząd tylko jeśli stan w DB NADAL ==
+                # old_stock. Jeśli inny run (albo redeliver ubitego taska) już
+                # złapał ten sam przeskok, zwróci 0 - wtedy NIE zapisujemy
+                # wiersza historii. Idempotencja + brak wyścigu (to WHERE
+                # stock=old_stock serializuje pisarzy) - patrz duplikaty w
+                # StockHistory przy nakładających się runach importu.
+                # updated_at ustawiane wprost, bo bridge
+                # MPD.tasks.update_stock_from_matterhorn1 filtruje po nim.
+                changed = ProductVariant.objects.using('matterhorn1').filter(
+                    pk=variant.pk, stock=old_stock
+                ).update(stock=new_stock, updated_at=timezone.now())
+                if not changed:
+                    continue
 
-        # Bulk update wariantów + bulk create historii
-        if variants_to_update:
-            with transaction.atomic(using='matterhorn1'):
-                ProductVariant.objects.using('matterhorn1').bulk_update(
-                    variants_to_update,
-                    ['stock', 'updated_at'],
-                    batch_size=100
+                stock_change = new_stock - old_stock
+                change_type = (
+                    'increase' if stock_change > 0
+                    else 'decrease' if stock_change < 0 else 'no_change'
                 )
-                if history_to_create:
-                    StockHistory.objects.using('matterhorn1').bulk_create(
-                        history_to_create, batch_size=100)
-                updated_count = len(variants_to_update)
-                logger.info(
-                    f"✅ INVENTORY bulk update: {updated_count} wariantów")
+                history_to_create.append(StockHistory(
+                    variant_uid=variant.variant_uid,
+                    product_uid=product.product_uid,
+                    product_name=product.name,
+                    variant_name=variant.name,
+                    old_stock=old_stock,
+                    new_stock=new_stock,
+                    stock_change=stock_change,
+                    change_type=change_type,
+                ))
+                updated_count += 1
+
+        # Warianty już zaktualizowane warunkowo wyżej; historia to log - zapis
+        # osobno (bez wspólnej transakcji, żeby ew. błąd bulk_create nie cofał
+        # zaktualizowanych stanów i nie prowadził do ponownego zapisu przy
+        # następnym runie).
+        if history_to_create:
+            StockHistory.objects.using('matterhorn1').bulk_create(
+                history_to_create, batch_size=100)
+            logger.info(
+                f"✅ INVENTORY bulk update: {updated_count} wariantów, "
+                f"{len(history_to_create)} wpisów historii")
 
         return updated_count
 

--- a/src/apps/matterhorn1/tests/tests_performance_bulk_update_inventory.py
+++ b/src/apps/matterhorn1/tests/tests_performance_bulk_update_inventory.py
@@ -1,13 +1,10 @@
 """
-Regresja wydajności: `_bulk_update_inventory` musi skalować się w stałej
-(małej) liczbie zapytań SQL na stronę, nie liniowo z liczbą produktów/
-wariantów (ten sam N+1 wzorzec co #223, tu w kroku INVENTORY).
-
-Przed fixem: query per produkt (`Product.objects.get`), query per wariant
-(`ProductVariant.objects.get`) i `StockHistory.objects.create()` per zmieniony
-wariant - strona 1000 pozycji = do ~3000 zapytań. Ten test aktualizuje stan
-20 wariantów (z czego połowa faktycznie się zmienia) i pilnuje że liczba
-zapytań zostaje płasko-mała, niezależna od N.
+`_bulk_update_inventory`:
+- pre-fetch produktów/wariantów batchem (nie query per element - wzorzec N+1
+  jak #223), więc liczba SELECT-ów nie rośnie z liczbą wariantów w danych,
+  tylko warunkowy UPDATE per FAKTYCZNIE zmieniony wariant (w praktyce garstka);
+- idempotencja: drugi run z tymi samymi danymi nie powiela wpisów StockHistory
+  (regresja na duplikaty przy nakładających się runach importu).
 """
 from __future__ import annotations
 
@@ -24,10 +21,6 @@ pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases=["default
 DB = "matterhorn1"
 
 N_PRODUCTS = 20
-# Płaski budżet: pre-fetch produktów + wariantów (2 SELECT-y) + bulk_update
-# wariantów + bulk_create historii + BEGIN/COMMIT. Rośnie z liczbą modeli
-# dotkniętych, nie z N.
-MAX_QUERIES = 15
 
 
 @pytest.fixture
@@ -43,40 +36,59 @@ def products_with_variants():
     return variants
 
 
-def _make_inventory(variants):
-    # Co drugi wariant zmienia stan (10 -> 3), reszta bez zmiany (10 -> 10).
+def _inventory(variants, changed_idx):
+    """INVENTORY dla wszystkich wariantów; te z `changed_idx` dostają stock=3,
+    reszta zostaje na 10 (bez zmiany)."""
     return [
         inventory_record(
             item_id=v.product.product_uid,
-            variants=[{"variant_uid": v.variant_uid, "stock": 3 if i % 2 == 0 else 10}],
+            variants=[{"variant_uid": v.variant_uid, "stock": 3 if i in changed_idx else 10}],
         )
         for i, v in enumerate(variants)
     ]
 
 
-def test_zapytania_nie_rosna_liniowo_z_liczba_wariantow(products_with_variants):
-    inventory_data = _make_inventory(products_with_variants)
+def test_liczba_zapytan_skaluje_sie_ze_zmienionymi_nie_z_wszystkimi(products_with_variants):
+    # 20 wariantów w danych, ale tylko 2 faktycznie się zmieniają.
+    data = _inventory(products_with_variants, changed_idx={0, 1})
 
     with CaptureQueriesContext(connections[DB]) as ctx:
-        updated_count = _bulk_update_inventory(inventory_data)
+        updated = _bulk_update_inventory(data)
 
-    assert updated_count == N_PRODUCTS // 2
-    assert len(ctx.captured_queries) < MAX_QUERIES, (
-        f"{len(ctx.captured_queries)} zapytań dla {N_PRODUCTS} wariantów — "
-        f"podejrzenie N+1 (query/create per element zamiast batcha)"
+    assert updated == 2
+    assert StockHistory.objects.using(DB).count() == 2
+    # 2 SELECT-y pre-fetch + 2 warunkowe UPDATE-y + 1 bulk_create.
+    # Kluczowe: NIE ~20 (query per wariant w danych).
+    assert len(ctx.captured_queries) <= 8, (
+        f"{len(ctx.captured_queries)} zapytań dla 20 wariantów w danych (2 zmienione) — "
+        f"podejrzenie query per element"
     )
-    assert StockHistory.objects.using(DB).count() == N_PRODUCTS // 2
 
 
-def test_zapytania_przy_ponownej_aktualizacji_tez_plaskie(products_with_variants):
-    inventory_data = _make_inventory(products_with_variants)
-    _bulk_update_inventory(inventory_data)
+def test_drugi_run_z_tymi_samymi_danymi_nie_powiela_historii(products_with_variants):
+    data = _inventory(products_with_variants, changed_idx={0, 1, 2})
+    assert _bulk_update_inventory(data) == 3
+    assert StockHistory.objects.using(DB).count() == 3
 
     with CaptureQueriesContext(connections[DB]) as ctx:
-        updated_count = _bulk_update_inventory(inventory_data)
+        updated = _bulk_update_inventory(data)
 
-    # Drugi przebieg z tymi samymi danymi: stan już zaktualizowany, więc
-    # nic się nie zmienia, ale pre-fetch nadal leci (2 SELECT-y + brak
-    # bulk_update/bulk_create bo nic do zapisania).
-    assert updated_count == 0
-    assert len(ctx.captured_queries) < MAX_QUERIES
+    # Stany już zaktualizowane -> nic do zrobienia, żadnego nowego wpisu.
+    assert updated == 0
+    assert StockHistory.objects.using(DB).count() == 3
+    # Same pre-fetch SELECT-y, bez UPDATE-ów i bez bulk_create.
+    assert len(ctx.captured_queries) <= 4
+
+
+def test_stan_juz_docelowy_w_dbie_nie_zapisuje_historii(products_with_variants):
+    """Inny run zdążył już zastosować tę zmianę - pre-fetch widzi stan
+    docelowy, więc nic nie robimy i nie ma wpisu (idempotencja)."""
+    variants = products_with_variants
+    data = _inventory(variants, changed_idx={0})
+
+    ProductVariant.objects.using(DB).filter(pk=variants[0].pk).update(stock=3)
+
+    updated = _bulk_update_inventory(data)
+
+    assert updated == 0
+    assert StockHistory.objects.using(DB).count() == 0


### PR DESCRIPTION
## Problem (zgłoszony z podglądu StockHistory)

W `matterhorn1_stock_history` powielały się wpisy dla tej samej zmiany
stanu. Przykład: wariant `1292763` (3→2) zapisany 3× w ciągu 10 minut
przez 3 różne runy `full_import_and_update`; niektóre warianty mają
setki identycznych wierszy.

## Przyczyna

1. **Nakładające się runy importu.** Restart `celery-import` w połowie
   taska → Celery nie dostaje ACK → **redeliveruje** taska po czasie. Wraca
   i przelatuje INVENTORY ponownie, równolegle z runem z beat.
2. **`_bulk_update_inventory` nie był idempotentny.** Decyzja "zapisz
   wiersz historii" opierała się na `variant.stock != new_stock`
   odczytanym **poza transakcją**. Dwa runy widzą ten sam stan "przed" i
   **oba** piszą wpis. Dodatkowo `bulk_update` stanu i `bulk_create`
   historii były w jednej `transaction.atomic` — przy nakładających się
   commitach stan się nie utrwalał, a historia tak, więc następny run
   znów łapał "zmianę".

## Fix

Dla każdego zmienionego wariantu — warunkowy UPDATE:

```python
changed = ProductVariant.objects.using('matterhorn1').filter(
    pk=variant.pk, stock=old_stock
).update(stock=new_stock, updated_at=timezone.now())
if changed:
    history_to_create.append(StockHistory(...))
```

Wiersz `StockHistory` **tylko gdy UPDATE naprawdę zmienił rząd**:

- **idempotencja** — re-run widzi już nowy stan → 0 rzędów → brak wpisu;
- **brak wyścigu** — `WHERE stock=old_stock` serializuje pisarzy, tylko
  jeden łapie przejście;
- `bulk_create` historii **poza** wspólną transakcją — jego błąd nie cofa
  zaktualizowanych stanów (co prowadziło do ponownego zapisu w kolejnym runie).

Koszt: kilka warunkowych UPDATE-ów na run (tylko **faktycznie** zmienione
warianty — z logów 1-7/stronę), nie N+1 na wszystkie. Batch pre-fetch
produktów/wariantów (#223) zostaje.

## Testy

`tests_performance_bulk_update_inventory.py` przepisany:
- liczba zapytań skaluje się ze **zmienionymi** wariantami, nie wszystkimi
  w danych (20 w danych, 2 zmienione → ≤8 zapytań);
- drugi run z tymi samymi danymi nie tworzy nowych wpisów historii;
- stan już docelowy w DB → brak wpisu.

Pełen zestaw `matterhorn1` (222) bez regresji.

> Redeliver/nakładające się taski to osobny, szerszy temat (ta sama dziura
> co zawieszone locki) — do issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)