### PR TITLE
test(mada): api_client, taski, komendy sync + gate pokrycia (odzysk #245)

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -195,15 +195,15 @@ jobs:
       - name: Testy (pytest)
         # Konfiguracja w pyproject.toml [tool.pytest.ini_options] + [tool.coverage.*].
         # Uruchamiane są WSZYSTKIE testy (testpaths=src/apps); próg pokrycia
-        # (--cov-fail-under) pilnuje matterhorn1 + tabu (management/commands
+        # (--cov-fail-under) pilnuje matterhorn1 + tabu + mada (management/commands
         # celowo poza pomiarem — patrz [tool.coverage.run] omit). Kolejne apki:
         # dopisać ścieżkę. Próg = wspólny dla wszystkich --cov, trzymany
         # zachowawczo poniżej realnego pokrycia — podnosić przy okazji.
         run: >-
           pytest
-          --cov=src/apps/matterhorn1 --cov=src/apps/tabu
+          --cov=src/apps/matterhorn1 --cov=src/apps/tabu --cov=src/apps/mada
           --cov-report=term-missing:skip-covered
-          --cov-fail-under=53
+          --cov-fail-under=55
 
   check-code-quality:
     name: Sprawdź jakość kodu (linting i formatowanie)

--- a/src/apps/mada/tests/mock_mada.py
+++ b/src/apps/mada/tests/mock_mada.py
@@ -1,0 +1,105 @@
+"""
+Buildery odpowiedzi API Mada (`get_xml.php`) do mockowania przez `responses`.
+
+- manifest: `<FILES><FILE><NAME/><DATE/><TYPE/></FILE>...</FILES>`
+- plik danych: ZIP zawierający `products.xml`
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Iterable
+
+import responses
+
+BASE_URL = "https://mada.test"
+MANIFEST_URL = f"{BASE_URL}/get_xml.php"
+
+
+def manifest_xml(files: Iterable[dict]) -> bytes:
+    """`files`: [{'name':..., 'date':'2026-01-15 00:01:00', 'type':'full'|'partial'}]"""
+    rows = "".join(
+        f"<FILE><NAME>{f['name']}</NAME><DATE>{f.get('date', '')}</DATE>"
+        f"<TYPE>{f['type']}</TYPE></FILE>"
+        for f in files
+    )
+    return f'<?xml version="1.0" encoding="utf-8"?><FILES>{rows}</FILES>'.encode()
+
+
+def _product_xml(p: dict) -> str:
+    cats = "".join(
+        f'<CATEGORY c1="{c["c1"]}" c2="{c["c2"]}"><![CDATA[{c.get("name", "")}]]></CATEGORY>'
+        for c in p.get("categories", [])
+    )
+    models = ""
+    for color, sizes in p.get("models", []):
+        size_els = "".join(
+            f'<SIZE amount="{s["amount"]}"'
+            + (f' ean="{s["ean"]}"' if s.get("ean") else "")
+            + f'>{s["label"]}</SIZE>'
+            for s in sizes
+        )
+        models += f"<MODEL><COLOR><![CDATA[{color}]]></COLOR>{size_els}</MODEL>"
+    imgs = "".join(
+        f'<IMG id="{i["id"]}">{i["url"]}</IMG>' for i in p.get("images", [])
+    )
+    old_price = f"<OLD_PRICE>{p['old_price']}</OLD_PRICE>" if p.get("old_price") else ""
+    return (
+        f"<PRODUCT><ID>{p['id']}</ID>"
+        f"<NAME><![CDATA[{p.get('name', '')}]]></NAME>"
+        f"<DESC><![CDATA[{p.get('desc', '')}]]></DESC>"
+        f"<PRODUCER>{p.get('producer_id', '')}</PRODUCER>"
+        f"<PRICE>{p.get('price', '0')}</PRICE>{old_price}<VAT>{p.get('vat', '23')}</VAT>"
+        f"<CATEGORIES>{cats}</CATEGORIES>"
+        f"<MODELS>{models}</MODELS><IMAGES>{imgs}</IMAGES></PRODUCT>"
+    )
+
+
+def products_xml(producers: dict, products: Iterable[dict]) -> bytes:
+    prod_rows = "".join(
+        f'<PRODUCER id="{pid}"><![CDATA[{name}]]></PRODUCER>'
+        for pid, name in producers.items()
+    )
+    product_rows = "".join(_product_xml(p) for p in products)
+    return (
+        '<?xml version="1.0" encoding="utf-8"?><DATA>'
+        f"<PRODUCERS>{prod_rows}</PRODUCERS>"
+        f"<PRODUCTS>{product_rows}</PRODUCTS></DATA>"
+    ).encode()
+
+
+def zip_bytes(inner_xml: bytes, inner_name: str = "products.xml") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(inner_name, inner_xml)
+    return buf.getvalue()
+
+
+def simple_product(pid: int, *, name="Rajstopy", producer_id="110", stock=5,
+                   ean="5901234567890", price="12.04", **over) -> dict:
+    d = {
+        "id": pid,
+        "name": name,
+        "desc": "Opis",
+        "producer_id": producer_id,
+        "price": price,
+        "categories": [{"c1": "30", "c2": "63", "name": "Rajstopy / lycra"}],
+        "models": [("czarny", [{"amount": stock, "ean": ean, "label": "M"}])],
+        "images": [],
+    }
+    d.update(over)
+    return d
+
+
+def register_manifest(rsps: responses.RequestsMock, files):
+    rsps.add(responses.GET, MANIFEST_URL, body=manifest_xml(files),
+             content_type="application/xml")
+
+
+def register_file(rsps: responses.RequestsMock, file_name: str, producers: dict, products):
+    rsps.add(
+        responses.GET, MANIFEST_URL,
+        match=[responses.matchers.query_param_matcher({"file": file_name}, strict_match=False)],
+        body=zip_bytes(products_xml(producers, products)),
+        content_type="application/zip",
+    )

--- a/src/apps/mada/tests/tests_integration_cleanup_commands.py
+++ b/src/apps/mada/tests/tests_integration_cleanup_commands.py
@@ -1,0 +1,41 @@
+"""
+Komenda sprzątająca Mada: `cleanup_empty_mada_products`.
+
+(`cleanup_orphaned_mada_mapping` sięga do `_get_mada_db()` / `_get_mpd_db()`
+bezpośrednio — poza remapowaniem routerów w trybie testowym — więc nie jest
+tu pokryta.)
+"""
+from __future__ import annotations
+
+import pytest
+from django.core.management import call_command
+
+from mada.models import MadaProduct
+
+from .factories import mada_product, mada_variant
+
+pytestmark = pytest.mark.django_db
+
+
+class TestCleanupEmptyProducts:
+    def test_usuwa_tylko_puste_niezmapowane(self):
+        mada_product(api_id=1, name="")                       # pusty, niezmapowany → kasowany
+        mada_product(api_id=2, name="", mapped_product_uid=55)  # pusty, ale zmapowany → zostaje
+        mada_product(api_id=3, name="Ma nazwę")                 # z nazwą → zostaje
+
+        call_command("cleanup_empty_mada_products")
+
+        assert set(MadaProduct.objects.values_list("api_id", flat=True)) == {2, 3}
+
+    def test_dry_run_nic_nie_kasuje(self):
+        mada_product(api_id=1, name="")
+        call_command("cleanup_empty_mada_products", "--dry-run")
+        assert MadaProduct.objects.filter(api_id=1).exists()
+
+    def test_kasuje_powiazane_warianty(self):
+        p = mada_product(api_id=1, name="")
+        mada_variant(p, variant_key="v1", ean="v1")
+
+        call_command("cleanup_empty_mada_products")
+
+        assert not MadaProduct.objects.filter(api_id=1).exists()

--- a/src/apps/mada/tests/tests_integration_sync_full.py
+++ b/src/apps/mada/tests/tests_integration_sync_full.py
@@ -1,0 +1,108 @@
+"""
+`sync_mada_full` — pełny import: pobranie najnowszego pliku full z manifestu,
+import produktów, wygaszenie nieobecnych, log ApiSyncLog.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import responses
+from django.core.management import call_command
+
+from mada.models import ApiSyncLog, MadaProduct, MadaProductVariant, StockHistory
+
+from . import mock_mada
+from .factories import mada_product
+
+pytestmark = pytest.mark.django_db
+
+PRODUCERS = {"110": "Gatta", "43": "Golden Lady"}
+
+
+@pytest.fixture
+def rsps():
+    with responses.RequestsMock() as r:
+        yield r
+
+
+def _manifest_and_file(rsps, file_name, products):
+    mock_mada.register_manifest(rsps, [
+        {"name": file_name, "date": "2026-01-15 00:01:00", "type": "full"},
+    ])
+    mock_mada.register_file(rsps, file_name, PRODUCERS, products)
+
+
+def test_pelny_import_tworzy_produkty_warianty_i_log(mada_api, rsps):
+    _manifest_and_file(rsps, "2026-01-15-full", [
+        mock_mada.simple_product(161, ean="111", stock=5),
+        mock_mada.simple_product(162, producer_id="43", ean="222", stock=0),
+    ])
+
+    call_command("sync_mada_full")
+
+    assert MadaProduct.objects.count() == 2
+    assert MadaProductVariant.objects.get(variant_key="111").stock == 5
+    log = ApiSyncLog.objects.get(sync_type="full_import")
+    assert log.status == "completed"
+    assert log.products_processed == 2
+    assert log.products_created == 2
+
+
+def test_deaktywuje_produkty_nieobecne_w_feedzie(mada_api, rsps):
+    mada_product(api_id=999, name="Znika z oferty", is_active=True)
+    _manifest_and_file(rsps, "2026-01-15-full", [mock_mada.simple_product(161, ean="111")])
+
+    call_command("sync_mada_full")
+
+    assert MadaProduct.objects.get(api_id=999).is_active is False
+    assert MadaProduct.objects.get(api_id=161).is_active is True
+
+
+def test_blad_jednego_produktu_nie_przerywa_importu(mada_api, rsps):
+    _manifest_and_file(rsps, "2026-01-15-full", [
+        mock_mada.simple_product(161, ean="111"),
+        mock_mada.simple_product(162, ean="222"),
+        mock_mada.simple_product(163, ean="333"),
+    ])
+    from mada import importer as mada_importer
+
+    def flaky(db, pd, cat_cache, brand_cache=None):
+        if pd["api_id"] == 162:
+            raise RuntimeError("boom")
+        return mada_importer.import_product_dict(db, pd, cat_cache, brand_cache)
+
+    with patch("mada.management.commands.sync_mada_full.import_product_dict", side_effect=flaky):
+        call_command("sync_mada_full")
+
+    assert MadaProduct.objects.filter(api_id__in=[161, 163]).count() == 2
+    assert not MadaProduct.objects.filter(api_id=162).exists()
+    log = ApiSyncLog.objects.get(sync_type="full_import")
+    assert log.status == "completed"
+    assert log.products_failed == 1
+
+
+def test_wymuszony_plik_pomija_manifest_full(mada_api, rsps):
+    mock_mada.register_file(rsps, "reczny-full", PRODUCERS,
+                            [mock_mada.simple_product(161, ean="111")])
+
+    call_command("sync_mada_full", file="reczny-full")
+
+    assert ApiSyncLog.objects.get(sync_type="full_import").file_name == "reczny-full"
+    assert MadaProduct.objects.count() == 1
+
+
+def test_powtorny_pelny_import_nie_dubluje_historii(mada_api):
+    """Idempotencja przez komendę (regresja na nakładające się runy / redelivery)."""
+    def run(stock):
+        with responses.RequestsMock() as rsps:
+            _manifest_and_file(rsps, "2026-01-15-full",
+                               [mock_mada.simple_product(161, ean="111", stock=stock)])
+            call_command("sync_mada_full")
+
+    run(5)          # increase 0→5
+    run(2)          # decrease 5→2
+    run(2)          # bez zmiany
+    run(2)
+
+    assert StockHistory.objects.count() == 2

--- a/src/apps/mada/tests/tests_integration_sync_partial.py
+++ b/src/apps/mada/tests/tests_integration_sync_partial.py
@@ -1,0 +1,77 @@
+"""
+`sync_mada_partial` — import przyrostowy: kursor = najwyższy `file_name` wśród
+ukończonych logów `partial_import`; przetwarza wszystkie nowsze pliki.
+"""
+from __future__ import annotations
+
+import pytest
+import responses
+from django.core.management import call_command
+
+from mada.models import ApiSyncLog, MadaProduct, StockHistory
+
+from . import mock_mada
+
+pytestmark = pytest.mark.django_db
+
+PRODUCERS = {"110": "Gatta"}
+
+
+@pytest.fixture
+def rsps():
+    with responses.RequestsMock() as r:
+        yield r
+
+
+def test_brak_nowych_plikow_to_noop(mada_api, rsps):
+    mock_mada.register_manifest(rsps, [
+        {"name": "2026-01-15_090000", "date": "2026-01-15 09:00:00", "type": "partial"},
+    ])
+    ApiSyncLog.objects.create(
+        sync_type="partial_import", status="completed", file_name="2026-01-15_090000")
+
+    call_command("sync_mada_partial")
+
+    assert ApiSyncLog.objects.filter(sync_type="partial_import").count() == 1
+
+
+def test_przetwarza_pliki_nowsze_niz_kursor(mada_api, rsps):
+    ApiSyncLog.objects.create(
+        sync_type="partial_import", status="completed", file_name="2026-01-15_090000")
+    mock_mada.register_manifest(rsps, [
+        {"name": "2026-01-15_090000", "date": "2026-01-15 09:00:00", "type": "partial"},
+        {"name": "2026-01-15_100000", "date": "2026-01-15 10:00:00", "type": "partial"},
+        {"name": "2026-01-15_110000", "date": "2026-01-15 11:00:00", "type": "partial"},
+    ])
+    mock_mada.register_file(rsps, "2026-01-15_100000", PRODUCERS,
+                            [mock_mada.simple_product(161, ean="111", stock=3)])
+    mock_mada.register_file(rsps, "2026-01-15_110000", PRODUCERS,
+                            [mock_mada.simple_product(162, ean="222", stock=7)])
+
+    call_command("sync_mada_partial")
+
+    assert MadaProduct.objects.filter(api_id__in=[161, 162]).count() == 2
+    done = set(ApiSyncLog.objects.filter(
+        sync_type="partial_import", status="completed").values_list("file_name", flat=True))
+    assert done == {"2026-01-15_090000", "2026-01-15_100000", "2026-01-15_110000"}
+
+
+def test_kolejne_uruchomienie_nie_dubluje_historii(mada_api):
+    def run(files_in_manifest, file_to_serve, stock):
+        with responses.RequestsMock() as rsps:
+            mock_mada.register_manifest(rsps, files_in_manifest)
+            mock_mada.register_file(rsps, file_to_serve, PRODUCERS,
+                                    [mock_mada.simple_product(161, ean="111", stock=stock)])
+            call_command("sync_mada_partial")
+
+    f1 = {"name": "2026-01-15_100000", "date": "2026-01-15 10:00:00", "type": "partial"}
+    f2 = {"name": "2026-01-15_110000", "date": "2026-01-15 11:00:00", "type": "partial"}
+
+    run([f1], "2026-01-15_100000", 5)            # increase 0→5
+    run([f1, f2], "2026-01-15_110000", 1)        # decrease 5→1
+
+    # symulacja redelivery: kursor "cofnięty", ten sam plik leci znów
+    ApiSyncLog.objects.filter(file_name="2026-01-15_110000").delete()
+    run([f1, f2], "2026-01-15_110000", 1)
+
+    assert StockHistory.objects.count() == 2

--- a/src/apps/mada/tests/tests_integration_tasks.py
+++ b/src/apps/mada/tests/tests_integration_tasks.py
@@ -1,0 +1,66 @@
+"""
+`mada.tasks` — cienkie wrappery Celery wokół komend zarządzania.
+Kluczowe: advisory lock (skip gdy nie zdobyty) i retry przy błędzie komendy.
+"""
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch
+
+import pytest
+from celery.exceptions import Retry
+
+from mada import tasks
+
+pytestmark = pytest.mark.django_db
+
+
+@contextlib.contextmanager
+def _lock(acquired):
+    yield acquired
+
+
+@pytest.mark.parametrize("task_fn, command", [
+    (tasks.sync_mada_full, "sync_mada_full"),
+    (tasks.sync_mada_partial, "sync_mada_partial"),
+    (tasks.cleanup_empty_products, "cleanup_empty_mada_products"),
+])
+class TestLockedTasks:
+    def test_skip_gdy_lock_nie_zdobyty(self, task_fn, command):
+        with patch.object(tasks, "advisory_lock", lambda name: _lock(False)), \
+                patch.object(tasks, "call_command") as cc:
+            result = task_fn.apply().get()
+
+        assert result == {"status": "skipped", "reason": "already_running"}
+        cc.assert_not_called()
+
+    def test_ok_wola_komende(self, task_fn, command):
+        with patch.object(tasks, "advisory_lock", lambda name: _lock(True)), \
+                patch.object(tasks, "call_command") as cc:
+            result = task_fn.apply().get()
+
+        assert result == {"status": "ok"}
+        cc.assert_called_once_with(command)
+
+    def test_blad_komendy_powoduje_retry(self, task_fn, command):
+        with patch.object(tasks, "advisory_lock", lambda name: _lock(True)), \
+                patch.object(tasks, "call_command", side_effect=RuntimeError("boom")), \
+                pytest.raises(Retry):
+            task_fn.apply(throw=True)
+
+
+def test_full_i_partial_uzywaja_roznych_lockow():
+    """Regresja: gdyby ktoś ujednolicił nazwy, ten test przypomni o decyzji
+    (#243) — dziś full i partial mają OSOBNE locki i mogą lecieć równolegle,
+    dlatego upsert_variants musi być idempotentny."""
+    seen = []
+
+    def _spy(name):
+        seen.append(name)
+        return _lock(True)
+
+    with patch.object(tasks, "advisory_lock", _spy), patch.object(tasks, "call_command"):
+        tasks.sync_mada_full.apply().get()
+        tasks.sync_mada_partial.apply().get()
+
+    assert seen == ["mada:sync_mada_full", "mada:sync_mada_partial"]

--- a/src/apps/mada/tests/tests_unit_api_client.py
+++ b/src/apps/mada/tests/tests_unit_api_client.py
@@ -1,0 +1,114 @@
+"""
+`mada.api_client.MadaApiClient` — parsowanie manifestu, wybór plików full/partial,
+rozpakowanie ZIP, redakcja danych logowania w komunikatach błędów.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+import responses
+
+from mada.api_client import MadaApiClient, MadaApiError
+
+from . import mock_mada
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client(mada_api):
+    return MadaApiClient()
+
+
+@pytest.fixture
+def rsps():
+    with responses.RequestsMock() as r:
+        yield r
+
+
+def test_list_files_parsuje_manifest(client, rsps):
+    mock_mada.register_manifest(rsps, [
+        {"name": "2026-01-15-full", "date": "2026-01-15 00:01:00", "type": "full"},
+        {"name": "2026-01-15_120500", "date": "2026-01-15 12:05:00", "type": "partial"},
+        {"name": "bez-daty", "date": "", "type": "partial"},
+    ])
+    files = client.list_files()
+
+    assert [f.name for f in files] == ["2026-01-15-full", "2026-01-15_120500", "bez-daty"]
+    assert files[0].is_full
+    assert files[2].date is None  # niepoprawna data → None, wpis zostaje
+
+
+def test_latest_full_file_bierze_najnowszy(client, rsps):
+    mock_mada.register_manifest(rsps, [
+        {"name": "old-full", "date": "2026-01-10 00:01:00", "type": "full"},
+        {"name": "new-full", "date": "2026-01-15 00:01:00", "type": "full"},
+        {"name": "p1", "date": "2026-01-16 00:01:00", "type": "partial"},
+    ])
+    assert client.latest_full_file().name == "new-full"
+
+
+def test_latest_full_file_none_gdy_brak_full(client, rsps):
+    mock_mada.register_manifest(rsps, [{"name": "p1", "date": "2026-01-16 00:01:00", "type": "partial"}])
+    assert client.latest_full_file() is None
+
+
+def test_partial_files_after_filtruje_i_sortuje(client, rsps):
+    mock_mada.register_manifest(rsps, [
+        {"name": "2026-01-15_090000", "date": "2026-01-15 09:00:00", "type": "partial"},
+        {"name": "2026-01-15_120000", "date": "2026-01-15 12:00:00", "type": "partial"},
+        {"name": "2026-01-15_100000", "date": "2026-01-15 10:00:00", "type": "partial"},
+        {"name": "2026-01-15-full", "date": "2026-01-15 00:01:00", "type": "full"},
+    ])
+    got = client.partial_files_after("2026-01-15_090000")
+    assert [f.name for f in got] == ["2026-01-15_100000", "2026-01-15_120000"]
+
+
+def test_partial_files_after_bez_kursora_zwraca_wszystkie(client, rsps):
+    mock_mada.register_manifest(rsps, [
+        {"name": "b", "date": "2026-01-15 12:00:00", "type": "partial"},
+        {"name": "a", "date": "2026-01-15 09:00:00", "type": "partial"},
+    ])
+    assert [f.name for f in client.partial_files_after(None)] == ["a", "b"]
+
+
+def test_download_products_xml_rozpakowuje_zip(client, rsps):
+    mock_mada.register_file(rsps, "2026-01-15-full", {"110": "Gatta"},
+                            [mock_mada.simple_product(161)])
+    xml = client.download_products_xml("2026-01-15-full")
+    assert b"<ID>161</ID>" in xml
+
+
+def test_download_products_xml_zip_bez_xml(client, rsps):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "nope")
+    rsps.add(responses.GET, mock_mada.MANIFEST_URL, body=buf.getvalue(),
+             content_type="application/zip")
+
+    with pytest.raises(MadaApiError, match="nie zawiera pliku XML"):
+        client.download_products_xml("x")
+
+
+def test_download_products_xml_zly_zip(client, rsps):
+    rsps.add(responses.GET, mock_mada.MANIFEST_URL, body=b"to nie jest zip")
+    with pytest.raises(MadaApiError, match="ZIP"):
+        client.download_products_xml("x")
+
+
+def test_blad_polaczenia_redaguje_haslo(client, rsps):
+    rsps.add(responses.GET, mock_mada.MANIFEST_URL,
+             body=responses.ConnectionError("failed for url: https://mada.test/get_xml.php?l=test-login&p=test-pass"))
+    with pytest.raises(MadaApiError) as exc:
+        client.list_files()
+    msg = str(exc.value)
+    assert "test-pass" not in msg and "test-login" not in msg
+    assert "p=***" in msg
+
+
+def test_brak_danych_logowania_blad_od_razu(mada_api):
+    mada_api.MADA_API_PASSWORD = ""
+    with pytest.raises(MadaApiError, match="MADA_API_LOGIN / MADA_API_PASSWORD"):
+        MadaApiClient()


### PR DESCRIPTION
## Dlaczego to jest ponownie

PR **#245** pokazuje się jako „MERGED", ale trafił do gałęzi `perf/mada-stock-idempotent-nplus1` (był na niej stackowany), **nie do main** — merge commit `61f9fe2` nie jest przodkiem `main`. Jego zawartość nigdy nie weszła na `main`. Ten PR odtwarza te zmiany od aktualnego main.

Na main jest tylko #244 (kod + `tests_integration_importer_idempotent.py` + `tests_performance_importer.py`). Brakuje testów `api_client.py` / `tasks.py` / komend sync/cleanup i wpięcia mada do bramki pokrycia.

## Zawartość (identyczna z #245)

| Plik | Zakres |
|------|--------|
| `tests_unit_api_client.py` | parsowanie manifestu, `latest_full_file`, `partial_files_after` (kursor), ZIP (+ złe archiwum / brak XML), **redakcja `l`/`p` w komunikatach błędów** |
| `tests_integration_tasks.py` | advisory lock → skip, retry, regresja: `sync_mada_full` i `sync_mada_partial` mają **osobne** locki |
| `tests_integration_sync_full.py` | import + log, wygaszanie nieobecnych, izolacja błędu produktu, `--file`, idempotencja |
| `tests_integration_sync_partial.py` | no-op bez nowych plików, przetwarzanie po kursorze, brak duplikatów przy redelivery |
| `tests_integration_cleanup_commands.py` | `cleanup_empty_mada_products` |
| `mock_mada.py` | buildery manifestu / `products.xml` / ZIP dla `responses` |

## CI

`check-branch.yml`: `--cov=src/apps/mada`, próg `--cov-fail-under` 53 → 55.

Zweryfikowane lokalnie na aktualnym main (z #244 + #247): `matterhorn1 + tabu + mada` = **60.73%**, 369 passed. Same testy mada: 66 passed.

Bez zmian w kodzie produkcyjnym.

🤖 Generated with [Claude Code](https://claude.com/claude-code)