### PR TITLE
fix(tabu): pomijaj sync stanów tylko przy identycznych danych (#233 faza 2)

### DIFF
--- a/src/apps/tabu/management/commands/sync_tabu_stock.py
+++ b/src/apps/tabu/management/commands/sync_tabu_stock.py
@@ -94,10 +94,12 @@ class Command(BaseTabuAPICommand):
 
             self.stdout.write(f'   Pobrano {len(all_products)} rekordów (wariantów)')
 
-            if update_from and not dry_run and self._should_skip_processing(len(all_products)):
+            fetch_fingerprint = self._fetch_fingerprint(all_products)
+
+            if update_from and not dry_run and self._should_skip_processing(fetch_fingerprint):
                 self.stdout.write(
                     self.style.WARNING(
-                        '   Pomijam aktualizację: liczba rekordów jest taka sama jak poprzednio.'
+                        '   Pomijam aktualizację: pobrane dane identyczne jak w poprzednim runie.'
                     )
                 )
                 self.update_sync_log(
@@ -107,8 +109,9 @@ class Command(BaseTabuAPICommand):
                     raw_response={
                         'stock_changes_logged': 0,
                         'update_from': update_from,
-                        'skipped_reason': 'same_count_as_previous_run',
+                        'skipped_reason': 'identical_fetch_as_previous_run',
                         'fetched_variants': len(all_products),
+                        'fetch_fingerprint': fetch_fingerprint,
                     },
                 )
                 self.complete_sync_log('completed')
@@ -153,6 +156,7 @@ class Command(BaseTabuAPICommand):
                     raw_response={
                         'stock_changes_logged': history_count,
                         'update_from': update_from,
+                        'fetch_fingerprint': fetch_fingerprint,
                     },
                 )
                 self.complete_sync_log('completed' if fail_count == 0 else 'completed')
@@ -184,10 +188,31 @@ class Command(BaseTabuAPICommand):
                 self.complete_sync_log('failed', str(e))
             raise
 
-    def _should_skip_processing(self, fetched_count):
+    @staticmethod
+    def _fetch_fingerprint(records):
+        """Stabilny odcisk pobranej listy wariantów - `(variant_id, store,
+        price_net, price_gross)` posortowane. Dwa runy o tym samym odcisku
+        pobrały DOKŁADNIE te same dane (nie tylko tyle samo rekordów - stąd
+        stary bug: 'ta sama liczba' pomijał realne zmiany innych wariantów).
         """
-        Pomija przetwarzanie stock_update, jeśli liczba pobranych rekordów
-        jest taka sama jak w poprzednim zakończonym uruchomieniu.
+        import hashlib
+
+        rows = sorted(
+            (
+                int(r.get('variant_id') or 0),
+                int(r.get('store') or 0),
+                str(r.get('price_net') or ''),
+                str(r.get('price_gross') or ''),
+            )
+            for r in records
+            if isinstance(r, dict) and r.get('variant_id') is not None
+        )
+        return hashlib.sha1(repr(rows).encode()).hexdigest()
+
+    def _should_skip_processing(self, fetch_fingerprint):
+        """
+        Pomija przetwarzanie stock_update tylko jeśli pobrane dane są
+        IDENTYCZNE jak w poprzednim zakończonym uruchomieniu (ten sam odcisk).
         """
         if not self.sync_log:
             return False
@@ -197,14 +222,14 @@ class Command(BaseTabuAPICommand):
             .filter(sync_type='stock_update', status='completed')
             .exclude(pk=self.sync_log.pk)
             .order_by('-started_at')
-            .only('products_processed')
+            .values('raw_response')
             .first()
         )
 
-        if not previous_log:
+        if not previous_log or not previous_log.get('raw_response'):
             return False
 
