### PR TITLE
test(tabu): testy _save_product + wpięcie tabu do bramki coverage (#233)

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -195,11 +195,14 @@ jobs:
       - name: Testy (pytest)
         # Konfiguracja w pyproject.toml [tool.pytest.ini_options] + [tool.coverage.*].
         # Uruchamiane są WSZYSTKIE testy (testpaths=src/apps); próg pokrycia
-        # (--cov-fail-under) pilnuje na razie tylko matterhorn1 — apki celowo
-        # pokrytej (patrz docs/TESTING.md). Kolejne apki: dopisać ścieżkę i próg.
+        # (--cov-fail-under) pilnuje matterhorn1 + tabu (management/commands
+        # celowo poza pomiarem — patrz [tool.coverage.run] omit). Kolejne apki:
+        # dopisać ścieżkę. Próg = wspólny dla wszystkich --cov, trzymany
+        # zachowawczo poniżej realnego pokrycia — podnosić przy okazji.
         run: >-
           pytest
-          --cov=src/apps/matterhorn1 --cov-report=term-missing:skip-covered
+          --cov=src/apps/matterhorn1 --cov=src/apps/tabu
+          --cov-report=term-missing:skip-covered
           --cov-fail-under=53
 
   check-code-quality:

--- a/src/apps/tabu/tests/factories.py
+++ b/src/apps/tabu/tests/factories.py
@@ -73,3 +73,39 @@ def basic_record(*, product_api_id: int, variant_api_id: int, store: int,
     if price_gross is not None:
         r["price_gross"] = str(price_gross)
     return r
+
+
+def api_variant_detail(*, api_id: int, store: int = 3, color="czarny", size="M", **over):
+    v = {
+        "id": api_id,
+        "symbol": f"V{api_id}",
+        "ean": "5901234567890",
+        "store": store,
+        "price_net": "100.00",
+        "price_gross": "123.00",
+        "items": [{"name": "Kolor", "value": color}, {"name": "Rozmiar", "value": size}],
+    }
+    v.update(over)
+    return v
+
+
+def api_product_detail(*, api_id: int, variants=None, gallery=None, **over) -> dict:
+    """Odpowiedź `GET products/{id}` (pełne dane) — kształt zgodny z
+    `map_api_product_to_model`."""
+    p = {
+        "id": api_id,
+        "symbol": f"P{api_id}",
+        "name": f"Produkt {api_id}",
+        "ean": "5900000000001",
+        "producer_id": 7,
+        "producer": "Marko",
+        "category_id": 42,
+        "category": "Damskie/Bluzki",
+        "price_net": "100.00",
+        "price_gross": "123.00",
+        "last_update": "2026-01-15T10:00:00",
+        "variants": variants if variants is not None else [api_variant_detail(api_id=api_id * 10)],
+        "gallery": gallery if gallery is not None else [],
+    }
+    p.update(over)
+    return p

--- a/src/apps/tabu/tests/tests_integration_save_product.py
+++ b/src/apps/tabu/tests/tests_integration_save_product.py
@@ -1,0 +1,93 @@
+"""
+Integration: `sync_tabu_products._save_product` — zapis produktu + gallery +
+wariantów z pełnej odpowiedzi `GET products/{id}` (mappery
+`map_api_product_to_model` / `map_api_variant_to_model`).
+
+Używane przez `sync_tabu_new_products` (import nowo znalezionych produktów).
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from tabu.models import Brand, Category, TabuProduct, TabuProductImage, TabuProductVariant
+from tabu.management.commands.sync_tabu_products import Command
+
+from . import factories
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+@pytest.fixture
+def cmd():
+    return Command()
+
+
+def test_tworzy_produkt_warianty_gallery_i_store_total(cmd):
+    api = factories.api_product_detail(
+        api_id=5001,
+        variants=[
+            factories.api_variant_detail(api_id=6001, store=4, color="czarny", size="M"),
+            factories.api_variant_detail(api_id=6002, store=6, color="czarny", size="L"),
+        ],
+        gallery=[
+            {"id": 1, "image": "https://tabu.example/1.jpg", "main": True},
+            {"id": 2, "image": "https://tabu.example/2.jpg"},
+        ],
+    )
+
+    cmd._save_product(api)
+
+    p = TabuProduct.objects.get(api_id=5001)
+    assert p.name == "Produkt 5001"
+    assert p.store_total == 10  # 4 + 6
+    assert p.brand.name == "Marko" and p.category is not None
+    vs = TabuProductVariant.objects.filter(product=p).order_by("api_id")
+    assert [v.api_id for v in vs] == [6001, 6002]
+    assert vs[0].color == "czarny" and vs[0].size == "M" and vs[0].store == 4
+    assert TabuProductImage.objects.filter(product=p).count() == 2
+    assert TabuProductImage.objects.get(product=p, api_image_id=1).is_main is True
+
+
+def test_ponowny_import_aktualizuje_bez_duplikatow(cmd):
+    api = factories.api_product_detail(api_id=5002, variants=[
+        factories.api_variant_detail(api_id=6100, store=5)])
+    cmd._save_product(api)
+
+    api["name"] = "Nowa nazwa"
+    api["variants"][0]["store"] = 2
+    api["gallery"] = [{"id": 9, "image": "https://tabu.example/nowe.jpg"}]
+    cmd._save_product(api)
+
+    assert TabuProduct.objects.filter(api_id=5002).count() == 1
+    p = TabuProduct.objects.get(api_id=5002)
+    assert p.name == "Nowa nazwa"
+    assert p.store_total == 2
+    assert TabuProductVariant.objects.filter(product=p).count() == 1
+    assert TabuProductVariant.objects.get(api_id=6100).store == 2
+    # gallery podmieniona (delete + recreate)
+    imgs = list(TabuProductImage.objects.filter(product=p).values_list("api_image_id", flat=True))
+    assert imgs == [9]
+
+
+def test_reuzywa_istniejacej_marki_i_kategorii(cmd):
+    b = Brand.objects.create(brand_id="7", name="Stara nazwa marki")
+    c = Category.objects.create(category_id="42", name="Stara kat", path="x")
+
+    cmd._save_product(factories.api_product_detail(api_id=5003))
+
+    assert Brand.objects.count() == 1
+    assert Category.objects.count() == 1
+    p = TabuProduct.objects.get(api_id=5003)
+    assert p.brand_id == b.id and p.category_id == c.id
+
+
+def test_ceny_wariantu_z_decimal(cmd):
+    cmd._save_product(factories.api_product_detail(
+        api_id=5004,
+        variants=[factories.api_variant_detail(
+            api_id=6200, price_net="19.99", price_gross="24.59")]))
+
+    v = TabuProductVariant.objects.get(api_id=6200)
+    assert v.price_net == Decimal("19.99") and v.price_gross == Decimal("24.59")


### PR DESCRIPTION
Domknięcie [#233](https://github.com/pawlo884/nc/issues/233) — testy najbardziej
nietkniętej powierzchni + bramka CI.

## `_save_product`

`sync_tabu_products._save_product` — zapis produktu + gallery + wariantów z
pełnej odpowiedzi `GET products/{id}` (mappery `map_api_product_to_model` /
`map_api_variant_to_model`). Używane przez `sync_tabu_new_products` przy
imporcie nowo wykrytych produktów; w fazie 4 było zamockowane.

`tests_integration_save_product.py`:
- tworzy produkt + warianty + gallery; `store_total` = suma `store` wariantów;
  `get_or_create` marki/kategorii,
- ponowny import → `update_or_create` bez duplikatów, gallery podmieniona,
- reużycie istniejącej marki/kategorii po `id`,
- ceny wariantu jako `Decimal`.

`factories`: `api_product_detail` / `api_variant_detail`.

## CI coverage gate

`--cov` obejmuje teraz też `src/apps/tabu` (obok `matterhorn1`).
`management/commands/*` pozostają **poza** pomiarem (`omit` w `pyproject.toml`
— decyzja projektu). Wspólne pokrycie `matterhorn1` + `tabu` ≈ **58%**, próg
`--cov-fail-under=53` bez zmian (zachowawczo, podnosić przy okazji).

## Testy

**63 testy `tabu`** (było 59).

---

Po tym #233 domknięte całkowicie (5 problemów + plan + CI).