### PR TITLE
fix(matterhorn1): nie kończ inventory po cichu jako sukces przy błędzie API

### DIFF
--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -126,6 +126,7 @@ def full_import_and_update(self, start_id=None, max_products=200000,
     total_updated = 0
     iteration = 0
     items_error = None  # ustawiane gdy _import_products_from_items zwróci błąd
+    inventory_degraded = None  # komunikat, gdy któraś aktualizacja INVENTORY padła (5xx/brak JSON/sieć)
 
     try:
         logger.info(
@@ -176,14 +177,19 @@ def full_import_and_update(self, start_id=None, max_products=200000,
                     dry_run=dry_run
                 )
 
-                if inventory_result['status'] == 'success':
-                    updated_count = inventory_result.get('updated_count', 0)
-                    total_updated += updated_count
-                    logger.info(
-                        f"✅ Iteracja {iteration} - Zaktualizowano {updated_count} produktów w INVENTORY")
-                else:
+                updated_count = inventory_result.get('updated_count', 0)
+                total_updated += updated_count
+                if inventory_result['status'] == 'partial':
+                    inventory_degraded = inventory_result.get('error') or 'INVENTORY nie dokończone'
+                    logger.error(
+                        f"❌ INVENTORY w iteracji {iteration} PRZERWANE - import NIE zostanie "
+                        f"oznaczony jako 'completed' (okno stanów nadgoni kolejny tick): {inventory_degraded}")
+                elif inventory_result['status'] != 'success':
                     logger.warning(
                         f"⚠️ Błąd aktualizacji INVENTORY w iteracji {iteration}: {inventory_result.get('error')}")
+                else:
+                    logger.info(
+                        f"✅ Iteracja {iteration} - Zaktualizowano {updated_count} produktów w INVENTORY")
                 break
             elif items_result['status'] != 'success':
                 logger.error(
@@ -205,14 +211,19 @@ def full_import_and_update(self, start_id=None, max_products=200000,
                 dry_run=dry_run
             )
 
-            if inventory_result['status'] == 'success':
-                updated_count = inventory_result.get('updated_count', 0)
-                total_updated += updated_count
-                logger.info(
-                    f"✅ Iteracja {iteration} - Zaktualizowano {updated_count} produktów w INVENTORY")
-            else:
+            updated_count = inventory_result.get('updated_count', 0)
+            total_updated += updated_count
+            if inventory_result['status'] == 'partial':
+                inventory_degraded = inventory_result.get('error') or 'INVENTORY nie dokończone'
+                logger.error(
+                    f"❌ INVENTORY w iteracji {iteration} PRZERWANE - import NIE zostanie "
+                    f"oznaczony jako 'completed' (okno stanów nadgoni kolejny tick): {inventory_degraded}")
+            elif inventory_result['status'] != 'success':
                 logger.warning(
                     f"⚠️ Błąd aktualizacji INVENTORY w iteracji {iteration}: {inventory_result.get('error')}")
+            else:
+                logger.info(
+                    f"✅ Iteracja {iteration} - Zaktualizowano {updated_count} produktów w INVENTORY")
 
             # Jeśli nie zaimportowano żadnych produktów, zakończ po aktualizacji INVENTORY
             if imported_count == 0:
@@ -248,6 +259,22 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             return {
                 'status': 'error',
                 'error': items_error,
+                'total_imported': total_imported,
+                'total_updated': total_updated,
+                'iterations': iteration,
+                'task_id': task_id_value,
+            }
+
+        if inventory_degraded:
+            # ITEMS przeszło, ale któraś strona INVENTORY padła. NIE oznaczamy
+            # importu jako 'completed' — status 'inventory_failed' jest pomijany
+            # przez _get_last_items_update_time (znacznik last_update nie
+            # przeskakuje) i przez _get_last_items_page (ITEMS rusza od strony 1),
+            # więc kolejny tick nadgoni pominięte okno stanów magazynowych.
+            return {
+                'status': 'partial',
+                'reason': 'inventory_failed',
+                'error': inventory_degraded,
                 'total_imported': total_imported,
                 'total_updated': total_updated,
                 'iterations': iteration,
@@ -306,6 +333,17 @@ def full_import_and_update(self, start_id=None, max_products=200000,
                 _update_items_import_status(
                     'completed', total_imported, updated_count=total_updated, processed_count=total_imported + total_updated)
                 logger.info("✅ Task zakończony jako 'completed'")
+            elif inventory_degraded:
+                # ITEMS OK, INVENTORY padło. Status 'inventory_failed' (pomijany
+                # przez _get_last_items_update_time) + current_page=1 (żeby ITEMS
+                # ruszył od początku szerszego okna) → kolejny tick nadgoni stany.
+                _update_items_import_status(
+                    'inventory_failed', total_imported, current_page=1,
+                    updated_count=total_updated, processed_count=total_imported + total_updated,
+                    error_details=f'INVENTORY nie dokończone: {inventory_degraded}')
+                logger.warning(
+                    "⚠️ Task zakończony jako 'inventory_failed' — ITEMS OK, ale INVENTORY "
+                    "przerwane; last_update NIE przeskakuje, kolejny tick nadgoni okno stanów")
             else:
                 _update_items_import_status(
                     'error', total_imported, updated_count=total_updated, processed_count=total_imported + total_updated)
@@ -682,6 +720,9 @@ def _get_last_items_update_time():
             from matterhorn1.models import ApiSyncLog
             import pytz
 
+            # 'inventory_failed' celowo POMIJANE — run, w którym padło INVENTORY,
+            # nie może przesunąć znacznika do przodu (kolejny tick musi nadgonić
+            # okno stanów, którego ten run nie dopobrał).
             last_sync = ApiSyncLog.objects.using('matterhorn1').filter(
                 sync_type__in=['items_import', 'items_sync'],
                 status__in=['success', 'partial', 'completed']
@@ -796,7 +837,8 @@ def _save_items_import_start_time():
                     "❌ Osiągnięto maksymalną liczbę prób zapisywania czasu rozpoczęcia importu")
 
 
-def _update_items_import_status(status, imported_count, current_page=None, updated_count=0, processed_count=0):
+def _update_items_import_status(status, imported_count, current_page=None, updated_count=0,
+                                processed_count=0, error_details=None):
     """Aktualizuje status ostatniego importu ITEMS z retry logic"""
     max_retries = 5
     retry_delay = 10  # 10 sekund między próbami
@@ -823,6 +865,9 @@ def _update_items_import_status(status, imported_count, current_page=None, updat
                 # Aktualizuj current_page jeśli podane
                 if current_page is not None:
                     last_running.current_page = current_page
+
+                if error_details is not None:
+                    last_running.error_details = error_details
 
                 last_running.save()
                 logger.info(
@@ -1395,53 +1440,97 @@ def _prepare_product_update(product, item, brand=None, category=None):
 
 
 def _fetch_inventory_page(page, api_url, headers, limit, last_update):
-    """Pobiera jedną stronę B2BAPI/ITEMS/INVENTORY. Bez retry - tak jak
-    oryginalnie: każdy błąd (JSON/status/sieć) albo koniec danych (pusta
-    strona/404) po prostu kończy pobieranie tej strony jako 'stop' (oryginalny
-    kod na każdym z tych przypadków po prostu przerywał pętlę i zwracał
-    'success' z tym, co już zdążono zaktualizować - to zachowanie zostaje).
+    """Pobiera jedną stronę B2BAPI/ITEMS/INVENTORY z retry/backoff (do 5 prób,
+    20 s między próbami) - jak `_fetch_items_page`.
 
-    Zwraca:
+    Rozróżnia KONIEC DANYCH od BŁĘDU (wcześniej jedno i drugie było 'stop' i
+    kończyło INVENTORY jako 'success', przez co np. HTTP 200 z ciałem które nie
+    jest JSON-em - strona błędu / rate-limit / WAF - było po cichu traktowane
+    jak koniec danych, a okno stanów magazynowych przepadało):
+
       {'outcome': 'ok', 'items': [...]}
-      {'outcome': 'stop'}
+      {'outcome': 'end_of_data'}          # pusta odpowiedź / [] / 404 - czysty koniec
+      {'outcome': 'error', 'error': str}  # 5xx / brak JSON / sieć po wyczerpaniu prób
     """
-    try:
-        import requests
+    max_attempts = 5
+    attempt = 1
 
-        url = f"{api_url}/B2BAPI/ITEMS/INVENTORY/?page={page}&limit={limit}&last_update={last_update}"
-        logger.info(f"🔗 INVENTORY Request URL: {url}")
-        response = requests.get(url, headers=headers, timeout=120)
+    while attempt <= max_attempts:
+        try:
+            import requests
 
-        logger.info(f"🔍 INVENTORY API Response strona {page}: status={response.status_code}")
+            url = f"{api_url}/B2BAPI/ITEMS/INVENTORY/?page={page}&limit={limit}&last_update={last_update}"
+            logger.info(f"🔗 INVENTORY Request URL: {url}")
+            response = requests.get(url, headers=headers, timeout=120)
 
-        if response.status_code == 200:
-            if not response.text.strip():
-                logger.info(f"📊 INVENTORY (strona {page}) - pusta odpowiedź - koniec danych")
-                return {'outcome': 'stop'}
+            logger.info(
+                f"🔍 INVENTORY API Response strona {page}: status={response.status_code}, "
+                f"content_length={len(response.text)}")
 
-            try:
-                inventory_data = response.json()
-            except Exception as e:
-                logger.error(f"❌ Błąd parsowania JSON INVENTORY (strona {page}): {e}")
-                return {'outcome': 'stop'}
+            if response.status_code == 200:
+                if not response.text.strip():
+                    logger.info(f"📊 INVENTORY (strona {page}) - pusta odpowiedź - koniec danych")
+                    return {'outcome': 'end_of_data'}
 
-            if not inventory_data:
-                logger.info(f"📊 INVENTORY (strona {page}) - brak danych na stronie - koniec")
-                return {'outcome': 'stop'}
+                try:
+                    inventory_data = response.json()
+                except SoftTimeLimitExceeded:
+                    raise
+                except Exception as e:
+                    logger.error(f"❌ Błąd parsowania JSON INVENTORY (strona {page}): {e}")
+                    logger.error(
+                        f"❌ INVENTORY (strona {page}) treść odpowiedzi (pierwsze 500 znaków): "
+                        f"{response.text[:500]!r}")
+                    if attempt < max_attempts:
+                        logger.warning(
+                            f"⚠️ Próba {attempt}/{max_attempts} (INVENTORY strona {page}) - ponawiam za 20 s...")
+                        time.sleep(20)
+                        attempt += 1
+                        continue
+                    return {
+                        'outcome': 'error',
+                        'error': f'INVENTORY strona {page}: HTTP 200 bez poprawnego JSON po {max_attempts} próbach',
+                    }
 
-            logger.info(f"📥 INVENTORY - pobrano {len(inventory_data)} rekordów ze strony {page}")
-            return {'outcome': 'ok', 'items': inventory_data}
+                if not inventory_data:
+                    logger.info(f"📊 INVENTORY (strona {page}) - brak danych na stronie - koniec")
+                    return {'outcome': 'end_of_data'}
 
-        elif response.status_code == 404:
-            logger.info(f"📊 INVENTORY (strona {page}) - strona nie istnieje - koniec danych")
-            return {'outcome': 'stop'}
-        else:
-            logger.warning(f"⚠️ Błąd INVENTORY API {response.status_code} (strona {page})")
-            return {'outcome': 'stop'}
+                logger.info(f"📥 INVENTORY - pobrano {len(inventory_data)} rekordów ze strony {page}")
+                return {'outcome': 'ok', 'items': inventory_data}
 
-    except Exception as e:
-        logger.error(f"❌ Błąd podczas pobierania INVENTORY strony {page}: {e}")
-        return {'outcome': 'stop'}
+            elif response.status_code == 404:
+                logger.info(f"📊 INVENTORY (strona {page}) - strona nie istnieje - koniec danych")
+                return {'outcome': 'end_of_data'}
+            else:
+                logger.warning(f"⚠️ Błąd INVENTORY API {response.status_code} (strona {page})")
+                if attempt < max_attempts:
+                    logger.warning(
+                        f"⚠️ Próba {attempt}/{max_attempts} (INVENTORY strona {page}) - ponawiam za 20 s...")
+                    time.sleep(20)
+                    attempt += 1
+                    continue
+                return {
+                    'outcome': 'error',
+                    'error': f'INVENTORY strona {page}: HTTP {response.status_code} po {max_attempts} próbach',
+                }
+
+        except SoftTimeLimitExceeded:
+            raise
+        except Exception as e:
+            logger.error(f"❌ Błąd podczas pobierania INVENTORY strony {page}: {e}")
+            if attempt < max_attempts:
+                logger.warning(
+                    f"⚠️ Próba {attempt}/{max_attempts} (INVENTORY strona {page}) - ponawiam za 20 s...")
+                time.sleep(20)
+                attempt += 1
+                continue
+            return {
+                'outcome': 'error',
+                'error': f'INVENTORY strona {page} nieosiągalna po {max_attempts} próbach: {e}',
+            }
+
+    return {'outcome': 'error', 'error': f'INVENTORY strona {page}: wyczerpano próby'}
 
 
 def _update_inventory_from_api(api_url, username, password, batch_size, dry_run):
@@ -1449,13 +1538,20 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
 
     Ten sam pipeline co w _import_products_from_items: WSZYSTKIE strony lecą
     w locie naraz, nowa co MATTERHORN_PAGE_LAUNCH_INTERVAL sekund, aż do
-    trafienia na koniec danych/błąd (a wystrzeliwanie kończy się wcześniej,
-    jak tylko którakolwiek już gotowa strona w buforze okaże się takim
-    "stop"). INVENTORY nie ma checkpointu do wznowienia (zawsze zaczyna od
+    trafienia na koniec danych albo błąd (a wystrzeliwanie kończy się
+    wcześniej, jak tylko którakolwiek już gotowa strona w buforze okaże się
+    nie-'ok'). INVENTORY nie ma checkpointu do wznowienia (zawsze zaczyna od
     strony 1) i _bulk_update_inventory per strona jest niezależny od innych
     stron, więc bufor porządkujący jest tu tylko dla przewidywalnej
-    kolejności logów/liczenia - nie ma ryzyka pominięcia danych przy
-    wznowieniu jak przy ITEMS.
+    kolejności logów/liczenia.
+
+    Zwraca:
+      {'status': 'success', 'updated_count': N}          - czysty przebieg
+      {'status': 'partial', 'updated_count': N, 'error'}  - któraś strona padła
+          (5xx / brak JSON / sieć) po wyczerpaniu prób; wołający NIE powinien
+          oznaczać importu jako 'completed', żeby znacznik last_update nie
+          przeskoczył i kolejny tick nadgonił pominięte okno stanów
+      {'status': 'error', 'error'}                        - nie dało się w ogóle wystartować
     """
     try:
         # Użyj tej samej daty startu co ITEMS z poprawnym formatowaniem
@@ -1484,6 +1580,7 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
 
         updated_count = 0
         limit = 1000
+        inventory_error = None  # ustawiane gdy strona INVENTORY padnie (nie: koniec danych)
 
         # Wystrzeliwanie na osobnym wątku, niezależnie od zapisu - patrz
         # obszerny komentarz w _import_products_from_items. Bez tego seria
@@ -1534,7 +1631,14 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
                     result = pending.pop(next_to_process).result()
                 current_page = next_to_process
 
-                if result['outcome'] != 'ok':
+                if result['outcome'] == 'error':
+                    stop_launching.set()
+                    inventory_error = result.get('error') or f'INVENTORY strona {current_page} - błąd'
+                    logger.error(
+                        f"❌ INVENTORY przerwane błędem na stronie {current_page}: {inventory_error}")
+                    break
+
+                if result['outcome'] == 'end_of_data':
                     stop_launching.set()
                     break
 
@@ -1555,7 +1659,18 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
             executor.shutdown(wait=False, cancel_futures=True)
 
         logger.info(
-            f"📊 INVENTORY zakończony: {updated_count} zaktualizowanych produktów")
+            f"📊 INVENTORY zakończony: {updated_count} zaktualizowanych produktów"
+            + (f" (PRZERWANE BŁĘDEM: {inventory_error})" if inventory_error else ""))
+
+        if inventory_error:
+            # Nie 'success' - wołający NIE oznaczy importu jako 'completed',
+            # więc znacznik last_update nie przeskoczy i kolejny tick nadgoni
+            # okno stanów, którego ten run nie zdążył pobrać.
+            return {
+                'status': 'partial',
+                'updated_count': updated_count,
+                'error': inventory_error,
+            }
 
         return {
             'status': 'success',

--- a/src/apps/matterhorn1/tests/mock_matterhorn.py
+++ b/src/apps/matterhorn1/tests/mock_matterhorn.py
@@ -60,13 +60,27 @@ def mock_items(rsps, pages: list[list[dict]], transient_errors: dict[int, list[i
     )
 
 
-def mock_inventory(rsps, pages: list[list[dict]]) -> None:
-    """`pages` = lista stron, każda to lista rekordów INVENTORY."""
+def mock_inventory(rsps, pages: list[list[dict]],
+                   transient_errors: dict[int, list[int]] | None = None) -> None:
+    """`pages` = lista stron, każda to lista rekordów INVENTORY.
+    `transient_errors` — patrz `_paginated_callback`."""
     rsps.add_callback(
         responses.GET,
         f"{_base_url()}{INVENTORY_PATH}",
-        callback=_paginated_callback(pages),
+        callback=_paginated_callback(pages, transient_errors),
         content_type="application/json",
+    )
+
+
+def mock_inventory_unparseable(rsps, body: str = "<html>Rate limit exceeded</html>",
+                               status: int = 200) -> None:
+    """Endpoint INVENTORY zwraca zawsze `status` z ciałem, które nie jest JSON-em
+    (strona błędu / WAF / rate-limit). Do regresji: taki przypadek MUSI zostać
+    zgłoszony jako błąd, a nie po cichu potraktowany jak koniec danych."""
+    rsps.add_callback(
+        responses.GET,
+        f"{_base_url()}{INVENTORY_PATH}",
+        callback=lambda request: (status, {}, body),
     )
 
 

--- a/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
+++ b/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
@@ -11,7 +11,7 @@ import pytest
 from matterhorn1.models import ApiSyncLog, Product, ProductVariant
 from matterhorn1.tasks import full_import_and_update
 
-from .mock_matterhorn import mock_inventory, mock_items
+from .mock_matterhorn import mock_inventory, mock_inventory_unparseable, mock_items
 
 pytestmark = [pytest.mark.e2e, pytest.mark.django_db(databases=["default", "matterhorn1"])]
 
@@ -50,6 +50,54 @@ def test_trwaly_500_na_stronie_przerywa_import_zamiast_petlic(
         sync_type="items_import").order_by("-started_at").first()
     assert last.status == "error"
     assert last.current_page == 2  # zachowane do wznowienia
+
+
+def test_inventory_nie_json_nie_przechodzi_po_cichu_jako_completed(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    """Regresja: INVENTORY strona 1 = HTTP 200 z ciałem nie-JSON. ITEMS przeszło,
+    ale import NIE może być 'completed' (inaczej znacznik last_update przeskakuje
+    i okno stanów przepada). Status 'inventory_failed' + current_page=1 →
+    kolejny tick nadgoni."""
+    mock_items(mocked_responses, [[api_item(id=6001)], []])
+    mock_inventory_unparseable(mocked_responses)
+
+    result = full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert result["status"] == "partial"
+    assert result["reason"] == "inventory_failed"
+
+    # produkt z ITEMS zaimportowany mimo błędu INVENTORY
+    assert Product.objects.using("matterhorn1").filter(product_uid=6001).exists()
+
+    last = ApiSyncLog.objects.using("matterhorn1").filter(
+        sync_type="items_import").order_by("-started_at").first()
+    assert last.status == "inventory_failed"
+    assert last.current_page == 1
+    assert "INVENTORY" in (last.error_details or "")
+
+    # znacznik last_update NIE przeskoczył — okno bierze się nadal z prior_items_sync
+    window_row = ApiSyncLog.objects.using("matterhorn1").filter(
+        sync_type__in=["items_import", "items_sync"],
+        status__in=["success", "partial", "completed"],
+    ).order_by("-started_at").first()
+    assert window_row.pk == prior_items_sync.pk
+
+
+def test_inventory_chwilowy_500_dogania_sie_i_konczy_completed(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    """Chwilowy 5xx na stronie INVENTORY jest ponawiany — po sukcesie import
+    kończy się normalnie jako 'success'."""
+    mock_items(mocked_responses, [[api_item(id=6100)], []])
+    mock_inventory(mocked_responses, [[], []], transient_errors={1: [500, 503]})
+
+    result = full_import_and_update(auto_continue=False, dry_run=False)
+
+    assert result["status"] == "success"
+    last = ApiSyncLog.objects.using("matterhorn1").filter(
+        sync_type="items_import").order_by("-started_at").first()
+    assert last.status == "completed"
 
 
 def test_blokada_rownoleglego_importu_zwraca_skipped(

--- a/src/apps/matterhorn1/tests/tests_unit_fetch_inventory_page.py
+++ b/src/apps/matterhorn1/tests/tests_unit_fetch_inventory_page.py
@@ -1,0 +1,93 @@
+"""
+Unit: `_fetch_inventory_page` — klasyfikacja odpowiedzi B2BAPI/ITEMS/INVENTORY.
+
+Regresja: wcześniej KAŻDY problem (200-nie-JSON, 5xx, sieć) był 'stop' i INVENTORY
+kończyło się jako 'success' z 0 update'ów — okno stanów magazynowych przepadało
+po cichu. Teraz błąd (po wyczerpaniu prób) to 'error', a tylko pusta odpowiedź /
+[] / 404 to 'end_of_data'.
+"""
+from __future__ import annotations
+
+import pytest
+import responses
+
+from matterhorn1.tasks import _fetch_inventory_page
+
+pytestmark = pytest.mark.unit
+
+URL_RE = responses.matchers.query_param_matcher({}, strict_match=False)
+BASE = "https://matterhorn.test/B2BAPI/ITEMS/INVENTORY/"
+HEADERS = {"Authorization": "test"}
+
+
+def _call(page=1):
+    return _fetch_inventory_page(page, "https://matterhorn.test", HEADERS, 1000, "2026-01-01 00:00:00")
+
+
+@responses.activate
+def test_200_z_danymi_to_ok():
+    responses.add(responses.GET, BASE, json=[{"id": 1, "inventory": []}], status=200)
+    assert _call() == {"outcome": "ok", "items": [{"id": 1, "inventory": []}]}
+
+
+@responses.activate
+def test_pusta_odpowiedz_to_end_of_data():
+    responses.add(responses.GET, BASE, body="   ", status=200)
+    assert _call() == {"outcome": "end_of_data"}
+
+
+@responses.activate
+def test_pusta_lista_to_end_of_data():
+    responses.add(responses.GET, BASE, json=[], status=200)
+    assert _call() == {"outcome": "end_of_data"}
+
+
+@responses.activate
+def test_404_to_end_of_data():
+    responses.add(responses.GET, BASE, status=404)
+    assert _call() == {"outcome": "end_of_data"}
+
+
+@responses.activate
+def test_200_nie_json_ponawiane_potem_error():
+    # 5 prób (max_attempts) — wszystkie 200 z HTML-em
+    for _ in range(5):
+        responses.add(responses.GET, BASE, body="<html>Rate limit exceeded</html>", status=200)
+    out = _call()
+    assert out["outcome"] == "error"
+    assert "JSON" in out["error"]
+    assert len(responses.calls) == 5
+
+
+@responses.activate
+def test_200_nie_json_a_potem_sukces():
+    responses.add(responses.GET, BASE, body="<html>chwilowy błąd</html>", status=200)
+    responses.add(responses.GET, BASE, json=[{"id": 7, "inventory": []}], status=200)
+    out = _call()
+    assert out == {"outcome": "ok", "items": [{"id": 7, "inventory": []}]}
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_500_ponawiane_potem_error():
+    for _ in range(5):
+        responses.add(responses.GET, BASE, status=500)
+    out = _call()
+    assert out["outcome"] == "error"
+    assert "500" in out["error"]
+
+
+@responses.activate
+def test_500_a_potem_sukces():
+    responses.add(responses.GET, BASE, status=503)
+    responses.add(responses.GET, BASE, json=[{"id": 9, "inventory": []}], status=200)
+    assert _call()["outcome"] == "ok"
+
+
+@responses.activate
+def test_blad_sieci_ponawiany_potem_error():
+    for _ in range(5):
+        responses.add(responses.GET, BASE, body=responses.ConnectionError("boom"))
+    out = _call()
+    assert out["outcome"] == "error"
+    assert "nieosiągalna" in out["error"]

--- a/src/apps/matterhorn1/tests/tests_unit_inventory_pipeline.py
+++ b/src/apps/matterhorn1/tests/tests_unit_inventory_pipeline.py
@@ -34,7 +34,7 @@ def test_strony_przetwarzane_w_kolejnosci_mimo_odwroconej_kolejnosci_odpowiedzi(
         if page == 2:
             page2_done.set()
             return {'outcome': 'ok', 'items': [{'id': 2, 'inventory': []}]}
-        return {'outcome': 'stop'}
+        return {'outcome': 'end_of_data'}
 
     processed_order = []
 
@@ -55,19 +55,17 @@ def test_strony_przetwarzane_w_kolejnosci_mimo_odwroconej_kolejnosci_odpowiedzi(
     assert processed_order == [1, 2]
 
 
-def test_stop_na_stronie_przerywa_i_ignoruje_juz_wystrzelone_strony(monkeypatch):
-    """Strona 2 kończy się "stop" (koniec danych/błąd - bez retry, jak
-    oryginalnie) - aktualizacja ma się zatrzymać, a wynik już pobranej
-    strony 3+ (wystrzelonej spekulatywnie zanim strona 2 zdążyła odpowiedzieć)
-    ma zostać zignorowany. W przeciwieństwie do ITEMS - to nadal 'success'
-    (częściowy wynik), bo INVENTORY tak działało już wcześniej."""
+def test_koniec_danych_przerywa_i_ignoruje_juz_wystrzelone_strony(monkeypatch):
+    """Strona 2 = 'end_of_data' (czysty koniec) - aktualizacja ma się
+    zatrzymać, a wynik już pobranej strony 3+ (wystrzelonej spekulatywnie)
+    ma zostać zignorowany. Wynik to 'success' - to normalny koniec danych."""
     monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
 
     def fake_fetch(page, api_url, headers, limit, last_update):
         if page == 1:
             return {'outcome': 'ok', 'items': [{'id': 1, 'inventory': []}]}
         if page == 2:
-            return {'outcome': 'stop'}
+            return {'outcome': 'end_of_data'}
         # strona 3 (i dalsze) - wystrzelona spekulatywnie, ma dane, ale nie
         # może zostać zapisana, bo stoi za stroną 2, która kończy pipeline.
         return {'outcome': 'ok', 'items': [{'id': page, 'inventory': []}]}
@@ -91,13 +89,42 @@ def test_stop_na_stronie_przerywa_i_ignoruje_juz_wystrzelone_strony(monkeypatch)
     assert processed_order == [1]
 
 
+def test_blad_strony_zwraca_partial_z_liczba_juz_zapisanych(monkeypatch):
+    """Strona 2 = 'error' (5xx / brak JSON po wyczerpaniu prób). Strona 1 już
+    zapisana. Wynik: 'partial' + komunikat błędu + updated_count z już
+    zapisanych stron - żeby wołający NIE oznaczył importu jako 'completed'."""
+    monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
+
+    def fake_fetch(page, api_url, headers, limit, last_update):
+        if page == 1:
+            return {'outcome': 'ok', 'items': [{'id': 1, 'inventory': []}]}
+        if page == 2:
+            return {'outcome': 'error', 'error': 'INVENTORY strona 2: HTTP 200 bez poprawnego JSON po 5 próbach'}
+        return {'outcome': 'ok', 'items': [{'id': page, 'inventory': []}]}
+
+    def fake_bulk_update(inventory_data):
+        return len(inventory_data)
+
+    with patch("matterhorn1.tasks._fetch_inventory_page", side_effect=fake_fetch), \
+            patch("matterhorn1.tasks._bulk_update_inventory", side_effect=fake_bulk_update), \
+            patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"):
+        result = _update_inventory_from_api(
+            api_url="https://matterhorn.example", username="u", password="p",
+            batch_size=100, dry_run=False,
+        )
+
+    assert result["status"] == "partial"
+    assert result["updated_count"] == 1
+    assert "JSON" in result["error"]
+
+
 def test_dry_run_nie_woła_bulk_update(monkeypatch):
     monkeypatch.setattr("matterhorn1.tasks.time.sleep", lambda *_a, **_k: None)
 
     def fake_fetch(page, api_url, headers, limit, last_update):
         if page == 1:
             return {'outcome': 'ok', 'items': [{'id': 1, 'inventory': []}]}
-        return {'outcome': 'stop'}
+        return {'outcome': 'end_of_data'}
 
     with patch("matterhorn1.tasks._fetch_inventory_page", side_effect=fake_fetch), \
             patch("matterhorn1.tasks._bulk_update_inventory") as mock_bulk, \


### PR DESCRIPTION
## Objaw (z logów prod)

```
🔍 INVENTORY API Response strona 1: status=200
❌ Błąd parsowania JSON INVENTORY (strona 1): Expecting value: line 1 column 1 (char 0)
📊 INVENTORY zakończony: 0 zaktualizowanych produktów
✅ Task zakończony jako 'completed'
```

INVENTORY strona 1 zwróciła **HTTP 200 z ciałem które nie jest JSON-em** (strona błędu / rate-limit / WAF), a task zakończył się jako `completed` z 0 update'ów. INVENTORY to jedyny mechanizm zerujący stany (*ITEMS API nie pokazuje stanów 0*) — te zmiany przepadły po cichu, bez alertu, i nie zostały nadgonione (kolejny run bierze `last_update` = start tego runu).

## Przyczyna

- `_fetch_inventory_page` zwijał **każdy** problem (200-nie-JSON, 5xx, błąd sieci) w jedno `{'outcome': 'stop'}` = to samo co czysty koniec danych.
- `_update_inventory_from_api` **zawsze** zwracał `{'status': 'success'}` — nie miał jak zasygnalizować „przerwałem przez błąd".

## Zmiany

| Miejsce | Zmiana |
|---|---|
| `_fetch_inventory_page` | retry/backoff (5 prób × 20 s) jak `_fetch_items_page`; rozróżnia `end_of_data` (pusta odp. / `[]` / 404) od `error` (5xx / brak JSON / sieć po wyczerpaniu prób); loguje `response.text[:500]` przy nie-JSON |
| `_update_inventory_from_api` | zwraca `{'status': 'partial', 'error': …}` gdy strona padła |
| `full_import_and_update` | przy zdegradowanym INVENTORY **nie** oznacza importu `completed` — status **`inventory_failed`** (pomijany przez `_get_last_items_update_time` → `last_update` nie przeskakuje; pomijany przez `_get_last_items_page` + `current_page=1` → ITEMS rusza od początku szerszego okna) + `error_details`. Task zwraca `{'status': 'partial', 'reason': 'inventory_failed'}`. **Kolejny tick nadgania pominięte okno stanów.** |
| `_update_items_import_status` | nowy param `error_details` |

Chwilowy błąd (transient 200-śmieć / 5xx) jest teraz ponawiany i zwykle znika bez śladu w statusie.

## Testy

- `tests_unit_fetch_inventory_page.py` (nowy) — klasyfikacja odpowiedzi + retry (`responses`)
- `tests_unit_inventory_pipeline.py` — `end_of_data` vs `error` → `partial` z liczbą już zapisanych stron
- `tests_e2e_import_errors.py` — nie-JSON INVENTORY → `inventory_failed` + `last_update` bez przeskoku + produkt z ITEMS zaimportowany; chwilowy 5xx → dogania się do `completed`

`pytest src/apps/matterhorn1` — 245 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)