### PR TITLE
chore(matterhorn): komenda dedupe_stock_history do czyszczenia duplikatów

### DIFF
--- a/src/apps/matterhorn1/management/commands/dedupe_stock_history.py
+++ b/src/apps/matterhorn1/management/commands/dedupe_stock_history.py
@@ -1,0 +1,109 @@
+"""
+Czyści zduplikowane wpisy w `matterhorn1_stock_history`, które powstały przy
+nakładających się runach importu INVENTORY (beat + redeliver ubitego taska)
+- ta sama zmiana stanu zapisana kilka razy w krótkim odstępie.
+
+Kod importu jest już idempotentny (warunkowy UPDATE w `_bulk_update_inventory`),
+ta komenda sprząta HISTORYCZNE duplikaty.
+
+Kryterium duplikatu (konserwatywne - nie rusza legalnych powtórzeń zmiany):
+dla danego wariantu, kolejne wpisy (po timestamp) o IDENTYCZNYM przejściu
+`old_stock -> new_stock`, których timestamp mieści się w oknie od pierwszego
+z serii. Legalne powtórzenie tego samego przejścia wymaga wpisu odwrotnego
+pomiędzy (żeby stan wrócił), więc dwa takie same przejścia pod rząd bez
+niczego pomiędzy = duplikat. Okno czasowe chroni przed usunięciem realnych
+powtórzeń oddalonych o godziny/dni (gdy wpis odwrotny gdzieś przepadł).
+
+Domyślnie DRY-RUN. Realne usunięcie: --execute.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+
+from core.db_routers import _get_matterhorn1_db
+from matterhorn1.models import StockHistory
+
+
+class Command(BaseCommand):
+    help = "Usuwa zduplikowane wpisy StockHistory z nakładających się runów importu"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--execute', action='store_true',
+            help='Faktycznie usuń (bez tego tylko raport - dry run)')
+        parser.add_argument(
+            '--window-minutes', type=int, default=15,
+            help='Maksymalny odstęp od pierwszego wpisu z serii, by uznać kolejny '
+                 'za duplikat (domyślnie 15 - obejmuje cykl beat 10 min + opóźnienie; '
+                 'szersze okno łapie też re-recordy z buga transakcji, ale mniej pewnie)')
+        parser.add_argument(
+            '--limit-sample', type=int, default=20,
+            help='Ile przykładowych duplikatów wypisać')
+
+    def handle(self, *args, **opts):
+        db = _get_matterhorn1_db()
+        window = timedelta(minutes=opts['window_minutes'])
+        execute = opts['execute']
+
+        qs = (StockHistory.objects.using(db)
+              .order_by('variant_uid', 'timestamp', 'id')
+              .values('id', 'variant_uid', 'old_stock', 'new_stock',
+                      'change_type', 'timestamp', 'product_name'))
+
+        dup_ids = []
+        samples = []
+        prev = None          # poprzedni wpis (dowolny) dla tego wariantu
+        keeper = None        # pierwszy wpis bieżącej serii identycznych przejść
+
+        for row in qs.iterator(chunk_size=5000):
+            same_variant = prev is not None and row['variant_uid'] == prev['variant_uid']
+            same_transition = (
+                same_variant
+                and row['old_stock'] == prev['old_stock']
+                and row['new_stock'] == prev['new_stock']
+            )
+
+            if same_transition and keeper is not None and \
+                    row['timestamp'] - keeper['timestamp'] <= window:
+                dup_ids.append(row['id'])
+                if len(samples) < opts['limit_sample']:
+                    samples.append((keeper, row))
+            elif same_transition and keeper is not None:
+                # to samo przejście, ale poza oknem - traktujemy jako nowy keeper
+                keeper = row
+            else:
+                keeper = row
+
+            prev = row
+
+        total = StockHistory.objects.using(db).count()
+        self.stdout.write(
+            f"StockHistory: {total} wpisów, znaleziono {len(dup_ids)} duplikatów "
+            f"(okno {opts['window_minutes']} min)")
+
+        for keeper, dup in samples:
+            self.stdout.write(
+                f"  keep id={keeper['id']} {keeper['timestamp']:%Y-%m-%d %H:%M:%S}"
+                f"  <-  del id={dup['id']} {dup['timestamp']:%H:%M:%S}"
+                f"  [{dup['variant_uid']}: {dup['old_stock']}->{dup['new_stock']}"
+                f" {dup['product_name']}]")
+        if len(dup_ids) > len(samples):
+            self.stdout.write(f"  ... i {len(dup_ids) - len(samples)} więcej")
+
+        if not dup_ids:
+            self.stdout.write(self.style.SUCCESS("Brak duplikatów do usunięcia"))
+            return
+
+        if not execute:
+            self.stdout.write(self.style.WARNING(
+                "DRY RUN - nic nie usunięto. Uruchom z --execute żeby usunąć."))
+            return
+
+        deleted = 0
+        for i in range(0, len(dup_ids), 1000):
+            batch = dup_ids[i:i + 1000]
+            n, _ = StockHistory.objects.using(db).filter(id__in=batch).delete()
+            deleted += n
+        self.stdout.write(self.style.SUCCESS(f"Usunięto {deleted} zduplikowanych wpisów"))

--- a/src/apps/matterhorn1/tests/tests_integration_dedupe_stock_history.py
+++ b/src/apps/matterhorn1/tests/tests_integration_dedupe_stock_history.py
@@ -1,0 +1,73 @@
+"""
+Integration: komenda `dedupe_stock_history` - usuwa wpisy StockHistory
+powielone przez nakładające się runy importu, nie rusza legalnych powtórzeń
+tej samej zmiany (oddalonych w czasie / z wpisem odwrotnym pomiędzy).
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from core.db_routers import _get_matterhorn1_db
+from matterhorn1.models import StockHistory
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(databases="__all__")]
+DB = _get_matterhorn1_db()
+
+
+def _row(variant_uid, old, new, ts):
+    r = StockHistory.objects.using(DB).create(
+        variant_uid=variant_uid, product_uid=1, product_name="P", variant_name="M",
+        old_stock=old, new_stock=new, stock_change=new - old,
+        change_type="decrease" if new < old else "increase")
+    StockHistory.objects.using(DB).filter(pk=r.pk).update(timestamp=ts)
+    return r.pk
+
+
+def test_usuwa_powielone_w_oknie_zostawia_pierwszy():
+    t0 = timezone.now()
+    keep = _row("V1", 3, 2, t0)
+    dup1 = _row("V1", 3, 2, t0 + timedelta(minutes=1))
+    dup2 = _row("V1", 3, 2, t0 + timedelta(minutes=9))
+
+    call_command("dedupe_stock_history", "--execute", "--window-minutes", "15")
+
+    ids = set(StockHistory.objects.using(DB).values_list("id", flat=True))
+    assert keep in ids
+    assert dup1 not in ids and dup2 not in ids
+
+
+def test_nie_rusza_powtorzenia_z_wpisem_odwrotnym_pomiedzy():
+    t0 = timezone.now()
+    a = _row("V2", 3, 2, t0)
+    b = _row("V2", 2, 3, t0 + timedelta(minutes=3))   # restock pomiędzy
+    c = _row("V2", 3, 2, t0 + timedelta(minutes=6))
+
+    call_command("dedupe_stock_history", "--execute", "--window-minutes", "15")
+
+    ids = set(StockHistory.objects.using(DB).values_list("id", flat=True))
+    assert {a, b, c} <= ids
+
+
+def test_nie_rusza_tego_samego_przejscia_poza_oknem():
+    t0 = timezone.now()
+    a = _row("V3", 1, 0, t0)
+    b = _row("V3", 1, 0, t0 + timedelta(hours=20))   # kolejny dzień, restock nie zalogowany
+
+    call_command("dedupe_stock_history", "--execute", "--window-minutes", "15")
+
+    ids = set(StockHistory.objects.using(DB).values_list("id", flat=True))
+    assert {a, b} <= ids
+
+
+def test_dry_run_domyslnie_nic_nie_usuwa():
+    t0 = timezone.now()
+    _row("V4", 5, 4, t0)
+    _row("V4", 5, 4, t0 + timedelta(minutes=2))
+
+    call_command("dedupe_stock_history", "--window-minutes", "15")
+
+    assert StockHistory.objects.using(DB).filter(variant_uid="V4").count() == 2


