### PR TITLE
perf(mada): idempotentny upsert stanów + batch historii + brand cache

### DIFF
--- a/src/apps/mada/importer.py
+++ b/src/apps/mada/importer.py
@@ -8,8 +8,10 @@ from typing import Dict, Optional, Tuple
 
 from django.utils import timezone
 
-from .models import Brand, Category, MadaProduct, MadaProductImage, MadaProductVariant
-from .stock_tracker import track_stock_change
+from .models import (
+    Brand, Category, MadaProduct, MadaProductImage, MadaProductVariant, StockHistory,
+)
+from .stock_tracker import build_stock_history_row
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,13 @@ def sync_brands(db: str, producers: Dict[str, str]) -> int:
     if to_update:
         Brand.objects.using(db).bulk_update(to_update, ['name', 'updated_at'], batch_size=500)
     return len(to_create) + len(to_update)
+
+
+def load_brand_cache(db: str) -> Dict[str, Brand]:
+    """Wczytuje wszystkie marki raz na przebieg importu ({producer_id: Brand}),
+    żeby `upsert_product` nie robił zapytania na każdy produkt (N+1). Wołać po
+    `sync_brands` (który dopisuje nowe marki z feedu)."""
+    return {b.producer_id: b for b in Brand.objects.using(db).all()}
 
 
 def resolve_category(db: str, categories: list, category_cache: dict) -> Optional[Category]:
@@ -88,12 +97,18 @@ def resolve_category(db: str, categories: list, category_cache: dict) -> Optiona
     return category
 
 
-def upsert_product(db: str, product_dict: dict, category_cache: dict) -> Tuple[MadaProduct, bool]:
+def upsert_product(
+    db: str, product_dict: dict, category_cache: dict,
+    brand_cache: Optional[Dict[str, Brand]] = None,
+) -> Tuple[MadaProduct, bool]:
     api_id = product_dict['api_id']
     brand = None
     producer_id = product_dict.get('producer_id')
     if producer_id:
