### PR TITLE
test(tabu): infra testowa + pokrycie sync stanów (#233 faza 1)

### DIFF
--- a/src/apps/tabu/tests.py
+++ b/src/apps/tabu/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/src/apps/tabu/tests/conftest.py
+++ b/src/apps/tabu/tests/conftest.py
@@ -1,0 +1,34 @@
+"""
+Fixture'y wspólne dla testów `tabu` (warstwa integration/e2e).
+
+`no_sleep` autouse — `sync_tabu_stock` woła `time.sleep(1)` po każdej stronie
+(limit API), a `base_tabu_api_command` `time.sleep(2)` przy retry / `120` przy
+429. Bez tego testy trwałyby minuty.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    for target in (
+        "tabu.management.commands.sync_tabu_stock.time.sleep",
+        "tabu.management.commands.base_tabu_api_command.time.sleep",
+    ):
+        monkeypatch.setattr(target, lambda *_a, **_k: None, raising=False)
+
+
+@pytest.fixture
+def tabu_api(settings):
+    """Adres + klucz API na wartości testowe."""
+    settings.TABU_API_BASE_URL = "https://tabu.test"
+    settings.TABU_API_KEY = "test-key"
+    return settings
+
+
+@pytest.fixture
+def mocked_responses():
+    import responses
+    with responses.RequestsMock() as rsps:
+        yield rsps

--- a/src/apps/tabu/tests/factories.py
+++ b/src/apps/tabu/tests/factories.py
@@ -1,0 +1,75 @@
+"""
+Buildery obiektów DB i ładunków API Tabu.
+
+Wartości domyślne = minimalny poprawny rekord; nadpisujesz tylko to, co
+testuje dany przypadek. `db` domyślnie `default` — w trybie testowym
+`DATABASE_ROUTERS = []`, więc modele `tabu` i tak lądują na `default`
+(patrz `sync_tabu_stock` — `router.db_for_write` → `default`).
+"""
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+from django.utils import timezone
+
+from tabu.models import Brand, Category, TabuProduct, TabuProductVariant
+
+_pid = itertools.count(500_000)
+_vid = itertools.count(700_000)
+
+
+def brand(db: str = "default", **over: Any) -> Brand:
+    data = {"brand_id": f"B{next(_pid)}", "name": "Marka"}
+    data.update(over)
+    return Brand.objects.using(db).create(**data)
+
+
+def category(db: str = "default", **over: Any) -> Category:
+    data = {"category_id": f"C{next(_pid)}", "name": "Kategoria", "path": "Damskie/Bluzki"}
+    data.update(over)
+    return Category.objects.using(db).create(**data)
+
+
+def tabu_product(db: str = "default", **over: Any) -> TabuProduct:
+    api_id = over.pop("api_id", None) or next(_pid)
+    data = {
+        "api_id": api_id,
+        "symbol": f"SYM-{api_id}",
+        "name": f"Produkt {api_id}",
+        "last_update": timezone.now(),
+        "store_total": 0,
+        "price_net": "100.00",
+        "price_gross": "123.00",
+    }
+    data.update(over)
+    return TabuProduct.objects.using(db).create(**data)
+
+
+def tabu_variant(product: TabuProduct, db: str = "default", **over: Any) -> TabuProductVariant:
+    api_id = over.pop("api_id", None) or next(_vid)
+    data = {
+        "api_id": api_id,
+        "product": product,
+        "symbol": f"VAR-{api_id}",
+        "ean": "5901234567890",
+        "store": 5,
+        "price_net": "100.00",
+        "price_gross": "123.00",
+        "size": "M",
+        "color": "czarny",
+    }
+    data.update(over)
+    return TabuProductVariant.objects.using(db).create(**data)
+
+
+def basic_record(*, product_api_id: int, variant_api_id: int, store: int,
+                 price_net=None, price_gross=None) -> dict:
+    """Pojedynczy rekord z `GET products/basic` — płaska lista wariantów
+    (`id` = produkt, `variant_id` = wariant)."""
+    r = {"id": product_api_id, "variant_id": variant_api_id, "store": store}
+    if price_net is not None:
+        r["price_net"] = str(price_net)
+    if price_gross is not None:
+        r["price_gross"] = str(price_gross)
+    return r

--- a/src/apps/tabu/tests/mock_tabu.py
+++ b/src/apps/tabu/tests/mock_tabu.py
@@ -1,0 +1,40 @@
+"""
+Mock API Tabu (`responses`). `GET {base}/products/basic` — stronicowana płaska
+lista wariantów; kolejne `?page=N` zwracają kolejne elementy listy `pages`,
+strona za końcem zwraca `{'products': []}` (command traktuje to jako koniec).
+"""
+from __future__ import annotations
+
+import json
+
+import responses
+
+BASIC_PATH = "products/basic"
+
+
+def _base(settings) -> str:
+    return (settings.TABU_API_BASE_URL or "https://tabu.test").rstrip("/")
+
+
+def mock_products_basic(rsps, settings, pages: list[list[dict]],
+                        total: int | None = None) -> None:
+    """`pages` = lista stron, każda to lista rekordów (`factories.basic_record`)."""
+    url = f"{_base(settings)}/{BASIC_PATH}"
+
+    def _cb(request):
+        try:
+            page = int(request.params.get("page", "1"))
+        except (TypeError, ValueError):
+            page = 1
+        idx = page - 1
+        body = pages[idx] if 0 <= idx < len(pages) else []
+        payload = {"products": body}
+        if total is not None:
+            payload["total"] = total
+        return (200, {"Content-Type": "application/json"}, json.dumps(payload))
+
+    rsps.add_callback(responses.GET, url, callback=_cb, content_type="application/json")
+
+
+def mock_products_basic_error(rsps, settings, status: int = 500) -> None:
+    rsps.add(responses.GET, f"{_base(settings)}/{BASIC_PATH}", status=status)

--- a/src/apps/tabu/tests/tests_integration_sync_stock.py
+++ b/src/apps/tabu/tests/tests_integration_sync_stock.py
@@ -1,0 +1,125 @@
+"""
+Integration: `sync_tabu_stock` — aktualizacja stanów/cen z `GET products/basic`.
+
+Utrwala OBECNE zachowanie (per-wariant `.get()`/`save()` + `store_total`
+przyrostowo + `_should_skip_processing`) jako punkt odniesienia przed
+refaktorem (issue #233).
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.core.management import call_command
+
+from tabu.models import ApiSyncLog, StockHistory, TabuProductVariant
+from tabu.management.commands.sync_tabu_stock import Command
+
+from . import factories
+from .mock_tabu import mock_products_basic
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+class TestUpdateVariant:
+    """`Command._update_variant` wołany bezpośrednio."""
+
+    @pytest.fixture
+    def cmd(self):
+        return Command()
+
+    def test_zmiana_stanu_aktualizuje_wariant_produkt_i_pisze_historie(self, cmd):
+        p = factories.tabu_product(api_id=1000, store_total=5)
+        v = factories.tabu_variant(p, api_id=2000, store=5)
+
+        hist, compared, changed = cmd._update_variant(
+            factories.basic_record(product_api_id=1000, variant_api_id=2000, store=2))
+
+        assert (hist, compared, changed) == (1, 1, 1)
+        v.refresh_from_db()
+        p.refresh_from_db()
+        assert v.store == 2
+        assert p.store_total == 2  # 5 - 5 + 2
+        h = StockHistory.objects.get(variant_api_id=2000)
+        assert (h.old_stock, h.new_stock) == (5, 2)
+
+    def test_brak_zmiany_stanu_bez_historii(self, cmd):
+        p = factories.tabu_product(api_id=1001)
+        factories.tabu_variant(p, api_id=2001, store=7)
+
+        hist, compared, changed = cmd._update_variant(
+            factories.basic_record(product_api_id=1001, variant_api_id=2001, store=7))
+
+        assert (hist, compared, changed) == (0, 1, 0)
+        assert StockHistory.objects.count() == 0
+
+    def test_nieznany_wariant_jest_pomijany(self, cmd):
+        assert cmd._update_variant(
+            factories.basic_record(product_api_id=9, variant_api_id=999999, store=1)
+        ) == (0, 0, 0)
+
+    def test_brak_variant_id_pomijany(self, cmd):
+        assert cmd._update_variant({"id": 1, "store": 3}) == (0, 0, 0)
+
+    def test_aktualizuje_ceny_gdy_podane(self, cmd):
+        p = factories.tabu_product(api_id=1002)
+        v = factories.tabu_variant(p, api_id=2002, store=1, price_net="10.00")
+
+        cmd._update_variant(factories.basic_record(
+            product_api_id=1002, variant_api_id=2002, store=1,
+            price_net="19.99", price_gross="24.59"))
+
+        v.refresh_from_db()
+        assert v.price_net == Decimal("19.99")
+        assert v.price_gross == Decimal("24.59")
+
+
+class TestSyncTabuStockCommand:
+    """Pełny przebieg `call_command('sync_tabu_stock', ...)`."""
+
+    def _run(self, **extra):
+        call_command(
+            "sync_tabu_stock", "--api-url", "https://tabu.test",
+            "--api-key", "test-key", **extra)
+
+    def test_pelny_przebieg_aktualizuje_i_loguje(self, tabu_api, mocked_responses):
+        p = factories.tabu_product(api_id=1, store_total=10)
+        factories.tabu_variant(p, api_id=11, store=5)
+        factories.tabu_variant(p, api_id=12, store=5)
+        mock_products_basic(mocked_responses, tabu_api, [
+            [
+                factories.basic_record(product_api_id=1, variant_api_id=11, store=3),
+                factories.basic_record(product_api_id=1, variant_api_id=12, store=0),
+            ],
+            [],
+        ])
+
+        self._run(**{"update_from": "2026-01-01 00:00:00"})
+
+        assert TabuProductVariant.objects.get(api_id=11).store == 3
+        assert TabuProductVariant.objects.get(api_id=12).store == 0
+        assert StockHistory.objects.count() == 2
+        log = ApiSyncLog.objects.filter(sync_type="stock_update").latest("started_at")
+        assert log.status == "completed"
+        assert log.products_processed == 2
+
+    def test_skip_gdy_ta_sama_liczba_rekordow_co_poprzednio(self, tabu_api, mocked_responses):
+        # OBECNE zachowanie (znane ograniczenie #233 pkt 2): jeśli poprzedni
+        # zakończony run stock_update miał tyle samo `products_processed`,
+        # cały bieżący run jest pomijany.
+        ApiSyncLog.objects.create(
+            sync_type="stock_update", status="completed", products_processed=1)
+        p = factories.tabu_product(api_id=2)
+        factories.tabu_variant(p, api_id=21, store=5)
+        mock_products_basic(mocked_responses, tabu_api, [
+            [factories.basic_record(product_api_id=2, variant_api_id=21, store=1)],
+            [],
+        ])
+
+        self._run(**{"update_from": "2026-01-01 00:00:00"})
+
+        # zmiana 5->1 NIE została zastosowana - run pominięty
+        assert TabuProductVariant.objects.get(api_id=21).store == 5
+        assert StockHistory.objects.count() == 0
+        log = ApiSyncLog.objects.filter(sync_type="stock_update").latest("started_at")
+        assert log.raw_response.get("skipped_reason") == "same_count_as_previous_run"

--- a/src/apps/tabu/tests/tests_unit_stock_tracker.py
+++ b/src/apps/tabu/tests/tests_unit_stock_tracker.py
@@ -1,0 +1,39 @@
+"""
+Unit: `tabu.stock_tracker.track_stock_change` — zapis pojedynczej zmiany
+stanu do `StockHistory`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tabu.models import StockHistory
+from tabu.stock_tracker import track_stock_change
+
+pytestmark = pytest.mark.django_db
+
+
+def test_zapisuje_wiersz_ze_spadkiem_stanu():
+    sh = track_stock_change(
+        variant_api_id=111, product_api_id=222, old_stock=5, new_stock=3,
+        product_name="Bluzka", variant_symbol="BL-M")
+
+    assert sh is not None
+    row = StockHistory.objects.get(pk=sh.pk)
+    assert (row.old_stock, row.new_stock, row.stock_change) == (5, 3, -2)
+    assert row.change_type == "decrease"
+    assert row.product_name == "Bluzka" and row.variant_symbol == "BL-M"
+
+
+def test_wzrost_i_brak_zmiany():
+    up = track_stock_change(variant_api_id=1, product_api_id=1, old_stock=0, new_stock=4)
+    same = track_stock_change(variant_api_id=2, product_api_id=1, old_stock=4, new_stock=4)
+
+    assert StockHistory.objects.get(pk=up.pk).change_type == "increase"
+    assert StockHistory.objects.get(pk=same.pk).change_type == "no_change"
+
+
+def test_none_traktowane_jak_zero():
+    sh = track_stock_change(variant_api_id=1, product_api_id=1, old_stock=None, new_stock=None)
+    row = StockHistory.objects.get(pk=sh.pk)
+    assert (row.old_stock, row.new_stock, row.stock_change) == (0, 0, 0)
+    assert row.change_type == "no_change"


### PR DESCRIPTION
Faza 1 z [#233](https://github.com/pawlo884/nc/issues/233). Analogicznie do
matterhorn1 (#210–#216).

## Co

- **`tabu/tests/`** — pakiet testowy jak `matterhorn1/tests/`:
  - `factories.py` — buildery obiektów DB (`tabu_product`, `tabu_variant`,
    `brand`, `category`) + rekordów `products/basic` (`basic_record`).
  - `mock_tabu.py` — `responses` dla `GET products/basic` (stronicowanie).
  - `conftest.py` — `no_sleep` (autouse), `tabu_api`, `mocked_responses`.
- **`tests_unit_stock_tracker.py`** — `track_stock_change` (spadek / wzrost /
  no_change / None).
- **`tests_integration_sync_stock.py`**:
  - `_update_variant` — zmiana stanu → wariant + `store_total` + `StockHistory`;
    brak zmiany → bez wpisu; nieznany wariant / brak `variant_id` → pominięcie;
    aktualizacja cen.
  - `call_command('sync_tabu_stock')` — happy path + **utrwalone znane
    ograniczenie** `_should_skip_processing` (pomija run przy tej samej liczbie
    rekordów — #233 pkt 2, fix w fazie 2).

Usunięty pusty stub `tabu/tests.py` (kolidował z pakietem `tests/`, jak
`tests.py` → `tests_api.py` w matterhorn1).

## Testy

41 testów `tabu` przechodzi (31 dotychczasowych + 10 nowych). Bez zmian w
kodzie produkcyjnym.

🤖 Generated with [Claude Code](https://claude.com/claude-code)