-        return previous_log.products_processed == fetched_count
+        return previous_log['raw_response'].get('fetch_fingerprint') == fetch_fingerprint
 
     def _update_variant(self, api_variant):
         """

--- a/src/apps/tabu/tests/tests_integration_sync_stock.py
+++ b/src/apps/tabu/tests/tests_integration_sync_stock.py
@@ -103,12 +103,12 @@ class TestSyncTabuStockCommand:
         assert log.status == "completed"
         assert log.products_processed == 2
 
-    def test_skip_gdy_ta_sama_liczba_rekordow_co_poprzednio(self, tabu_api, mocked_responses):
-        # OBECNE zachowanie (znane ograniczenie #233 pkt 2): jeśli poprzedni
-        # zakończony run stock_update miał tyle samo `products_processed`,
-        # cały bieżący run jest pomijany.
+    def test_ta_sama_liczba_ale_inne_dane_NIE_pomija(self, tabu_api, mocked_responses):
+        # #233 pkt 2: dawniej "ta sama liczba rekordów" = skip, co gubiło
+        # realne zmiany innych wariantów. Teraz liczy się odcisk DANYCH.
         ApiSyncLog.objects.create(
-            sync_type="stock_update", status="completed", products_processed=1)
+            sync_type="stock_update", status="completed", products_processed=1,
+            raw_response={"fetch_fingerprint": "cos-zupelnie-innego"})
         p = factories.tabu_product(api_id=2)
         factories.tabu_variant(p, api_id=21, store=5)
         mock_products_basic(mocked_responses, tabu_api, [
@@ -118,8 +118,26 @@ class TestSyncTabuStockCommand:
 
         self._run(**{"update_from": "2026-01-01 00:00:00"})
 
-        # zmiana 5->1 NIE została zastosowana - run pominięty
-        assert TabuProductVariant.objects.get(api_id=21).store == 5
+        assert TabuProductVariant.objects.get(api_id=21).store == 1  # zmiana zastosowana
+        assert StockHistory.objects.count() == 1
+
+    def test_identyczne_dane_jak_poprzednio_pomija_run(self, tabu_api, mocked_responses):
+        p = factories.tabu_product(api_id=3)
+        factories.tabu_variant(p, api_id=31, store=9)
+        pages = [
+            [factories.basic_record(product_api_id=3, variant_api_id=31, store=4)],
+            [],
+        ]
+        mock_products_basic(mocked_responses, tabu_api, pages)
+        # 1. run: stosuje 9->4, zapisuje odcisk
+        self._run(**{"update_from": "2026-01-01 00:00:00"})
+        assert TabuProductVariant.objects.get(api_id=31).store == 4
+        StockHistory.objects.all().delete()
+
+        # 2. run: API zwraca DOKŁADNIE to samo -> pomijamy
+        mock_products_basic(mocked_responses, tabu_api, pages)
+        self._run(**{"update_from": "2026-01-02 00:00:00"})
+
         assert StockHistory.objects.count() == 0
         log = ApiSyncLog.objects.filter(sync_type="stock_update").latest("started_at")
-        assert log.raw_response.get("skipped_reason") == "same_count_as_previous_run"
+        assert log.raw_response.get("skipped_reason") == "identical_fetch_as_previous_run"


### PR DESCRIPTION
Faza 2 z [#233](https://github.com/pawlo884/nc/issues/233). **Base: `test/tabu-phase1` (#234)** — po jego merge GitHub przekieruje na `main`.

## Problem (#233 pkt 2)

`_should_skip_processing` pomijał **cały** run `stock_update`, gdy poprzedni
zakończony run miał tyle samo `products_processed`. „Ta sama liczba" ≠ „te
same dane" — jeśli między runami zmienił się **inny zestaw** wariantów (ta
sama liczebność), realne zmiany stanów były gubione bez śladu.

## Fix

`_fetch_fingerprint(records)` — stabilny `sha1` z posortowanych
`(variant_id, store, price_net, price_gross)`. Run jest pomijany **tylko**
gdy odcisk pobranych danych == odcisk z poprzedniego zakończonego runu
(zapisywany w `ApiSyncLog.raw_response.fetch_fingerprint`).
`skipped_reason: identical_fetch_as_previous_run`.

## Testy

- „ta sama liczba, inne dane" → **NIE pomija** (zmiana 5→1 zastosowana,
  wpis w historii).
- „identyczne dane jak poprzednio" → **pomija** run.

Pełen `tabu`: 42 testy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)