-        brand = Brand.objects.using(db).filter(producer_id=producer_id).first()
+        if brand_cache is not None:
+            brand = brand_cache.get(producer_id)
+        else:
+            brand = Brand.objects.using(db).filter(producer_id=producer_id).first()
     category = resolve_category(db, product_dict.get('categories') or [], category_cache)
 
     defaults = {
@@ -116,11 +131,22 @@ def upsert_product(db: str, product_dict: dict, category_cache: dict) -> Tuple[M
 
 def upsert_variants(db: str, product: MadaProduct, variants: list) -> int:
     """Upsert wariantów produktu, zapisując zmiany stanu do StockHistory. Zwraca
-    liczbę utworzonych/zmienionych wariantów."""
+    liczbę utworzonych/zmienionych wariantów.
+
+    Stan magazynowy aktualizujemy warunkowym UPDATE (`filter(pk=…, stock=old)`),
+    a wpis do StockHistory tworzymy tylko gdy ten UPDATE faktycznie zmienił wiersz.
+    Dzięki temu operacja jest:
+      * odporna na wyścig — dwa równoległe importy (full + partial) nie zdublują
+        historii, bo `WHERE stock=old` serializuje zapisujących;
+      * idempotentna — powtórny import tego samego pliku (redelivery Celery po
+        `visibility_timeout`) widzi stan już docelowy → 0 wierszy → brak duplikatu.
+    Wpisy historii zbieramy i wrzucamy jednym `bulk_create` (zamiast INSERT/wariant).
+    """
     existing = {
         v.variant_key: v
         for v in MadaProductVariant.objects.using(db).filter(product=product)
     }
+    history_rows = []
     changed = 0
     for v in variants:
         key = v['variant_key']
@@ -136,36 +162,46 @@ def upsert_variants(db: str, product: MadaProduct, variants: list) -> int:
                 ean=v['ean'], stock=v['stock'],
             )
             existing[key] = current
-            track_stock_change(
-                product_api_id=product.api_id, variant_key=key,
-                old_stock=0, new_stock=v['stock'],
-                product_name=product.name, variant_label=label,
+            row = build_stock_history_row(
+                product.api_id, key, 0, v['stock'], product.name, label,
             )
+            if row is not None:
+                history_rows.append(row)
             changed += 1
             continue
 
-        fields_changed = []
+        row_changed = False
         if current.stock != v['stock']:
-            track_stock_change(
-                product_api_id=product.api_id, variant_key=key,
-                old_stock=current.stock, new_stock=v['stock'],
-                product_name=product.name, variant_label=label,
+            old_stock, new_stock = current.stock, v['stock']
+            n = (
+                MadaProductVariant.objects.using(db)
+                .filter(pk=current.pk, stock=old_stock)
+                .update(stock=new_stock, updated_at=timezone.now())
             )
-            current.stock = v['stock']
-            fields_changed.append('stock')
-        if current.color != v['color']:
-            current.color = v['color']
-            fields_changed.append('color')
-        if current.size != v['size']:
-            current.size = v['size']
-            fields_changed.append('size')
-        if current.ean != v['ean']:
-            current.ean = v['ean']
-            fields_changed.append('ean')
-        if fields_changed:
-            fields_changed.append('updated_at')
-            current.save(using=db, update_fields=fields_changed)
+            if n:
+                current.stock = new_stock
+                row = build_stock_history_row(
+                    product.api_id, key, old_stock, new_stock, product.name, label,
+                )
+                if row is not None:
+                    history_rows.append(row)
+                row_changed = True
+
+        attr_changed = []
+        for field in ('color', 'size', 'ean'):
+            if getattr(current, field) != v[field]:
+                setattr(current, field, v[field])
+                attr_changed.append(field)
+        if attr_changed:
+            attr_changed.append('updated_at')
+            current.save(using=db, update_fields=attr_changed)
+            row_changed = True
+
+        if row_changed:
             changed += 1
+
+    if history_rows:
+        StockHistory.objects.using(db).bulk_create(history_rows, batch_size=200)
     return changed
 
 
@@ -188,9 +224,12 @@ def upsert_images(db: str, product: MadaProduct, images: list) -> None:
         MadaProductImage.objects.using(db).filter(product=product, api_image_id__in=stale_ids).delete()
 
 
-def import_product_dict(db: str, product_dict: dict, category_cache: dict) -> bool:
+def import_product_dict(
+    db: str, product_dict: dict, category_cache: dict,
+    brand_cache: Optional[Dict[str, Brand]] = None,
+) -> bool:
     """Importuje jeden produkt (+ warianty, + zdjęcia). Zwraca True gdy produkt był nowy."""
-    product, created = upsert_product(db, product_dict, category_cache)
+    product, created = upsert_product(db, product_dict, category_cache, brand_cache)
     upsert_variants(db, product, product_dict.get('variants') or [])
     upsert_images(db, product, product_dict.get('images') or [])
     return created

--- a/src/apps/mada/management/commands/sync_mada_full.py
+++ b/src/apps/mada/management/commands/sync_mada_full.py
@@ -11,7 +11,7 @@ from django.db import router, transaction
 from django.utils import timezone
 
 from mada.api_client import MadaApiClient, MadaApiError
-from mada.importer import import_product_dict, sync_brands
+from mada.importer import import_product_dict, load_brand_cache, sync_brands
 from mada.models import ApiSyncLog, MadaProduct
 from mada.parser import iter_products, parse_producers
 
@@ -57,12 +57,13 @@ class Command(BaseCommand):
             producers = parse_producers(xml_bytes)
             self.stdout.write(f'Producenci w feedzie: {len(producers)}')
             sync_brands(db, producers)
+            brand_cache = load_brand_cache(db)
 
             batch = []
             for product_dict in iter_products(xml_bytes):
                 batch.append(product_dict)
                 if len(batch) >= BATCH_SIZE:
-                    c, e = self._process_batch(db, batch, category_cache)
+                    c, e = self._process_batch(db, batch, category_cache, brand_cache)
                     created += c
                     errors += e
                     processed += len(batch)
@@ -70,7 +71,7 @@ class Command(BaseCommand):
                     self.stdout.write(f'  ... przetworzono {processed}')
                     batch = []
             if batch:
-                c, e = self._process_batch(db, batch, category_cache)
+                c, e = self._process_batch(db, batch, category_cache, brand_cache)
                 created += c
                 errors += e
                 processed += len(batch)
@@ -99,7 +100,7 @@ class Command(BaseCommand):
             self._fail(db, log, str(exc)[:2000])
             raise
 
-    def _process_batch(self, db, batch, category_cache):
+    def _process_batch(self, db, batch, category_cache, brand_cache=None):
         # Osobna transakcja (savepoint) na produkt - błąd jednego nie psuje reszty
         # batcha (błąd w atomic() na Postgresie unieważnia całą otaczającą transakcję).
         created = 0
@@ -107,7 +108,7 @@ class Command(BaseCommand):
         for product_dict in batch:
             try:
                 with transaction.atomic(using=db):
-                    was_created = import_product_dict(db, product_dict, category_cache)
+                    was_created = import_product_dict(db, product_dict, category_cache, brand_cache)
                     if was_created:
                         created += 1
             except Exception:

--- a/src/apps/mada/management/commands/sync_mada_partial.py
+++ b/src/apps/mada/management/commands/sync_mada_partial.py
@@ -17,7 +17,7 @@ from django.db import router, transaction
 from django.utils import timezone
 
 from mada.api_client import MadaApiClient, MadaApiError
-from mada.importer import import_product_dict, sync_brands
+from mada.importer import import_product_dict, load_brand_cache, sync_brands
 from mada.models import ApiSyncLog, MadaProduct
 from mada.parser import iter_products, parse_producers
 
@@ -70,12 +70,13 @@ class Command(BaseCommand):
             producers = parse_producers(xml_bytes)
             if producers:
                 sync_brands(db, producers)
+            brand_cache = load_brand_cache(db)
 
             processed = created = errors = 0
             for product_dict in iter_products(xml_bytes):
                 try:
                     with transaction.atomic(using=db):
-                        was_created = import_product_dict(db, product_dict, category_cache)
+                        was_created = import_product_dict(db, product_dict, category_cache, brand_cache)
                         if was_created:
                             created += 1
                 except Exception:

--- a/src/apps/mada/stock_tracker.py
+++ b/src/apps/mada/stock_tracker.py
@@ -10,6 +10,33 @@ from .models import StockHistory
 logger = logging.getLogger(__name__)
 
 
+def build_stock_history_row(
+    product_api_id,
+    variant_key,
+    old_stock,
+    new_stock,
+    product_name=None,
+    variant_label=None,
+):
+    """Zwraca niezapisany obiekt StockHistory gotowy do bulk_create.
+    None, gdy stan się nie zmienił (nic do zapisania)."""
+    old = old_stock or 0
+    new = new_stock or 0
+    stock_change = new - old
+    if stock_change == 0:
+        return None
+    return StockHistory(
+        product_api_id=product_api_id,
+        variant_key=variant_key or '',
+        product_name=product_name or '',
+        variant_label=variant_label or '',
+        old_stock=old,
+        new_stock=new,
+        stock_change=stock_change,
+        change_type='increase' if stock_change > 0 else 'decrease',
+    )
+
+
 def track_stock_change(
     product_api_id,
     variant_key,
@@ -18,25 +45,18 @@ def track_stock_change(
     product_name=None,
     variant_label=None,
 ):
-    """Zapisuje zmianę stanu magazynowego do StockHistory (tylko gdy faktycznie się zmienił)."""
+    """Zapisuje pojedynczą zmianę stanu do StockHistory (tylko gdy faktycznie się
+    zmienił). Import masowy używa `build_stock_history_row` + `bulk_create`;
+    ten helper zostaje dla użycia ad-hoc (np. z shella / sagi)."""
     try:
-        stock_change = (new_stock or 0) - (old_stock or 0)
-        if stock_change == 0:
-            return None
-        change_type = 'increase' if stock_change > 0 else 'decrease'
-
-        db = router.db_for_write(StockHistory)
-        stock_history = StockHistory.objects.using(db).create(
-            product_api_id=product_api_id,
-            variant_key=variant_key or '',
-            product_name=product_name or '',
-            variant_label=variant_label or '',
-            old_stock=old_stock or 0,
-            new_stock=new_stock or 0,
-            stock_change=stock_change,
-            change_type=change_type,
+        row = build_stock_history_row(
+            product_api_id, variant_key, old_stock, new_stock, product_name, variant_label,
         )
-        return stock_history
+        if row is None:
+            return None
+        db = router.db_for_write(StockHistory)
+        row.save(using=db)
+        return row
     except Exception:
         logger.exception(
             'Błąd zapisu historii stanu Mada: product=%s variant=%s', product_api_id, variant_key,

--- a/src/apps/mada/tests/conftest.py
+++ b/src/apps/mada/tests/conftest.py
@@ -1,0 +1,22 @@
+"""
+Fixture'y wspólne dla testów `mada` (warstwa integration/e2e/performance).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def mada_api(settings):
+    """Adres + dane logowania API na wartości testowe."""
+    settings.MADA_API_BASE_URL = "https://mada.test"
+    settings.MADA_API_LOGIN = "test-login"
+    settings.MADA_API_PASSWORD = "test-pass"
+    return settings
+
+
+@pytest.fixture
+def mocked_responses():
+    import responses
+    with responses.RequestsMock() as rsps:
+        yield rsps

--- a/src/apps/mada/tests/factories.py
+++ b/src/apps/mada/tests/factories.py
@@ -1,0 +1,87 @@
+"""
+Buildery obiektów DB i ładunków feedu Mada.
+
+Wartości domyślne = minimalny poprawny rekord; nadpisujesz tylko to, co
+testuje dany przypadek. `db` domyślnie `default` — w trybie testowym
+`DATABASE_ROUTERS = []`, więc modele `mada` i tak lądują na `default`.
+"""
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+from mada.models import Brand, Category, MadaProduct, MadaProductVariant
+
+_pid = itertools.count(160_000)
+_producer = itertools.count(100)
+_img = itertools.count(300_000)
+
+
+def brand(db: str = "default", **over: Any) -> Brand:
+    data = {"producer_id": str(next(_producer)), "name": "Gatta"}
+    data.update(over)
+    return Brand.objects.using(db).create(**data)
+
+
+def category(db: str = "default", **over: Any) -> Category:
+    data = {"category_id": f"{next(_pid)}-1", "name": "Rajstopy", "path": "Rajstopy"}
+    data.update(over)
+    return Category.objects.using(db).create(**data)
+
+
+def mada_product(db: str = "default", **over: Any) -> MadaProduct:
+    api_id = over.pop("api_id", None) or next(_pid)
+    data = {
+        "api_id": api_id,
+        "name": f"Produkt {api_id}",
+        "price": "12.00",
+        "vat": "23",
+    }
+    data.update(over)
+    return MadaProduct.objects.using(db).create(**data)
+
+
+def mada_variant(product: MadaProduct, db: str = "default", **over: Any) -> MadaProductVariant:
+    ean = over.pop("ean", None) or f"590{next(_img):010d}"
+    data = {
+        "product": product,
+        "variant_key": ean,
+        "color": "czarny",
+        "size": "M",
+        "ean": ean,
+        "stock": 5,
+    }
+    data.update(over)
+    return MadaProductVariant.objects.using(db).create(**data)
+
+
+# --- ładunki feedu (dict po parsowaniu, kształt jak `parse_product_element`) ---
+
+def variant_dict(*, color="czarny", size="M", ean=None, stock=5) -> dict:
+    ean = ean if ean is not None else f"590{next(_img):010d}"
+    return {
+        "color": color,
+        "size": size,
+        "ean": ean,
+        "stock": stock,
+        "variant_key": ean or f"{color}|{size}",
+    }
+
+
+def product_dict(*, api_id=None, producer_id="110", variants=None, images=None, **over) -> dict:
+    api_id = api_id if api_id is not None else next(_pid)
+    d = {
+        "api_id": api_id,
+        "name": f"Rajstopy {api_id}",
+        "desc": "Opis",
+        "producer_id": producer_id,
+        "price": "12.04",
+        "old_price": None,
+        "vat": "23",
+        "categories": [{"c1": "30", "c2": "63", "name": "Rajstopy / lycra"}],
+        "variants": variants if variants is not None else [variant_dict()],
+        "images": images if images is not None else [],
+        "raw_data": {"similar_products": []},
+    }
+    d.update(over)
+    return d

--- a/src/apps/mada/tests/tests_integration_importer_idempotent.py
+++ b/src/apps/mada/tests/tests_integration_importer_idempotent.py
@@ -1,0 +1,82 @@
+"""
+`importer.upsert_variants` — idempotencja i odporność na wyścig full/partial.
+
+Stan aktualizowany warunkowym UPDATE (`filter(pk=…, stock=old)`), wpis do
+StockHistory tylko gdy UPDATE zmienił wiersz. Powtórny import tego samego okna
+(redelivery Celery) lub równoległy full+partial nie dublują historii.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mada.importer import import_product_dict, upsert_variants
+from mada.models import MadaProductVariant, StockHistory
+
+from .factories import brand, mada_product, mada_variant, product_dict, variant_dict
+
+pytestmark = pytest.mark.django_db
+
+
+def test_utworzenie_wariantu_zapisuje_wpis_increase():
+    brand(producer_id="110")
+    import_product_dict("default", product_dict(producer_id="110",
+                        variants=[variant_dict(ean="111", stock=43)]), {})
+
+    rows = list(StockHistory.objects.all())
+    assert len(rows) == 1
+    assert (rows[0].old_stock, rows[0].new_stock, rows[0].change_type) == (0, 43, "increase")
+
+
+def test_zmiana_stanu_tworzy_jeden_wpis():
+    cache = {}
+    pd = product_dict(producer_id="110", variants=[variant_dict(ean="111", stock=43)])
+    import_product_dict("default", pd, cache)
+
+    pd2 = {**pd, "variants": [variant_dict(ean="111", stock=10)]}
+    import_product_dict("default", pd2, cache)
+
+    assert MadaProductVariant.objects.get(variant_key="111").stock == 10
+    assert StockHistory.objects.count() == 2
+    last = StockHistory.objects.order_by("-timestamp", "-id").first()
+    assert (last.old_stock, last.new_stock, last.change_type) == (43, 10, "decrease")
+
+
+def test_powtorny_import_tego_samego_okna_nie_dubluje_historii():
+    """Redelivery Celery po visibility_timeout: ten sam plik leci drugi raz."""
+    cache = {}
+    pd = product_dict(producer_id="110", variants=[variant_dict(ean="111", stock=43)])
+    import_product_dict("default", pd, cache)
+    pd2 = {**pd, "variants": [variant_dict(ean="111", stock=10)]}
+
+    import_product_dict("default", pd2, cache)
+    import_product_dict("default", pd2, cache)  # powtórka
+    import_product_dict("default", pd2, cache)  # i jeszcze raz
+
+    assert StockHistory.objects.count() == 2  # increase 0→43, decrease 43→10 — bez duplikatów
+
+
+def test_import_gdy_stan_juz_docelowy_nie_tworzy_wpisu():
+    """Równoległy przebieg (full) zdążył ustawić stan docelowy zanim nasz
+    (partial) doszedł do UPDATE — warunek `stock=old` nie łapie, 0 wierszy."""
+    product = mada_product(api_id=161)
+    v = mada_variant(product, variant_key="111", ean="111", stock=5)
+    # inny przebieg ustawił już 9
+    MadaProductVariant.objects.filter(pk=v.pk).update(stock=9)
+
+    changed = upsert_variants("default", product, [variant_dict(ean="111", stock=9)])
+
+    assert changed == 0
+    assert StockHistory.objects.count() == 0
+    assert MadaProductVariant.objects.get(pk=v.pk).stock == 9
+
+
+def test_zmiana_atrybutu_bez_zmiany_stanu_nie_tworzy_wpisu_historii():
+    product = mada_product(api_id=161)
+    mada_variant(product, variant_key="111", ean="111", stock=5, color="czarny")
+
+    upsert_variants("default", product, [
+        variant_dict(ean="111", stock=5, color="grafitowy"),
+    ])
+
+    assert StockHistory.objects.count() == 0
+    assert MadaProductVariant.objects.get(variant_key="111").color == "grafitowy"

--- a/src/apps/mada/tests/tests_performance_importer.py
+++ b/src/apps/mada/tests/tests_performance_importer.py
@@ -1,0 +1,60 @@
+"""
+`importer` — brak N+1 przy imporcie masowym:
+- `brand_cache` (load_brand_cache) zdejmuje zapytanie o markę per produkt;
+- historia stanów leci jednym `bulk_create`, nie INSERT per zmieniony wariant.
+"""
+from __future__ import annotations
+
+import pytest
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+
+from mada.importer import import_product_dict, load_brand_cache, upsert_variants
+from mada.models import StockHistory
+
+from .factories import brand, mada_product, product_dict, variant_dict
+
+pytestmark = pytest.mark.django_db
+DB = "default"
+
+
+def _count(ctx, needle):
+    return sum(1 for q in ctx.captured_queries if needle in q["sql"])
+
+
+def test_brand_cache_zdejmuje_zapytanie_o_marke_per_produkt():
+    brand(producer_id="110", name="Gatta")
+    cache = load_brand_cache(DB)
+    cat_cache = {}
+
+    with CaptureQueriesContext(connections[DB]) as ctx:
+        for i in range(10):
+            import_product_dict(DB, product_dict(api_id=5000 + i, producer_id="110"),
+                                cat_cache, cache)
+
+    # z brand_cache: zero SELECT-ów po mada_brand w pętli importu
+    assert _count(ctx, 'FROM "mada_brand"') == 0
+
+
+def test_bez_brand_cache_jest_nplus1():
+    brand(producer_id="110", name="Gatta")
+    cat_cache = {}
+
+    with CaptureQueriesContext(connections[DB]) as ctx:
+        for i in range(10):
+            import_product_dict(DB, product_dict(api_id=6000 + i, producer_id="110"), cat_cache)
+
+    assert _count(ctx, 'FROM "mada_brand"') >= 10
+
+
+def test_historia_stanow_zapisywana_batchem():
+    product = mada_product(api_id=161)
+    variants = [variant_dict(ean=f"E{i}", stock=i + 1) for i in range(15)]
+
+    with CaptureQueriesContext(connections[DB]) as ctx:
+        changed = upsert_variants(DB, product, variants)
+
+    assert changed == 15
+    assert StockHistory.objects.count() == 15
+    # jeden INSERT zbiorczy do historii, nie 15
+    assert _count(ctx, 'INSERT INTO "mada_stock_history"') == 1


### PR DESCRIPTION
Zamyka część #243 (pkt 1–3).

## Problem
`mada.importer.upsert_variants` czytał `current.stock` → porównywał → `current.save()`. Bez warunkowego UPDATE:
- `sync_mada_full` (lock `mada:sync_mada_full`) i `sync_mada_partial` (lock `mada:sync_mada_partial`) mają **różne** advisory locki → mogą lecieć równolegle → zgubione update'y + zdublowane `StockHistory`.
- `task_acks_late=True` + Redis `visibility_timeout=3600` → zabity `full` wraca po 1h i leci drugi raz na nieaktualnym oknie.

To ten sam bug co matterhorn1 #230 / tabu #236.

## Zmiany
- **`upsert_variants`** aktualizuje stan `filter(pk=…, stock=old).update(stock=new, updated_at=now())`; wpis do `StockHistory` tylko gdy UPDATE zmienił wiersz → race-safe + idempotentne (powtórny import okna nie dubluje historii).
- **Historia stanów** zbierana i zapisywana jednym `bulk_create` zamiast `INSERT` per zmieniony wariant.
- **`load_brand_cache(db)`** — `upsert_product` bierze markę z dicta zamiast `SELECT ... FROM mada_brand` per produkt (N+1); `sync_mada_full`/`sync_mada_partial` budują cache po `sync_brands`.
- **`stock_tracker`** — wydzielony `build_stock_history_row` (niezapisany obiekt do `bulk_create`); `track_stock_change` zostaje jako wrapper ad-hoc.

## Testy
Nowy pakiet `src/apps/mada/tests/` (factories, conftest):
- `tests_integration_importer_idempotent.py` — powtórny import nie dubluje historii, „stan już docelowy" → 0 wierszy, zmiana atrybutu bez wpisu do historii.
- `tests_performance_importer.py` — `brand_cache` = 0 SELECT-ów po `mada_brand` w pętli (vs ≥10 bez cache), historia jednym `INSERT`.

`pytest src/apps/mada` — 35 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)