### PR TITLE
fix(tabu): update_from tylko z zakończonych syncow stanów (#233 pkt 4)

### DIFF
--- a/src/apps/tabu/tasks.py
+++ b/src/apps/tabu/tasks.py
@@ -38,9 +38,13 @@ def sync_tabu_stock(self):
 
         db = router.db_for_read(ApiSyncLog)
         try:
+            # Tylko ZAKOŃCZONE runy - inaczej zawieszony 'running'/'failed'
+            # przypina update_from do swojego started_at i kolejne runy pomijają
+            # dane z okna, którego ten run nie zdążył zaimportować. Po nieudanym
+            # runie okno ma się cofnąć do ostatniego udanego (catch-up).
             last_sync = (
                 ApiSyncLog.objects.using(db)  # type: ignore[attr-defined]
-                .filter(sync_type__in=('stock_update', 'stock_full'))
+                .filter(sync_type__in=('stock_update', 'stock_full'), status='completed')
                 .order_by('-started_at')
                 .values('started_at')
                 .first()

--- a/src/apps/tabu/tests/tests_integration_tasks.py
+++ b/src/apps/tabu/tests/tests_integration_tasks.py
@@ -57,6 +57,22 @@ class TestSyncTabuStockTask:
         assert result["update_from"] == ts.strftime("%Y-%m-%d %H:%M:%S")
         assert cc.call_args[0][2] == ts.strftime("%Y-%m-%d %H:%M:%S")
 
+    def test_update_from_ignoruje_niezakonczone_logi(self):
+        # ostatni udany run 5 h temu; potem run 'failed' 1 h temu (nie zdążył
+        # zaimportować swojego okna) → update_from ma się cofnąć do udanego.
+        good = timezone.now() - timedelta(hours=5)
+        bad = timezone.now() - timedelta(hours=1)
+        g = ApiSyncLog.objects.create(sync_type="stock_update", status="completed")
+        ApiSyncLog.objects.filter(pk=g.pk).update(started_at=good)
+        b = ApiSyncLog.objects.create(sync_type="stock_update", status="failed")
+        ApiSyncLog.objects.filter(pk=b.pk).update(started_at=bad)
+
+        with patch.object(tasks, "advisory_lock", lambda name: _lock(True)), \
+                patch.object(tasks, "call_command") as cc:
+            result = tasks.sync_tabu_stock.apply().get()
+
+        assert result["update_from"] == good.strftime("%Y-%m-%d %H:%M:%S")
+
     def test_blad_komendy_powoduje_retry(self):
         with patch.object(tasks, "advisory_lock", lambda name: _lock(True)), \
                 patch.object(tasks, "call_command", side_effect=RuntimeError("boom")), \


### PR DESCRIPTION
Ostatni punkt z [#233](https://github.com/pawlo884/nc/issues/233).

## Problem

`sync_tabu_stock` (task) brał `started_at` **najnowszego** `ApiSyncLog`
niezależnie od statusu. Zawieszony `running` albo `failed` przypinał
`update_from` do swojego `started_at` → kolejne runy pomijały dane z okna,
którego ten run nie zdążył zaimportować.

## Fix

`.filter(status='completed')` — po nieudanym runie okno cofa się do
ostatniego **udanego** (catch-up). Spójne z `_should_skip_processing` i
`sync_tabu_new_products._load_check_range`, które już filtrują `completed`.

## Test

`failed` run 1 h temu + `completed` 5 h temu → `update_from` = ten sprzed 5 h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)