### PR DESCRIPTION
## Po co

`#230` zablokował powstawanie **nowych** duplikatów w
`matterhorn1_stock_history`. Ta komenda sprząta **historyczne** — na dev
**~20 tys. z ~456 tys.** wpisów (duplikaty ciągną się od stycznia 2026).

## Kryterium (konserwatywne)

Dla danego wariantu: kolejne wpisy (po `timestamp`) o **identycznym**
przejściu `old_stock -> new_stock`, **bez wpisu odwrotnego pomiędzy**, w
oknie czasowym od pierwszego z serii (domyślnie **15 min** — cykl beat
10 min + opóźnienie).

Legalne powtórzenie tego samego przejścia wymaga wpisu odwrotnego
pomiędzy (żeby stan wrócił do `old_stock`) — takie zostają. Powtórzenia
oddalone o godziny/dni też zostają (np. codzienny wyprzedaż `1->0`, gdzie
restock `0->1` gdzieś przepadł — osobny, mniejszy problem).

## Użycie

```bash
python manage.py dedupe_stock_history                    # DRY RUN - raport
python manage.py dedupe_stock_history --execute          # faktyczne usunięcie
python manage.py dedupe_stock_history --window-minutes 30  # szersze okno
```

Szersze okno (30-60 min) łapie też re-recordy z buga transakcji sprzed
#230, ale mniej pewnie — domyślne 15 min jest bezpieczne.

## Testy

`tests_integration_dedupe_stock_history.py`: usuwa powielone w oknie
(zostawia pierwszy), nie rusza powtórzenia z wpisem odwrotnym pomiędzy
ani tego samego przejścia poza oknem, dry-run domyślny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)