### PR TITLE
perf(tabu): batch _apply_stock_updates zamiast query-per-wariant (#233 faza 3)

### DIFF
--- a/src/apps/tabu/management/commands/sync_tabu_stock.py
+++ b/src/apps/tabu/management/commands/sync_tabu_stock.py
@@ -8,12 +8,12 @@ Użycie:
 """
 import logging
 import time
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
-from django.db import router, transaction
+from django.db import router
+from django.db.models import Sum
 
-from tabu.models import ApiSyncLog, TabuProduct, TabuProductVariant
-from tabu.stock_tracker import track_stock_change
+from tabu.models import ApiSyncLog, StockHistory, TabuProduct, TabuProductVariant
 
 from .base_tabu_api_command import BaseTabuAPICommand
 
@@ -117,36 +117,16 @@ class Command(BaseTabuAPICommand):
                 self.complete_sync_log('completed')
                 return
 
-            success_count = 0
-            fail_count = 0
             history_count = 0
             variants_compared = 0
             variants_with_change = 0
+            fail_count = 0
 
-            for i, api_variant in enumerate(all_products):
-                if not dry_run:
-                    try:
-                        h, cmp_count, chg_count = self._update_variant(api_variant)
-                        success_count += 1
-                        history_count += h
-                        variants_compared += cmp_count
-                        variants_with_change += chg_count
-                    except Exception as e:
-                        fail_count += 1
-                        logger.error(
-                            f'Błąd aktualizacji wariantu {api_variant.get("variant_id")}: {e}'
-                        )
-                else:
-                    success_count += 1
-
-                if (i + 1) % 500 == 0:
-                    self.stdout.write(f'   Przetworzono {i + 1}/{len(all_products)}...')
-                    if not dry_run and self.sync_log:
-                        self.update_sync_log(
-                            products_processed=i + 1,
-                            products_success=success_count,
-                            products_failed=fail_count,
-                        )
+            if not dry_run:
+                history_count, variants_compared, variants_with_change, fail_count = (
+                    self._apply_stock_updates(all_products)
+                )
+            success_count = variants_compared
 
             if not dry_run:
                 self.update_sync_log(
@@ -231,69 +211,108 @@ class Command(BaseTabuAPICommand):
 
         return previous_log['raw_response'].get('fetch_fingerprint') == fetch_fingerprint
 
-    def _update_variant(self, api_variant):
-        """
-        products/basic zwraca płaską listę – każdy element to wariant (id=product_id, variant_id=variant).
-        Aktualizuj stan, ceny wariantu i produktu. Zwraca (history_count, 1 lub 0, 1 lub 0).
-        """
-        variant_id = api_variant.get('variant_id')
-        product_api_id = api_variant.get('id')
-        if variant_id is None:
-            logger.debug(f'Brak variant_id w rekordzie, pomijam')
-            return 0, 0, 0
+    @staticmethod
+    def _parse_price(value):
+        if value is None:
+            return None
+        try:
+            return Decimal(str(value))
+        except (InvalidOperation, ValueError, TypeError):
+            return None
 
-        variant_id = int(variant_id)
-        product_api_id = int(product_api_id or 0)
-        new_store = int(api_variant.get('store') or 0)
-
+    def _apply_stock_updates(self, records):
+        """Batch: 1 SELECT wariantów po `api_id__in` zamiast query per rekord;
+        warunkowy `filter(pk=..., store=old).update(...)` per zmieniony wariant
+        (idempotencja + brak wyścigu jak matterhorn1 #230); `bulk_create`
+        historii; `store_total` policzony z SUMY wariantów produktu (bez dryfu
+        - #233 pkt 3). Zwraca (history_count, compared, with_change, fail_count).
+        """
         db = router.db_for_write(TabuProduct)
-        history_count = 0
-        compared = 0
-        with_change = 0
 
-        with transaction.atomic(using=db):
+        parsed, fail_count = [], 0
+        for r in records:
+            if not isinstance(r, dict) or r.get('variant_id') is None:
+                continue
             try:
-                variant = TabuProductVariant.objects.using(db).select_related('product').get(
-                    api_id=variant_id
-                )
-            except TabuProductVariant.DoesNotExist:
-                logger.debug(f'Wariant {variant_id} nie istnieje, pomijam')
-                return 0, 0, 0
+                parsed.append({
+                    'variant_id': int(r['variant_id']),
+                    'new_store': int(r.get('store') or 0),
+                    'price_net': self._parse_price(r.get('price_net')),
+                    'price_gross': self._parse_price(r.get('price_gross')),
+                })
+            except (ValueError, TypeError) as e:
+                fail_count += 1
+                logger.error(f'Zły rekord stanu (variant_id={r.get("variant_id")}): {e}')
 
-            product = variant.product
-            old_store = variant.store
-            compared = 1
+        if not parsed:
+            return 0, 0, 0, fail_count
 
-            variant.store = new_store
-            vf = ['store']
-            if api_variant.get('price_net') is not None:
-                variant.price_net = Decimal(str(api_variant.get('price_net') or 0))
-                vf.append('price_net')
-            if api_variant.get('price_gross') is not None:
-                variant.price_gross = Decimal(str(api_variant.get('price_gross') or 0))
-                vf.append('price_gross')
-            variant.save(update_fields=vf)
+        variants_by_api = {
+            v.api_id: v for v in
+            TabuProductVariant.objects.using(db).select_related('product').filter(
+                api_id__in=[p['variant_id'] for p in parsed])
+        }
 
-            product.store_total = max(
-                0,
-                (product.store_total or 0) - (old_store or 0) + new_store
-            )
-            product.save(update_fields=['store_total'])
+        history_to_create = []
+        price_only = []
+        affected_products = set()
+        compared = 0
+
+        for p in parsed:
+            v = variants_by_api.get(p['variant_id'])
+            if v is None:
+                continue
+            compared += 1
+            old_store, new_store = v.store, p['new_store']
 
             if old_store != new_store:
-                with_change = 1
-                sh = track_stock_change(
-                    variant_api_id=variant_id,
-                    product_api_id=product.api_id,
+                fields = {'store': new_store}
+                if p['price_net'] is not None:
+                    fields['price_net'] = p['price_net']
+                if p['price_gross'] is not None:
+                    fields['price_gross'] = p['price_gross']
+                changed = TabuProductVariant.objects.using(db).filter(
+                    pk=v.pk, store=old_store).update(**fields)
+                if not changed:
+                    continue  # inny run już złapał tę zmianę
+                affected_products.add(v.product_id)
+                history_to_create.append(StockHistory(
+                    variant_api_id=v.api_id,
+                    product_api_id=v.product.api_id,
+                    product_name=v.product.name,
+                    variant_symbol=v.symbol,
                     old_stock=old_store,
                     new_stock=new_store,
-                    product_name=product.name,
-                    variant_symbol=variant.symbol,
-                )
-                if sh:
-                    history_count = 1
+                    stock_change=new_store - old_store,
+                    change_type='increase' if new_store > old_store else 'decrease',
+                ))
+            elif p['price_net'] is not None or p['price_gross'] is not None:
+                if p['price_net'] is not None:
+                    v.price_net = p['price_net']
+                if p['price_gross'] is not None:
+                    v.price_gross = p['price_gross']
+                price_only.append(v)
 
-        return history_count, compared, with_change
+        if price_only:
+            TabuProductVariant.objects.using(db).bulk_update(
+                price_only, ['price_net', 'price_gross'], batch_size=200)
+
+        if affected_products:
+            totals = dict(
+                TabuProductVariant.objects.using(db)
+                .filter(product_id__in=affected_products)
+                .values('product_id').annotate(t=Sum('store'))
+                .values_list('product_id', 't')
+            )
+            prods = list(TabuProduct.objects.using(db).filter(pk__in=affected_products))
+            for prod in prods:
+                prod.store_total = max(0, totals.get(prod.pk, 0) or 0)
+            TabuProduct.objects.using(db).bulk_update(prods, ['store_total'], batch_size=200)
+
+        if history_to_create:
+            StockHistory.objects.using(db).bulk_create(history_to_create, batch_size=200)
+
+        return len(history_to_create), compared, len(history_to_create), fail_count
 
     def _debug_sample(self, options):
         """Diagnostyka: products/basic zwraca płaską listę wariantów (id=product, variant_id=variant)."""

--- a/src/apps/tabu/management/commands/sync_tabu_stock.py
+++ b/src/apps/tabu/management/commands/sync_tabu_stock.py
@@ -94,10 +94,12 @@ class Command(BaseTabuAPICommand):
 
             self.stdout.write(f'   Pobrano {len(all_products)} rekordów (wariantów)')
 
-            if update_from and not dry_run and self._should_skip_processing(len(all_products)):
+            fetch_fingerprint = self._fetch_fingerprint(all_products)
+
+            if update_from and not dry_run and self._should_skip_processing(fetch_fingerprint):
                 self.stdout.write(
                     self.style.WARNING(
-                        '   Pomijam aktualizację: liczba rekordów jest taka sama jak poprzednio.'
+                        '   Pomijam aktualizację: pobrane dane identyczne jak w poprzednim runie.'
                     )
                 )
                 self.update_sync_log(
@@ -107,8 +109,9 @@ class Command(BaseTabuAPICommand):
                     raw_response={
                         'stock_changes_logged': 0,
                         'update_from': update_from,
-                        'skipped_reason': 'same_count_as_previous_run',
+                        'skipped_reason': 'identical_fetch_as_previous_run',
                         'fetched_variants': len(all_products),
+                        'fetch_fingerprint': fetch_fingerprint,
                     },
                 )
                 self.complete_sync_log('completed')
@@ -153,6 +156,7 @@ class Command(BaseTabuAPICommand):
                     raw_response={
                         'stock_changes_logged': history_count,
                         'update_from': update_from,
+                        'fetch_fingerprint': fetch_fingerprint,
                     },
                 )
                 self.complete_sync_log('completed' if fail_count == 0 else 'completed')
@@ -184,10 +188,31 @@ class Command(BaseTabuAPICommand):
                 self.complete_sync_log('failed', str(e))
             raise
 
-    def _should_skip_processing(self, fetched_count):
+    @staticmethod
+    def _fetch_fingerprint(records):
+        """Stabilny odcisk pobranej listy wariantów - `(variant_id, store,
+        price_net, price_gross)` posortowane. Dwa runy o tym samym odcisku
+        pobrały DOKŁADNIE te same dane (nie tylko tyle samo rekordów - stąd
+        stary bug: 'ta sama liczba' pomijał realne zmiany innych wariantów).
         """
-        Pomija przetwarzanie stock_update, jeśli liczba pobranych rekordów
-        jest taka sama jak w poprzednim zakończonym uruchomieniu.
+        import hashlib
+
+        rows = sorted(
+            (
+                int(r.get('variant_id') or 0),
+                int(r.get('store') or 0),
+                str(r.get('price_net') or ''),
+                str(r.get('price_gross') or ''),
+            )
+            for r in records
+            if isinstance(r, dict) and r.get('variant_id') is not None
+        )
+        return hashlib.sha1(repr(rows).encode()).hexdigest()
+
+    def _should_skip_processing(self, fetch_fingerprint):
+        """
+        Pomija przetwarzanie stock_update tylko jeśli pobrane dane są
+        IDENTYCZNE jak w poprzednim zakończonym uruchomieniu (ten sam odcisk).
         """
         if not self.sync_log:
             return False
@@ -197,14 +222,14 @@ class Command(BaseTabuAPICommand):
             .filter(sync_type='stock_update', status='completed')
             .exclude(pk=self.sync_log.pk)
             .order_by('-started_at')
-            .only('products_processed')
+            .values('raw_response')
             .first()
         )
 
-        if not previous_log:
+        if not previous_log or not previous_log.get('raw_response'):
             return False
 
-        return previous_log.products_processed == fetched_count
+        return previous_log['raw_response'].get('fetch_fingerprint') == fetch_fingerprint
 
     def _update_variant(self, api_variant):
         """

--- a/src/apps/tabu/tests/tests_integration_sync_stock.py
+++ b/src/apps/tabu/tests/tests_integration_sync_stock.py
@@ -103,12 +103,12 @@ class TestSyncTabuStockCommand:
         assert log.status == "completed"
         assert log.products_processed == 2
 
-    def test_skip_gdy_ta_sama_liczba_rekordow_co_poprzednio(self, tabu_api, mocked_responses):
-        # OBECNE zachowanie (znane ograniczenie #233 pkt 2): jeśli poprzedni
-        # zakończony run stock_update miał tyle samo `products_processed`,
-        # cały bieżący run jest pomijany.
+    def test_ta_sama_liczba_ale_inne_dane_NIE_pomija(self, tabu_api, mocked_responses):
+        # #233 pkt 2: dawniej "ta sama liczba rekordów" = skip, co gubiło
+        # realne zmiany innych wariantów. Teraz liczy się odcisk DANYCH.
         ApiSyncLog.objects.create(
-            sync_type="stock_update", status="completed", products_processed=1)
+            sync_type="stock_update", status="completed", products_processed=1,
+            raw_response={"fetch_fingerprint": "cos-zupelnie-innego"})
         p = factories.tabu_product(api_id=2)
         factories.tabu_variant(p, api_id=21, store=5)
         mock_products_basic(mocked_responses, tabu_api, [
@@ -118,8 +118,26 @@ class TestSyncTabuStockCommand:
 
         self._run(**{"update_from": "2026-01-01 00:00:00"})
 
-        # zmiana 5->1 NIE została zastosowana - run pominięty
-        assert TabuProductVariant.objects.get(api_id=21).store == 5
+        assert TabuProductVariant.objects.get(api_id=21).store == 1  # zmiana zastosowana
+        assert StockHistory.objects.count() == 1
+
+    def test_identyczne_dane_jak_poprzednio_pomija_run(self, tabu_api, mocked_responses):
+        p = factories.tabu_product(api_id=3)
+        factories.tabu_variant(p, api_id=31, store=9)
+        pages = [
+            [factories.basic_record(product_api_id=3, variant_api_id=31, store=4)],
+            [],
+        ]
+        mock_products_basic(mocked_responses, tabu_api, pages)
+        # 1. run: stosuje 9->4, zapisuje odcisk
+        self._run(**{"update_from": "2026-01-01 00:00:00"})
+        assert TabuProductVariant.objects.get(api_id=31).store == 4
+        StockHistory.objects.all().delete()
+
+        # 2. run: API zwraca DOKŁADNIE to samo -> pomijamy
+        mock_products_basic(mocked_responses, tabu_api, pages)
+        self._run(**{"update_from": "2026-01-02 00:00:00"})
+
         assert StockHistory.objects.count() == 0
         log = ApiSyncLog.objects.filter(sync_type="stock_update").latest("started_at")
-        assert log.raw_response.get("skipped_reason") == "same_count_as_previous_run"
+        assert log.raw_response.get("skipped_reason") == "identical_fetch_as_previous_run"

--- a/src/apps/tabu/tests/tests_integration_sync_stock.py
+++ b/src/apps/tabu/tests/tests_integration_sync_stock.py
@@ -1,9 +1,5 @@
 """
 Integration: `sync_tabu_stock` — aktualizacja stanów/cen z `GET products/basic`.
-
-Utrwala OBECNE zachowanie (per-wariant `.get()`/`save()` + `store_total`
-przyrostowo + `_should_skip_processing`) jako punkt odniesienia przed
-refaktorem (issue #233).
 """
 from __future__ import annotations
 
@@ -11,8 +7,10 @@ from decimal import Decimal
 
 import pytest
 from django.core.management import call_command
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
 
-from tabu.models import ApiSyncLog, StockHistory, TabuProductVariant
+from tabu.models import ApiSyncLog, StockHistory, TabuProduct, TabuProductVariant
 from tabu.management.commands.sync_tabu_stock import Command
 
 from . import factories
@@ -21,8 +19,8 @@ from .mock_tabu import mock_products_basic
 pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 
-class TestUpdateVariant:
-    """`Command._update_variant` wołany bezpośrednio."""
+class TestApplyStockUpdates:
+    """`Command._apply_stock_updates` — batch, warunkowy UPDATE, store_total z sumy."""
 
     @pytest.fixture
     def cmd(self):
@@ -32,46 +30,88 @@ class TestUpdateVariant:
         p = factories.tabu_product(api_id=1000, store_total=5)
         v = factories.tabu_variant(p, api_id=2000, store=5)
 
-        hist, compared, changed = cmd._update_variant(
-            factories.basic_record(product_api_id=1000, variant_api_id=2000, store=2))
+        hist, compared, changed, failed = cmd._apply_stock_updates([
+            factories.basic_record(product_api_id=1000, variant_api_id=2000, store=2)])
 
-        assert (hist, compared, changed) == (1, 1, 1)
+        assert (hist, compared, changed, failed) == (1, 1, 1, 0)
         v.refresh_from_db()
         p.refresh_from_db()
         assert v.store == 2
-        assert p.store_total == 2  # 5 - 5 + 2
+        assert p.store_total == 2  # suma wariantów produktu
         h = StockHistory.objects.get(variant_api_id=2000)
-        assert (h.old_stock, h.new_stock) == (5, 2)
+        assert (h.old_stock, h.new_stock, h.change_type) == (5, 2, "decrease")
 
     def test_brak_zmiany_stanu_bez_historii(self, cmd):
         p = factories.tabu_product(api_id=1001)
         factories.tabu_variant(p, api_id=2001, store=7)
 
-        hist, compared, changed = cmd._update_variant(
-            factories.basic_record(product_api_id=1001, variant_api_id=2001, store=7))
-
-        assert (hist, compared, changed) == (0, 1, 0)
+        assert cmd._apply_stock_updates([
+            factories.basic_record(product_api_id=1001, variant_api_id=2001, store=7)
+        ]) == (0, 1, 0, 0)
         assert StockHistory.objects.count() == 0
 
     def test_nieznany_wariant_jest_pomijany(self, cmd):
-        assert cmd._update_variant(
+        assert cmd._apply_stock_updates([
             factories.basic_record(product_api_id=9, variant_api_id=999999, store=1)
-        ) == (0, 0, 0)
+        ]) == (0, 0, 0, 0)
 
     def test_brak_variant_id_pomijany(self, cmd):
-        assert cmd._update_variant({"id": 1, "store": 3}) == (0, 0, 0)
+        assert cmd._apply_stock_updates([{"id": 1, "store": 3}]) == (0, 0, 0, 0)
 
-    def test_aktualizuje_ceny_gdy_podane(self, cmd):
+    def test_aktualizuje_ceny_gdy_podane_bez_zmiany_stanu(self, cmd):
         p = factories.tabu_product(api_id=1002)
         v = factories.tabu_variant(p, api_id=2002, store=1, price_net="10.00")
 
-        cmd._update_variant(factories.basic_record(
+        cmd._apply_stock_updates([factories.basic_record(
             product_api_id=1002, variant_api_id=2002, store=1,
-            price_net="19.99", price_gross="24.59"))
+            price_net="19.99", price_gross="24.59")])
 
         v.refresh_from_db()
         assert v.price_net == Decimal("19.99")
         assert v.price_gross == Decimal("24.59")
+
+    def test_store_total_z_sumy_wariantow_bez_dryfu(self, cmd):
+        # store_total w bazie zawyżony (dryf), fix policzy go z sumy wariantów
+        p = factories.tabu_product(api_id=1003, store_total=999)
+        factories.tabu_variant(p, api_id=3001, store=4)
+        v2 = factories.tabu_variant(p, api_id=3002, store=6)
+
+        cmd._apply_stock_updates([
+            factories.basic_record(product_api_id=1003, variant_api_id=3002, store=1)])
+
+        p.refresh_from_db()
+        assert p.store_total == 5  # 4 (bez zmian) + 1 (nowy) — nie 999, nie przyrostowo
+
+    def test_idempotencja_drugi_run_nie_powiela_historii(self, cmd):
+        p = factories.tabu_product(api_id=1004)
+        factories.tabu_variant(p, api_id=4001, store=8)
+        rec = [factories.basic_record(product_api_id=1004, variant_api_id=4001, store=2)]
+
+        assert cmd._apply_stock_updates(rec)[0] == 1
+        assert cmd._apply_stock_updates(rec)[0] == 0  # stan już 2 → nic
+        assert StockHistory.objects.filter(variant_api_id=4001).count() == 1
+
+    def test_zapytania_nie_rosna_liniowo_z_liczba_wariantow(self, cmd):
+        p = factories.tabu_product(api_id=1005)
+        for i in range(20):
+            factories.tabu_variant(p, api_id=5000 + i, store=10)
+        # połowa się zmienia
+        recs = [
+            factories.basic_record(product_api_id=1005, variant_api_id=5000 + i,
+                                   store=3 if i % 2 == 0 else 10)
+            for i in range(20)
+        ]
+
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            hist, compared, changed, failed = cmd._apply_stock_updates(recs)
+
+        assert (hist, compared) == (10, 20)
+        # 1 SELECT wariantów + 10 warunkowych UPDATE + agregat store_total +
+        # SELECT produktów + bulk_update produktów + bulk_create historii.
+        # Rośnie ze ZMIENIONYMI (10), nie z 20 w danych.
+        assert len(ctx.captured_queries) < 20, (
+            f"{len(ctx.captured_queries)} zapytań dla 20 wariantów (10 zmian)"
+        )
 
 
 class TestSyncTabuStockCommand:


### PR DESCRIPTION
Faza 3 z [#233](https://github.com/pawlo884/nc/issues/233). **Base: `fix/tabu-skip-processing` (#235)** — po jego merge przekieruje na `main`.

## Problem (#233 pkt 1 + 3)

`sync_tabu_stock` na **każdy** rekord z `products/basic`:
`BEGIN` + `SELECT` wariantu + `variant.save()` + `product.save(store_total)`
+ `INSERT` historii + `COMMIT`. `stock_full` (tysiące wariantów) = tysiące
zapytań przez tunel SSH. Do tego `store_total` utrzymywany **przyrostowo**
(`- old + new`) → dryf przy pominiętym wariancie / niepełnej odpowiedzi API.

## Fix

`_update_variant` → **`_apply_stock_updates(records)`**:

- **1 `SELECT`** wariantów po `api_id__in` (`select_related('product')`) zamiast N.
- **warunkowy `UPDATE` per zmieniony wariant** — `filter(pk=v.pk, store=old)
  .update(store=new, price…)` → idempotencja + brak wyścigu (jak
  matterhorn1 #230); wiersz `StockHistory` **tylko gdy `UPDATE` zmienił rząd**.
- ceny wariantów bez zmiany stanu → jeden `bulk_update`.
- **`store_total` z SUMY wariantów** produktu (agregat `Sum` + `bulk_update`),
  nie przyrostowo → koniec dryfu. `store_total` idzie do MPD (saga) i do
  raportów bestsellerów.
- historia → `bulk_create`.

Liczba zapytań skaluje się ze **zmienionymi** wariantami (garstka przy
`update_from`), nie z liczbą w danych: **20 wariantów / 10 zmian = 15
zapytań** (było ~110).

`tabu.stock_tracker.track_stock_change` zostaje (tested, symetryczne z
`mada`/`matterhorn1`) mimo że `sync_tabu_stock` już go nie woła.

## Testy

45 testów `tabu`. Nowe: `store_total` z sumy (bez dryfu), idempotencja
drugiego runu, regresja liczby zapytań (`CaptureQueriesContext`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)