### PR TITLE
fix(docker): kopiuj src/templates/ do obrazu prod

### DIFF
--- a/deployments/docker/Dockerfile.prod
+++ b/deployments/docker/Dockerfile.prod
@@ -47,6 +47,9 @@ ENV PYTHONPATH=/app:/app/apps
 COPY src/manage.py .
 COPY src/core/ ./core/
 COPY src/apps/ ./apps/
+# Szablony projektowe (TEMPLATES['DIRS'] = BASE_DIR/'templates'): admin/input_filter.html,
+# admin/app_list.html, robots.txt, index.html. Bez tego 500 na changelistach z InputFilter.
+COPY src/templates/ ./templates/
 # COPY static/ ./static/  # Nie kopiujemy - zostanie utworzony przez collectstatic
 COPY deployments/nginx/nginx.conf ./nginx.conf
 COPY deployments/redis.conf ./redis.conf


### PR DESCRIPTION
TEMPLATES['DIRS'] = [BASE_DIR / 'templates'] (czyli /app/templates), ale Dockerfile.prod nigdy nie kopiował tego katalogu — selektywne COPY brało tylko manage.py, core/, apps/. Efekt: admin/input_filter.html, admin/app_list.html, robots.txt i index.html nie istniały w obrazie.

Objawy na produkcji:
- 500 na /admin/matterhorn1/stockhistory/ (TemplateDoesNotExist: admin/input_filter.html) — changelist używa make_input_filter z #229
- 500 na /robots.txt (po cichu, od zawsze)
- customowy admin/app_list.html (kafelki) nigdy nie działał w prod