### PR TITLE
fix(matterhorn1): advisory lock + acks_late=False dla full_import (#238)

### DIFF
--- a/docs/matterhorn/MATTERHORN1.md
+++ b/docs/matterhorn/MATTERHORN1.md
@@ -56,17 +56,17 @@ Matterhorn to jedna z trzech działających hurtowni (obok `tabu` i `mada`);
 `src/apps/matterhorn1/models.py`. Tabele bez prefiksu (`brand`, `product`, …)
 poza `matterhorn1_stock_history`.
 
-| Model | Tabela | Rola | Klucz z API |
-| --- | --- | --- | --- |
-| `Brand` | `brand` | marka | `brand_id` (unique) |
-| `Category` | `category` | kategoria + `path` | `category_id` (unique) |
-| `Product` | `product` | produkt | `product_uid` (IntegerField, **unique**) |
-| `ProductDetails` | `productdetails` | 1:1 — waga, tabela rozmiarów | — |
-| `ProductImage` | `productimage` | zdjęcia, `unique(product, image_url)` | — |
-| `ProductVariant` | `productvariant` | wariant/rozmiar, **`stock`** | `variant_uid` (CharField, **unique globalnie**) |
-| `ApiSyncLog` | `apisynclog` | log + **checkpoint** (`current_page`, `status`) | — |
-| `StockHistory` | `matterhorn1_stock_history` | historia zmian stanu | — |
-| `Saga` / `SagaStep` | `saga_logs` / `saga_steps` | saga mapowania do MPD (`core.saga`) | — |
+| Model               | Tabela                      | Rola                                            | Klucz z API                                     |
+| ------------------- | --------------------------- | ----------------------------------------------- | ----------------------------------------------- |
+| `Brand`             | `brand`                     | marka                                           | `brand_id` (unique)                             |
+| `Category`          | `category`                  | kategoria + `path`                              | `category_id` (unique)                          |
+| `Product`           | `product`                   | produkt                                         | `product_uid` (IntegerField, **unique**)        |
+| `ProductDetails`    | `productdetails`            | 1:1 — waga, tabela rozmiarów                    | —                                               |
+| `ProductImage`      | `productimage`              | zdjęcia, `unique(product, image_url)`           | —                                               |
+| `ProductVariant`    | `productvariant`            | wariant/rozmiar, **`stock`**                    | `variant_uid` (CharField, **unique globalnie**) |
+| `ApiSyncLog`        | `apisynclog`                | log + **checkpoint** (`current_page`, `status`) | —                                               |
+| `StockHistory`      | `matterhorn1_stock_history` | historia zmian stanu                            | —                                               |
+| `Saga` / `SagaStep` | `saga_logs` / `saga_steps`  | saga mapowania do MPD (`core.saga`)             | —                                               |
 
 Mapowanie do MPD: `Product.mapped_product_uid` / `is_mapped`,
 `ProductVariant.mapped_variant_uid` / `is_mapped`. Ustawiane ręcznie w adminie
@@ -114,13 +114,16 @@ full_import_and_update(start_id=None, max_products=200000, api_url=None,
 Przebieg:
 
 1. `_check_database_connection()` — retry x3, przerwij jak baza niedostępna.
-2. `_cleanup_old_running_imports()` — oznacz jako `error` runy `running`
-   starsze niż 2 h.
-3. `_cleanup_all_running_imports()` — jeśli są rekordy `running` **bez**
-   blokady Redis → oznacz `error` (task przerwany); jeśli blokada **bez**
-   rekordów → usuń ghost lock. (Nie łapie przypadku "oba istnieją" — patrz §12.)
-4. **Blokada:** `cache.add('matterhorn1_full_import_lock', task_id, 3600)`.
-   Nie udało się zdobyć → `return {'status': 'skipped', 'reason': 'already_running'}`.
+2. **Blokada:** `advisory_lock('matterhorn1:full_import_and_update')` — PostgreSQL
+   advisory lock (`core.pg_locks`, jak `tabu`). Zwalnia się sam po padzie workera,
+   bez TTL i ghost-locków. Nie zdobyta → `return {'status': 'skipped', 'reason': 'already_running'}`.
+   Dekorator taska: `acks_late=False` — ubity w połowie run **nie** jest
+   redeliverowany po `visibility_timeout` (1 h); kolejny tick beat wznawia od
+   `current_page`.
+3. `_fail_stale_running_imports()` — trzymamy wyłączny lock, więc każdy rekord
+   `items_import` w statusie `running` to sierota po ubitym workerze → `error`
+   (`current_page` zostaje do wznowienia).
+4. `_run_full_import_locked(...)` — właściwe ciało importu.
 5. Pętla iteracji (`while True`, bezpiecznik 100 iteracji):
    - **KROK 1 — ITEMS:** `_import_products_from_items(...)`.
      - `status == 'completed'` (koniec danych) → zrób ostatni INVENTORY i `break`.
@@ -129,8 +132,9 @@ Przebieg:
      - `status == 'success'` (osiągnięto `max_products`) → leć dalej.
    - **KROK 2 — INVENTORY:** `_update_inventory_from_api(...)`.
    - `imported_count == 0` albo `auto_continue == False` → `break`.
-6. Zwolnij blokadę, zapisz `ApiSyncLog` (`success` / `completed` / `error`),
-   `return {'status': 'success'|'error', 'total_imported', 'total_updated', ...}`.
+6. Zapisz `ApiSyncLog` (`success` / `completed` / `error` / `inventory_failed`),
+   `return {'status': 'success'|'error'|'partial', 'total_imported', 'total_updated', ...}`.
+   Advisory lock zwalnia context manager.
 
 `dry_run=True` — pobiera z API i liczy, ale **nie** pisze do bazy i nie
 aktualizuje `ApiSyncLog`.
@@ -164,6 +168,7 @@ API; pod obciążeniem współbieżnym jeszcze wolniej). Sekwencyjnie: godzina+.
   logi z wątków miały `full_import_and_update[<task_id>]` zamiast `???[???]`.
 
 Fetch pojedynczej strony (`_fetch_items_page` / `_fetch_inventory_page`):
+
 - ITEMS: do 10 prób, 20 s między próbami; zwraca `{'outcome': 'ok'|'end_of_data'|'error'}`.
 - INVENTORY: **bez retry** (historycznie tak było) — każdy błąd/koniec = `{'outcome': 'ok'|'stop'}`.
 
@@ -175,6 +180,7 @@ Fetch pojedynczej strony (`_fetch_items_page` / `_fetch_inventory_page`):
 per strona (w kolejności).
 
 `_bulk_import_products` (batch, bez N+1):
+
 1. `_resolve_brands_categories(items)` — batch `get_or_create` marek/kategorii.
 2. Batch pre-fetch istniejących produktów po `product_uid`
    (`filter(product_uid__in=...)`).
@@ -198,6 +204,7 @@ Item bez `creation_date` jest pomijany.
 per strona (w kolejności).
 
 `_bulk_update_inventory`:
+
 1. Batch pre-fetch produktów (po `product_uid`) i wariantów (po
    `str(variant_uid)`, `select_related('product')`).
 2. Dla każdego wariantu, którego stan się różni — **warunkowy UPDATE**:
@@ -236,7 +243,7 @@ filtruje warianty po `updated_at`.
   strony. Wszystkie przerwane runy używają **tego samego** `last_update`
   (znacznik przeskakuje dopiero po `completed`), więc numer strony jest spójny.
 - Po zapisaniu każdej strony ITEMS: `_update_items_import_status('running',
-  imported_count, next_page, ...)` — utrwala checkpoint.
+imported_count, next_page, ...)` — utrwala checkpoint.
 - Import ITEMS, który padł na stronie N (5xx/sieć po wyczerpaniu prób), **nie**
   jest oznaczany `completed`. Kolejny tick celery-beat wznowi od strony N.
 - Bug #214 (naprawiony): dawniej `page` rosło tylko po sukcesie, więc trwały
@@ -253,11 +260,11 @@ tam tylko dla przewidywalnej kolejności logów).
 
 Schedule w bazie (`django_celery_beat`, `DatabaseScheduler`), nie w kodzie:
 
-| Zadanie | Harmonogram | Uwaga |
-| --- | --- | --- |
-| `matterhorn1.tasks.full_import_and_update` | crontab `2,12,22,32,42,52 * * * *` (Europe/Warsaw) | co 10 min |
-| `matterhorn1.tasks.watchdog_import_healthcheck` | co 5 min | sprawdza spójność blokada↔DB, sprząta ghost locki |
-| `MPD.tasks.update_stock_from_matterhorn1` | co 5 min | most stanów matterhorn1 → MPD |
+| Zadanie                                         | Harmonogram                                        | Uwaga                                                                                                                                                            |
+| ----------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `matterhorn1.tasks.full_import_and_update`      | crontab `2,12,22,32,42,52 * * * *` (Europe/Warsaw) | co 10 min                                                                                                                                                        |
+| `matterhorn1.tasks.watchdog_import_healthcheck` | co 5 min                                           | siatka bezpieczeństwa: `running` bez postępu > 15 min → `error`, bardzo stare (> 3 h) → `error`. Blokada = advisory lock, więc nie ma ghost-locków do sprzątania |
+| `MPD.tasks.update_stock_from_matterhorn1`       | co 5 min                                           | most stanów matterhorn1 → MPD                                                                                                                                    |
 
 Pozostałe taski (bez harmonogramu / punktowe):
 `clean_old_stock_history` (kasuje wpisy `StockHistory` starsze niż N dni —
@@ -280,6 +287,7 @@ domyślne zachowanie, nie bug (widoczne w logach jako run o "dziwnej" minucie).
 `stock_tracker.track_stock_change()` (punktowo).
 
 Most do MPD: **`MPD.tasks.update_stock_from_matterhorn1`** (co 5 min):
+
 1. Bierze warianty `matterhorn1` z `is_mapped=True` zmienione w oknie
    (`updated_at` w ostatnich ~15 min).
 2. Po `mapped_variant_uid` znajduje wariant w MPD.
@@ -314,14 +322,13 @@ Wspólna baza: `core/wholesaler_admin/` (`RouterScopedQuerysetMixin`,
 
 ## 12. Znane problemy i pułapki
 
-| Problem | Opis | Status |
-| --- | --- | --- |
-| **Redeliver ubitych tasków / nakładające się runy** | Restart `celery-import` w połowie taska → Celery nie dostaje ACK → redeliveruje po czasie (do ~1 h). Wraca, bierze wolną blokadę, przelatuje ponownie na przesuniętym `last_update` — równolegle z runem z beat. Powodowało duplikaty w `StockHistory` i "zawieszone" locki. | Objawy złagodzone (#230 idempotencja INVENTORY); root cause = osobne issue |
-| **Self-healing nie łapie "oba istnieją"** | `_cleanup_all_running_imports` naprawia tylko gdy jest rekord `running` **bez** blokady albo blokada **bez** rekordów. Twarde ubicie procesu zostawia oba → wygląda jak "działa normalnie", blokuje kolejne importy do wygaśnięcia locka (1 h) lub aż `watchdog_import_healthcheck` posprząta. | osobne issue |
-| **Deploy nie jest automatyczny** | `deploy-vps.yml` nie odpala się po tagu (`GITHUB_TOKEN` nie triggeruje workflowów). Każdy deploy na prod jest w praktyce ręczny. | issue #224 |
-| **Niezalogowane restocki** | Gdy między dwoma runami stan poszedł `0→N→0`, run widzi `0` i `0` → nic nie loguje. W `StockHistory` widać serię `1→0` "pod rząd" bez `0→1` między nimi (to nie duplikaty). | drobne, nietknięte |
-| **`limit=1000` w URL, serwer daje 500** | API tnie stronę do 500 pozycji niezależnie od `limit`. Kosmetyka. | — |
-| **`.isdigit()` bez `str()`** | `variant_data.get('stock','0').isdigit()` w `_bulk_update_inventory` — pre-istniejący edge case (rzuci `AttributeError` gdy `stock` nie jest stringiem). Poza zakresem dotychczasowych fixów. | — |
+| Problem                                             | Opis                                                                                                                                                                                                                      | Status                                                                                                                                                                                                                                                 |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Redeliver ubitych tasków / nakładające się runy** | Restart `celery-import` w połowie taska → Celery nie dostaje ACK → redeliveruje po czasie (do ~1 h) na przesuniętym `last_update`, równolegle z runem z beat. Powodowało duplikaty w `StockHistory` i "zawieszone" locki. | **Naprawione** (#238): `acks_late=False` (brak redeliveru) + advisory lock zamiast `cache.add` (brak ghost-locków, auto-release po padzie); `_fail_stale_running_imports` sprząta osierocone rekordy `running`. #230 dodatkowo utrzymuje idempotencję. |
+| **Deploy nie jest automatyczny**                    | `deploy-vps.yml` nie odpala się po tagu (`GITHUB_TOKEN` nie triggeruje workflowów). Każdy deploy na prod jest w praktyce ręczny.                                                                                          | issue #224                                                                                                                                                                                                                                             |
+| **Niezalogowane restocki**                          | Gdy między dwoma runami stan poszedł `0→N→0`, run widzi `0` i `0` → nic nie loguje. W `StockHistory` widać serię `1→0` "pod rząd" bez `0→1` między nimi (to nie duplikaty).                                               | drobne, nietknięte                                                                                                                                                                                                                                     |
+| **`limit=1000` w URL, serwer daje 500**             | API tnie stronę do 500 pozycji niezależnie od `limit`. Kosmetyka.                                                                                                                                                         | —                                                                                                                                                                                                                                                      |
+| **`.isdigit()` bez `str()`**                        | `variant_data.get('stock','0').isdigit()` w `_bulk_update_inventory` — pre-istniejący edge case (rzuci `AttributeError` gdy `stock` nie jest stringiem). Poza zakresem dotychczasowych fixów.                             | —                                                                                                                                                                                                                                                      |
 
 Czyszczenie historycznych duplikatów: `python manage.py dedupe_stock_history`
 (§14).
@@ -353,32 +360,32 @@ Uruchomienie: `pytest src/apps/matterhorn1` (CI: `working-directory: src`,
 
 `src/apps/matterhorn1/management/commands/`:
 
-| Komenda | Rola |
-| --- | --- |
-| `celery_import --action import` / `status` | ręczne odpalenie / status `full_import_and_update` |
-| `dedupe_stock_history [--execute] [--window-minutes N]` | czyści historyczne duplikaty `StockHistory` (dry-run domyślnie); idempotentna |
-| `best_sellers` | eksport CSV bestsellerów |
-| `sync_products` / `sync_variants` / `sync_inventory` / `sync_brands_categories` / `sync_all` | starsze, punktowe importy (przed `full_import_and_update`) |
-| `import_products_bulk` / `_optimized` / `_sequence` | j.w. |
+| Komenda                                                                                      | Rola                                                                          |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `celery_import --action import` / `status`                                                   | ręczne odpalenie / status `full_import_and_update`                            |
+| `dedupe_stock_history [--execute] [--window-minutes N]`                                      | czyści historyczne duplikaty `StockHistory` (dry-run domyślnie); idempotentna |
+| `best_sellers`                                                                               | eksport CSV bestsellerów                                                      |
+| `sync_products` / `sync_variants` / `sync_inventory` / `sync_brands_categories` / `sync_all` | starsze, punktowe importy (przed `full_import_and_update`)                    |
+| `import_products_bulk` / `_optimized` / `_sequence`                                          | j.w.                                                                          |
 
 ---
 
 ## 15. Historia zmian (istotne PR-y)
 
-| PR | Zmiana |
-| --- | --- |
-| #204 | wznawianie importu ITEMS od przerwanej strony |
-| #210–#216, #219, #222 | migracja na pytest-django + pokrycie testami `matterhorn1` (98 → 213 testów) |
-| #217 (issue #214) | trwały 5xx na stronie przerywa import zamiast pętlić do soft-timeoutu |
-| #222 (issue #221) | `product_id` → `product_uid` w `views.py` (FieldError → 500) |
-| #223 | batch zapytań w imporcie ITEMS zamiast N+1 |
-| #225 | batch zapytań w `_bulk_update_inventory` (N+1) |
-| #226 | pipeline pobierania stron ITEMS zamiast sekwencyjnego (wątek launcher, wczesny stop) |
-| #227 | odseparowanie wystrzeliwania stron od zapisu do bazy (osobny wątek) |
-| #228 | kontekst zadania Celery w logach z wątków (`???[???]` → `[<task_id>]`) |
-| #229 | przyspieszenie changelist admina `StockHistory` |
-| #230 | idempotentny `_bulk_update_inventory` (duplikaty w `StockHistory`) |
-| #231 | komenda `dedupe_stock_history` |
+| PR                    | Zmiana                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| #204                  | wznawianie importu ITEMS od przerwanej strony                                        |
+| #210–#216, #219, #222 | migracja na pytest-django + pokrycie testami `matterhorn1` (98 → 213 testów)         |
+| #217 (issue #214)     | trwały 5xx na stronie przerywa import zamiast pętlić do soft-timeoutu                |
+| #222 (issue #221)     | `product_id` → `product_uid` w `views.py` (FieldError → 500)                         |
+| #223                  | batch zapytań w imporcie ITEMS zamiast N+1                                           |
+| #225                  | batch zapytań w `_bulk_update_inventory` (N+1)                                       |
+| #226                  | pipeline pobierania stron ITEMS zamiast sekwencyjnego (wątek launcher, wczesny stop) |
+| #227                  | odseparowanie wystrzeliwania stron od zapisu do bazy (osobny wątek)                  |
+| #228                  | kontekst zadania Celery w logach z wątków (`???[???]` → `[<task_id>]`)               |
+| #229                  | przyspieszenie changelist admina `StockHistory`                                      |
+| #230                  | idempotentny `_bulk_update_inventory` (duplikaty w `StockHistory`)                   |
+| #231                  | komenda `dedupe_stock_history`                                                       |
 
 Powiązane: [`../HOW_IT_WORKS.md`](../HOW_IT_WORKS.md) §1 (import z hurtowni),
 [`../PROJECT_OVERVIEW.md`](../PROJECT_OVERVIEW.md),

--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -6,6 +6,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.cache import cache
+from core.pg_locks import advisory_lock
 from .stock_tracker import track_stock_change, track_bulk_stock_changes, sync_stock_changes_from_api
 from .defs_db import normalize_storage_key
 
@@ -60,7 +61,8 @@ MATTERHORN_PAGE_LAUNCH_INTERVAL = 2.0
 MATTERHORN_PIPELINE_MAX_WORKERS = 50
 
 
-@shared_task(bind=True, name='matterhorn1.tasks.full_import_and_update', queue='import')
+@shared_task(bind=True, name='matterhorn1.tasks.full_import_and_update', queue='import',
+             acks_late=False)
 def full_import_and_update(self, start_id=None, max_products=200000,
                            api_url=None, username=None, password=None,
                            batch_size=100, dry_run=False, auto_continue=True):
@@ -91,35 +93,34 @@ def full_import_and_update(self, start_id=None, max_products=200000,
             'task_id': getattr(getattr(self, 'request', None), 'id', 'direct_call')
         }
 
-    # BLOKADA - zapobiega równoległemu wykonaniu (działa dla Celery i bezpośrednich wywołań)
-    lock_id = 'matterhorn1_full_import_lock'
-    lock_timeout = 3600  # 1 godzina
+    task_id_value = getattr(getattr(self, 'request', None), 'id', None) or 'direct_call'
 
-    # Użyj task_id jeśli dostępny (Celery), w przeciwnym razie 'direct_call'
-    task_identifier = getattr(self, 'request', None)
-    task_id_value = task_identifier.id if task_identifier else 'direct_call'
+    # BLOKADA: PostgreSQL advisory lock zamiast cache.add na Redisie (#238).
+    # Zwalnia się SAM, gdy proces trzymający połączenie padnie - bez TTL, bez
+    # "ghost locków", bez watchdoga do sprzątania blokady. Razem z acks_late=False
+    # (dekorator): ubity w połowie run NIE jest redeliverowany po godzinie -
+    # kolejny tick Celery Beat wznawia od current_page (mechanizm #204/#214).
+    with advisory_lock('matterhorn1:full_import_and_update') as acquired:
+        if not acquired:
+            logger.warning("❌ Import już w trakcie wykonywania (advisory lock zajęty). Pominięty.")
+            return {'status': 'skipped', 'reason': 'already_running', 'task_id': task_id_value}
 
-    # CZYŚĆ STARE RUNNING REKORDY (starsze niż 2 godziny)
-    _cleanup_old_running_imports()
+        # Trzymamy WYŁĄCZNY lock → żaden inny run nie działa, więc każdy rekord
+        # 'running' to sierota po ubitym workerze. Oznacz 'error' (current_page
+        # zostaje do wznowienia przez _get_last_items_page).
+        _fail_stale_running_imports()
 
-    # CZYŚĆ WSZYSTKIE RUNNING REKORDY (rozwiązuje problem z ręcznym przerywaniem)
-    _cleanup_all_running_imports()
+        return _run_full_import_locked(
+            self, task_id_value, start_id, max_products, api_url, username, password,
+            batch_size, dry_run, auto_continue,
+        )
 
-    # ATOMOWA OPERACJA BLOKADY - zapobiega race condition
-    # Sprawdź czy blokada istnieje i ustaw ją w jednej operacji
-    acquired = cache.add(lock_id, task_id_value, lock_timeout)
 
-    if not acquired:
-        current_lock = cache.get(lock_id)
-        logger.warning(
-            f"❌ Import już w trakcie wykonywania (lock: {current_lock}). Pominięty.")
-        return {
-            'status': 'skipped',
-            'reason': 'already_running',
-            'current_lock': current_lock,
-            'task_id': task_id_value
-        }
-
+def _run_full_import_locked(self, task_id_value, start_id, max_products, api_url,
+                            username, password, batch_size, dry_run, auto_continue):
+    """Ciało importu ITEMS + INVENTORY. Wołane po zdobyciu advisory locka
+    (patrz `full_import_and_update`). Advisory lock jest zwalniany przez context
+    manager w wołającym - tu tylko aktualizacja statusu w ApiSyncLog."""
     task_completed_successfully = False
     soft_timeout_hit = False
     total_imported = 0
@@ -320,11 +321,7 @@ def full_import_and_update(self, start_id=None, max_products=200000,
         }
 
     finally:
-        # Zawsze zwalniaj blokadę i zaktualizuj status
-        if cache.get(lock_id) == task_id_value:
-            cache.delete(lock_id)
-            logger.info(f"🔓 Blokada zwolniona dla {task_id_value}")
-
+        # Advisory lock zwalnia context manager w full_import_and_update.
         # Aktualizuj status na podstawie tego czy task się zakończył sukcesem.
         # Przy soft-timeout zostawiamy status 'error' z zachowanym current_page —
         # _get_last_items_page wznowi od tej strony.
@@ -1895,14 +1892,22 @@ def test_periodic_task():
 # simple_import_task usunięty - był redundantny z full_import_and_update
 
 
-def _cleanup_old_running_imports():
-    """
-    Czyści stare rekordy 'running' starsze niż 2 godziny.
-    To zapobiega kumulowaniu się zawieszonych importów.
+def _fail_stale_running_imports(older_than_minutes=None):
+    """Oznacza rekordy ITEMS w statusie 'running' jako 'error' (zachowując
+    current_page — `_get_last_items_page` wznowi od tej strony).
+
+    Wołane w dwóch miejscach:
+    * `full_import_and_update` PO zdobyciu advisory locka, bez `older_than_minutes`:
+      skoro trzymamy wyłączny lock, żaden inny run nie działa → każdy 'running'
+      to sierota po ubitym/zrestartowanym workerze.
+    * `watchdog_import_healthcheck` z `older_than_minutes=180`: siatka
+      bezpieczeństwa dla runa wiszącego mimo żywego workera (advisory lock się
+      wtedy NIE zwolnił — nie da się go bezpiecznie sprzątnąć spoza tej sesji).
+
     Z retry logic dla połączenia z bazą danych.
     """
     max_retries = 5
-    retry_delay = 10  # 10 sekund między próbami
+    retry_delay = 10
 
     for attempt in range(max_retries):
         try:
@@ -1910,126 +1915,32 @@ def _cleanup_old_running_imports():
             from django.utils import timezone
             from datetime import timedelta
 
-            # Znajdź stare running rekordy (starsze niż 2 godziny)
-            cutoff_time = timezone.now() - timedelta(hours=2)
-            old_running = ApiSyncLog.objects.using('matterhorn1').filter(
-                sync_type='items_import',
-                status='running',
-                started_at__lt=cutoff_time
-            )
+            qs = ApiSyncLog.objects.using('matterhorn1').filter(
+                sync_type='items_import', status='running')
+            if older_than_minutes is not None:
+                qs = qs.filter(
+                    started_at__lt=timezone.now() - timedelta(minutes=older_than_minutes))
 
-            count = old_running.count()
-            if count > 0:
-                logger.warning(
-                    f"🧹 Znaleziono {count} starych 'running' rekordów - oznaczam jako 'error'")
-
-                # Oznacz jako 'error' zamiast usuwać
-                old_running.update(
+            count = qs.count()
+            if count:
+                qs.update(
                     status='error',
                     completed_at=timezone.now(),
-                    error_details='Zawieszone - automatycznie oznaczone jako błąd po 2 godzinach'
+                    error_details=(
+                        'Sierota po ubitym workerze — advisory lock wolny, rekord '
+                        'został "running"' if older_than_minutes is None
+                        else f'Zawieszone > {older_than_minutes} min bez zakończenia'),
                 )
-                logger.info(
-                    f"✅ Oznaczono {count} starych rekordów jako 'error'")
-            else:
-                logger.info("✅ Brak starych 'running' rekordów do czyszczenia")
-
-            # Jeśli dotarliśmy tutaj, operacja się powiodła
+                logger.warning(f"🧹 Oznaczono {count} zawieszonych 'running' rekordów ITEMS jako 'error'")
             return
 
         except Exception as e:
             logger.error(
-                f"❌ Błąd podczas czyszczenia starych running rekordów (próba {attempt + 1}/{max_retries}): {e}")
-
+                f"❌ Błąd czyszczenia zawieszonych 'running' (próba {attempt + 1}/{max_retries}): {e}")
             if attempt < max_retries - 1:
-                logger.warning(
-                    f"⏳ Czekam {retry_delay} sekund przed ponowną próbą...")
                 time.sleep(retry_delay)
             else:
-                logger.error(
-                    "❌ Osiągnięto maksymalną liczbę prób czyszczenia starych rekordów")
-
-
-def _cleanup_all_running_imports():
-    """
-    Sprawdza czy są zawieszone taski i czyści blokadę Redis tylko jeśli task został przerwany.
-    NIE czyści aktywnych tasków - tylko sprawdza czy blokada Redis jest spójna z DB.
-    Z retry logic dla połączenia z bazą danych.
-    """
-    max_retries = 5
-    retry_delay = 10  # 10 sekund między próbami
-
-    for attempt in range(max_retries):
-        try:
-            from matterhorn1.models import ApiSyncLog
-            from django.utils import timezone
-            from django.core.cache import cache
-
-            # Znajdź WSZYSTKIE running rekordy (niezależnie od wieku)
-            all_running = ApiSyncLog.objects.using('matterhorn1').filter(
-                sync_type='items_import',
-                status='running'
-            )
-
-            count = all_running.count()
-
-            # Sprawdź blokadę Redis
-            lock_id = 'matterhorn1_full_import_lock'
-            current_lock = cache.get(lock_id)
-
-            if count > 0 and current_lock:
-                # Są running rekordy w DB I blokada Redis - task działa normalnie
-                logger.info(
-                    f"✅ Znaleziono {count} aktywnych 'running' rekordów - task działa normalnie")
-                logger.info(
-                    "✅ Blokada Redis pozostaje aktywna - task nie został przerwany")
-
-            elif count > 0 and not current_lock:
-                # Są running rekordy w DB ale BRAK blokady Redis - task został przerwany
-                logger.warning(
-                    f"🧹 Znaleziono {count} 'running' rekordów bez blokady Redis - task został przerwany")
-
-                # Oznacz jako 'error' - task został przerwany
-                all_running.update(
-                    status='error',
-                    completed_at=timezone.now(),
-                    error_details='Zawieszone - task został przerwany (restart/stop systemu)'
-                )
-
-                logger.info(
-                    f"✅ Oznaczono {count} przerwanych rekordów jako 'error'")
-
-            elif count == 0 and current_lock:
-                # BRAK running rekordów w DB ale jest blokada Redis - ghost lock
-                logger.warning(
-                    f"🔒 Znaleziono blokadę Redis bez aktywnych tasków: {current_lock}")
-                logger.info("🗑️  Usuwam ghost lock Redis")
-
-                cache.delete(lock_id)
-
-                if not cache.get(lock_id):
-                    logger.info("✅ Ghost lock Redis został usunięty")
-                else:
-                    logger.error("❌ Nie udało się usunąć ghost lock Redis")
-
-            else:
-                # Brak running rekordów i brak blokady Redis - wszystko OK
-                logger.info("✅ Brak aktywnych tasków - system gotowy")
-
-            # Jeśli dotarliśmy tutaj, operacja się powiodła
-            return
-
-        except Exception as e:
-            logger.error(
-                f"❌ Błąd podczas sprawdzania running rekordów (próba {attempt + 1}/{max_retries}): {e}")
-
-            if attempt < max_retries - 1:
-                logger.warning(
-                    f"⏳ Czekam {retry_delay} sekund przed ponowną próbą...")
-                time.sleep(retry_delay)
-            else:
-                logger.error(
-                    "❌ Osiągnięto maksymalną liczbę prób sprawdzania running rekordów")
+                logger.error("❌ Osiągnięto maksymalną liczbę prób czyszczenia 'running'")
 
 
 @shared_task(bind=True, name='matterhorn1.tasks.track_stock_changes', queue='default')
@@ -2172,18 +2083,20 @@ def clean_old_stock_history_task(self, days_to_keep=90):
 @shared_task(bind=True, name='matterhorn1.tasks.watchdog_import_healthcheck')
 def watchdog_import_healthcheck(self):
     """
-    Watchdog task - sprząta stare running oraz ghost locki importu ITEMS.
-    Sprawdza czy taski rzeczywiście pracują na podstawie postępu.
+    Watchdog task - siatka bezpieczeństwa dla zawieszonych importów ITEMS.
+    Blokadą importu jest teraz PostgreSQL advisory lock (#238), który zwalnia
+    się sam po padzie workera - nie ma "ghost locków" do sprzątania. Zostaje
+    tylko wykrywanie rekordów 'running' bez postępu (worker żywy, ale wiszący).
     Uruchamiany co 5 minut przez Celery Beat.
     """
-    logger.info("🔍 Watchdog: Sprawdzam i czyszczę stare blokady importu")
+    logger.info("🔍 Watchdog: sprawdzam zawieszone importy ITEMS")
 
     try:
         from matterhorn1.models import ApiSyncLog
         import datetime
 
-        # Wyczyść stare running rekordy (starsze niż 2 godziny)
-        cleaned_running = _cleanup_old_running_imports()
+        # Bardzo stare 'running' (> 3 h) - twardo na 'error' niezależnie od postępu
+        _fail_stale_running_imports(older_than_minutes=180)
 
         # Sprawdź ghost taski - taski w statusie 'running' bez postępu
         ghost_tasks_cleaned = 0
@@ -2285,37 +2198,15 @@ def watchdog_import_healthcheck(self):
                 logger.info(
                     f"✅ Watchdog: Task ID {task.id} młody ({int(task_age_minutes)} min) - prawdopodobnie pracuje")
 
-        # Wyczyść cache blokady jeśli są stare
-        lock_id = 'matterhorn1_full_import_lock'
-        current_lock = cache.get(lock_id)
-        if current_lock:
-            # Sprawdź czy task nadal istnieje w Celery
-            from celery.result import AsyncResult
-            try:
-                result = AsyncResult(current_lock)
-                if result.state in ['PENDING', 'RETRY']:
-                    # Task nadal istnieje - nie ruszaj blokady
-                    logger.info(
-                        f"🔒 Watchdog: Blokada aktywna (task: {current_lock})")
-                else:
-                    # Task nie istnieje - wyczyść blokadę
-                    cache.delete(lock_id)
-                    logger.info(
-                        f"🧹 Watchdog: Usunięto starą blokadę (task: {current_lock})")
-            except Exception:
-                # Nie można sprawdzić task - wyczyść blokadę
-                cache.delete(lock_id)
-                logger.info(
-                    f"🧹 Watchdog: Usunięto nieznaną blokadę (task: {current_lock})")
+        # Blokada importu = PostgreSQL advisory lock (#238) - zwalnia się sama
+        # po padzie workera, nie ma "ghost locków" Redis do sprzątania.
 
         logger.info(
-            f"✅ Watchdog: Zakończono czyszczenie (running: {cleaned_running}, ghost: {ghost_tasks_cleaned})")
+            f"✅ Watchdog: zakończono (ghost: {ghost_tasks_cleaned})")
 
         return {
             'status': 'success',
-            'cleaned_running': cleaned_running,
             'ghost_tasks_cleaned': ghost_tasks_cleaned,
-            'lock_cleaned': current_lock is not None
         }
 
     except Exception as e:

--- a/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
+++ b/src/apps/matterhorn1/tests/tests_e2e_import_errors.py
@@ -103,13 +103,40 @@ def test_inventory_chwilowy_500_dogania_sie_i_konczy_completed(
 def test_blokada_rownoleglego_importu_zwraca_skipped(
     matterhorn_api, prior_items_sync, monkeypatch
 ):
-    monkeypatch.setattr("matterhorn1.tasks.cache.add", lambda *a, **k: False)
+    # advisory lock zajęty przez inny run → skip (#238)
+    import contextlib
+
+    @contextlib.contextmanager
+    def _busy_lock(name, **kw):
+        yield False
+
+    monkeypatch.setattr("matterhorn1.tasks.advisory_lock", _busy_lock)
 
     result = full_import_and_update(auto_continue=False, dry_run=False)
 
     assert result["status"] == "skipped"
     assert result["reason"] == "already_running"
     assert Product.objects.using("matterhorn1").count() == 0
+
+
+def test_osierocony_running_oznaczony_error_gdy_nowy_run_ma_lock(
+    matterhorn_api, mocked_responses, prior_items_sync, api_item
+):
+    """#238: po restarcie workera advisory lock się zwolnił, ale rekord ITEMS
+    został 'running'. Nowy run trzyma WYŁĄCZNY lock → sierota zostaje oznaczona
+    'error', import leci dalej normalnie."""
+    stale = ApiSyncLog.objects.using("matterhorn1").create(
+        sync_type="items_import", status="running")
+
+    mock_items(mocked_responses, [[api_item(id=7001)], []])
+    mock_inventory(mocked_responses, [[]])
+
+    full_import_and_update(auto_continue=False, dry_run=False)
+
+    stale.refresh_from_db()
+    assert stale.status == "error"
+    assert "Sierota" in (stale.error_details or "")
+    assert Product.objects.using("matterhorn1").filter(product_uid=7001).exists()
 
 
 def test_wznowienie_od_przerwanej_strony(

--- a/src/apps/matterhorn1/tests/tests_unit_helpers.py
+++ b/src/apps/matterhorn1/tests/tests_unit_helpers.py
@@ -12,9 +12,15 @@ from datetime import datetime, timezone as dt_timezone
 import pytest
 from django.utils import timezone
 
-from matterhorn1.tasks import _parse_creation_date
+from matterhorn1.tasks import _parse_creation_date, full_import_and_update
 
 pytestmark = pytest.mark.unit
+
+
+def test_full_import_ma_acks_late_false():
+    """#238: bez acks_late ubity w połowie run byłby redeliverowany po
+    visibility_timeout (1 h) i leciał drugi raz na nieaktualnym oknie."""
+    assert full_import_and_update.acks_late is False
 
 
 class TestParseCreationDate:

--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -444,9 +444,9 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
 }
 
 # Cache Configuration - PostgreSQL (DatabaseCache)
-# Używane przez: throttling DRF, wartości porównawcze watchdoga importu matterhorn1
-# oraz blokadę matterhorn1_full_import_lock. Krótkie blokady tasków (tabu/mada)
-# używają natomiast PostgreSQL advisory locks - patrz core.pg_locks.
+# Używane przez: throttling DRF, wartości porównawcze watchdoga importu matterhorn1.
+# Blokady tasków (matterhorn1/tabu/mada) używają PostgreSQL advisory locks -
+# patrz core.pg_locks.
 # Tabelę tworzy `manage.py createcachetable` (odpalane w krokach migracji deployu).
 CACHES = {
     'default': {

--- a/src/core/settings/prod.py
+++ b/src/core/settings/prod.py
@@ -311,9 +311,9 @@ CELERY_TASK_ROUTES = {
 }
 
 # Cache Configuration - PostgreSQL (DatabaseCache), tabela w bazie 'default'.
-# Używane przez throttling DRF, watchdog importu matterhorn1 oraz blokadę
-# matterhorn1_full_import_lock. Tabelę tworzy `manage.py createcachetable`
-# (krok w migracji deployu). Krótkie blokady tasków tabu/mada -> core.pg_locks.
+# Używane przez throttling DRF i watchdog importu matterhorn1. Tabelę tworzy
+# `manage.py createcachetable` (krok w migracji deployu).
+# Blokady tasków (matterhorn1/tabu/mada) -> PostgreSQL advisory locks, core.pg_locks.
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',


### PR DESCRIPTION
Zamyka #238.

## Problem

Restart `celery-import` w połowie `full_import_and_update` (deploy / OOM / ręczny restart) → Celery nie dostaje ACK-a → po `visibility_timeout` (1 h) **redeliveruje** taska. Wraca, bierze wolną blokadę, przelatuje **drugi raz** na przesuniętym `last_update`, równolegle z runem z beat.

Skutki: duplikaty w `StockHistory` (#230 łagodził objaw), oraz "zawieszone" locki — blokada `cache.add(..., 3600)` z TTL zostawała po twardym ubiciu procesu, a `_cleanup_all_running_imports` nie łapał przypadku „rekord `running` **i** lock istnieją naraz" → wyglądało jak „działa normalnie" i blokowało importy do wygaśnięcia TTL.

## Fix (kierunek 1 + 2 z issue)

| Zmiana | Efekt |
|---|---|
| `advisory_lock('matterhorn1:full_import_and_update')` zamiast `cache.add` (jak `tabu`) | zwalnia się **sama** po padzie połączenia — bez TTL, bez ghost-locków, bez watchdoga do blokady |
| `@shared_task(acks_late=False)` | wiadomość ACK-owana na odbiór → ubity run **nie** jest redeliverowany; kolejny tick beat wznawia od `current_page` (#204/#214) |
| ciało importu → `_run_full_import_locked(...)` | wołane pod lockiem, `with` zwalnia po wyjściu |
| `_cleanup_old_running_imports` + `_cleanup_all_running_imports` → `_fail_stale_running_imports` | pod wyłącznym lockiem każdy `running` to sierota → `error` (`current_page` zostaje). Watchdog woła z `older_than_minutes=180` jako siatka bezpieczeństwa dla runa wiszącego mimo żywego workera |
| `watchdog_import_healthcheck` | usunięta sekcja czyszczenia ghost-locków Redis (martwy kod); zostaje wykrywanie `running` bez postępu |

Komentarze `CACHES` w `settings/{base,prod}.py` + `docs/matterhorn/MATTERHORN1.md` (§4/§9/§12) zaktualizowane.

## Testy

- `test_full_import_ma_acks_late_false`
- `test_blokada_rownoleglego_importu_zwraca_skipped` — przepięte z `cache.add` na patch `advisory_lock`
- `test_osierocony_running_oznaczony_error_gdy_nowy_run_ma_lock` — sierota `running` → `error`, import leci dalej
- `tests_integration_watchdog.py` — bez zmian, nadal zielone

`pytest src/apps/matterhorn1` — 246 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)