### PR TITLE
ci(deploy): faza 0 — jeden docker-compose zamiast k3s (#259)

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,15 +1,9 @@
-name: Deploy Test (k3s)
+name: Deploy Test (k3s) — WYGASZANE (#259)
 
+# Klaster nc-test schodzi razem z prod k3s (issue #259). Auto-trigger wyłączony;
+# workflow i scripts/k8s-test/ + deployments/k8s/nc-test/ do usunięcia w Fazie 2.
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'deployments/k8s/nc-test/**'
-      - 'deployments/docker/Dockerfile.prod'
-      - 'scripts/k8s-test/**'
-      - 'src/**'
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,18 +1,14 @@
 name: Deploy to VPS
 
+# Deploy produkcji na VPS = jeden stack docker-compose (docker-compose.prod.yml).
+# Tylko RĘCZNE uruchomienie (workflow_dispatch). Auto-deploy na tagu jest
+# świadomie wyłączony — GITHUB_TOKEN z release.yml i tak nie triggeruje
+# workflowów (issue #224), a deploy prod ma być decyzją człowieka.
 on:
-  # Deployment tylko gdy zostanie utworzony tag (np. v1.0.0, v1.1.0)
-  # Tagi są tworzone przez semantic-release w workflow Release
-  push:
-    tags:
-      - 'v*'  # Wszystkie tagi zaczynające się od 'v'
-    branches:
-      - k8s-nc-test  # tymczasowo: deploy k3s z brancha testowego
-  # Ręczne wywołanie z UI (możesz wybrać tag lub branch)
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Tag lub branch do deployowania (np. v1.0.0 lub main)'
+        description: 'Tag lub branch do zdeployowania (np. v1.44.20 lub main)'
         required: false
         default: 'main'
         type: string
@@ -23,109 +19,17 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Test SSH connection
-      uses: appleboy/ssh-action@master
-      id: ssh-test
-      continue-on-error: true
-      with:
-        host: ${{ secrets.VPS_HOST }}
-        username: ${{ secrets.VPS_USER }}
-        key: ${{ secrets.VPS_SSH_KEY }}
-        port: 22
-        timeout: 30s
-        script: |
-          echo "Testing SSH connection..."
-          whoami
-          echo "✅ SSH connection successful!"
-    
-    - name: Check SSH connection result
-      if: steps.ssh-test.outcome != 'success'
-      run: |
-        echo "❌ SSH connection failed!"
-        echo "Please check:"
-        echo "1. Port 22 is forwarded in router (external port 22 → internal IP:22)"
-        echo "2. Firewall allows port 22 on server"
-        echo "3. SSH service is running on server"
-        echo "4. VPS_HOST secret is correct (public IP or domain)"
-        echo "5. Server is accessible from internet"
-        exit 1
-    
-    - name: Deploy to VPS via SSH
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.VPS_HOST }}
-        username: ${{ secrets.VPS_USER }}
-        key: ${{ secrets.VPS_SSH_KEY }}
-        port: 22
-        debug: true
-        timeout: 60s
-        command_timeout: 20m
-        script: |
-          set -euo pipefail
-          echo "🚀 Starting deployment..."
-          
-          # Aktualizuj kod aplikacji
-          cd /home/pawel/apps/nc
-          echo "📥 Pulling latest code..."
-          git fetch origin --tags
-          
-          # Określ co deployować
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Ręczne wywołanie - użyj podanego ref (tag lub branch)
-            DEPLOY_REF="${{ github.event.inputs.ref }}"
-            echo "🔧 Manual deployment: ${DEPLOY_REF}"
-          elif [ "${{ github.ref_type }}" = "branch" ]; then
-            DEPLOY_REF="${{ github.ref_name }}"
-            echo "🌿 Branch deployment: ${DEPLOY_REF}"
-          else
-            # Deployment z tagu - użyj tagu który wywołał workflow
-            DEPLOY_REF="${{ github.ref_name }}"
-            echo "🏷️ Tag deployment: ${DEPLOY_REF}"
-          fi
-          
-          # Sprawdź czy ref istnieje
-          if git rev-parse --verify "origin/${DEPLOY_REF}" >/dev/null 2>&1; then
-            echo "✅ Found branch: ${DEPLOY_REF}"
-            git reset --hard "origin/${DEPLOY_REF}"
-          elif git rev-parse --verify "${DEPLOY_REF}" >/dev/null 2>&1; then
-            echo "✅ Found tag: ${DEPLOY_REF}"
-            git reset --hard "${DEPLOY_REF}"
-          else
-            echo "❌ Ref ${DEPLOY_REF} not found!"
-            exit 1
-          fi
-          
-          echo "📌 Deploying: $(git rev-parse HEAD) ($(git log -1 --pretty=format:'%h - %s'))"
-          
-          export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-          chmod +x scripts/k8s-prod/*.sh
-          if [[ ! -f "$KUBECONFIG" ]]; then
-            ./scripts/k8s-prod/setup-kubeconfig.sh
-          fi
-          export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-
-          ./scripts/k8s-prod/expose-traefik.sh
-
-          if [[ ! -f .env.prod ]]; then
-            echo "Brak .env.prod na serwerze — wymagany przed pierwszym deployem k3s."
-            exit 1
-          fi
-          
-          echo "=== k3s prod deploy (Traefik + repliki) ==="
-          ./scripts/k8s-prod/create-secret.sh
-          ./scripts/k8s-prod/build-image.sh
-          ./scripts/k8s-prod/deploy.sh --migrate
-          
-          echo "=== Status nc-prod ==="
-          kubectl get pods,ingress,deployments -n nc-prod
-          POD_COUNT="$(kubectl get pods -n nc-prod --no-headers 2>/dev/null | wc -l | tr -d ' ')"
-          if [[ "${POD_COUNT:-0}" -lt 1 ]]; then
-            echo "❌ Brak podow w nc-prod — deploy nieudany!"
-            kubectl get events -n nc-prod --sort-by='.lastTimestamp' | tail -20
-            exit 1
-          fi
-          curl -sf -H "Host: nc.sowa.ch" http://127.0.0.1/health/ && echo " health OK" || echo "⚠️ health check failed (sprawdz NPM/Traefik)"
-          
-          echo "✅ Deployment completed!"
+      - name: Deploy przez SSH
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          command_timeout: 20m
+          script: |
+            set -euo pipefail
+            cd /home/pawel/apps/nc
+            chmod +x scripts/deploy-prod.sh
+            ./scripts/deploy-prod.sh "${{ github.event.inputs.ref }}"

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -1,0 +1,288 @@
+# Produkcja — JEDEN stack docker-compose (zastępuje k3s + blue-green).
+#
+# Model: obraz `nc-django-app:latest` budowany z Dockerfile.prod (kod + React SPA
+# + collectstatic WYPALONE w obrazie, bez bind-mountów — tak jak działały pody
+# k3s). Deploy = git reset --hard <ref> → build → migracje → up -d.
+# Patrz scripts/deploy-prod.sh oraz issue #259.
+#
+# Wejście publiczne: NPM (Nginx Proxy Manager) → `web` (gunicorn + whitenoise
+# dla /static/). Media → MinIO/S3. Bez dodatkowego nginx.
+#
+# Postgres (`nc-postgres-1`) NIE jest zarządzany z tego pliku — profile "shared",
+# zawiera dane produkcyjne, uruchamiany osobno. Definicja tylko dla `config`.
+
+x-django-image: &django-image
+  build:
+    context: ..
+    dockerfile: deployments/docker/Dockerfile.prod
+  image: nc-django-app:latest
+
+x-django-env: &django-env
+  DJANGO_SETTINGS_MODULE: core.settings.prod
+  DJANGO_ENV: prod
+  TZ: Europe/Warsaw
+  REDIS_HOST: redis
+  CELERY_BROKER_URL: redis://:${REDIS_PASSWORD:-prod_password}@redis:6379/0
+  CELERY_RESULT_BACKEND: ""
+
+services:
+  # ==========================================
+  # WEB — gunicorn + whitenoise (/static/), 1 kontener
+  # ==========================================
+  web:
+    <<: *django-image
+    container_name: nc-web
+    command:
+      - /bin/bash
+      - -c
+      - >
+        gunicorn core.wsgi:application --bind 0.0.0.0:8000 --workers 4
+        --worker-class sync --timeout 300 --keep-alive 5
+        --max-requests 1000 --max-requests-jitter 100 --preload
+        --access-logfile - --error-logfile - --log-level warning
+        --capture-output --worker-tmp-dir /dev/shm --graceful-timeout 30
+        --limit-request-line 8190 --limit-request-fields 100 --limit-request-field_size 8190
+    env_file:
+      - ../.env.prod
+    environment:
+      <<: *django-env
+    ports:
+      - "127.0.0.1:8000:8000"          # NPM przez host: Forward -> IP:8000
+    networks:
+      - nc_network                      # NPM przez sieć: Forward Hostname -> nc-web:8000
+      - nc_dbnet
+      - nginx_proxy_manager_network
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: always
+    user: "1001:1001"
+    deploy:
+      resources:
+        limits: { memory: 2G, cpus: "2.0" }
+        reservations: { memory: 1G }
+    labels:
+      - "nc.type=web"
+
+  # ==========================================
+  # MIGRACJE — jednorazowo: docker compose --profile migrate run --rm migrate
+  # ==========================================
+  migrate:
+    <<: *django-image
+    container_name: nc-migrate
+    profiles: ["migrate"]
+    command:
+      - /bin/bash
+      - -c
+      - |
+        set -e
+        echo "== Migracje prod =="
+        python manage.py migrate --database=default --noinput
+        python manage.py migrate matterhorn1 --database=matterhorn1 --noinput
+        python manage.py migrate MPD --database=MPD --noinput
+        python manage.py migrate web_agent --database=web_agent --noinput
+        python manage.py migrate tabu --database=tabu --noinput
+        python manage.py migrate mada --database=mada --noinput
+        python manage.py createcachetable --database=default
+        echo "== Migracje OK =="
+    env_file:
+      - ../.env.prod
+    environment:
+      <<: *django-env
+    networks:
+      - nc_network
+      - nc_dbnet
+    restart: "no"
+
+  # ==========================================
+  # REDIS — broker Celery + cache/locki DRF
+  # ==========================================
+  redis:
+    image: redis:7.2-alpine
+    container_name: nc-redis-1
+    command: redis-server /usr/local/etc/redis/redis.conf --requirepass ${REDIS_PASSWORD:-prod_password}
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - /mnt/data2tb/docker/volumes/nc_redis_data:/data
+      - ../deployments/redis.conf:/usr/local/etc/redis/redis.conf:ro
+    networks:
+      - nc_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-prod_password}", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits: { memory: 512M, cpus: "0.5" }
+    labels:
+      - "nc.protected=true"
+
+  # ==========================================
+  # CELERY
+  # ==========================================
+  celery-default:
+    <<: *django-image
+    container_name: nc-celery-default
+    command:
+      - /bin/bash
+      - -c
+      - >
+        celery -A core.celery worker -Q default --loglevel=info --concurrency=1
+        --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+    env_file:
+      - ../.env.prod
+    environment:
+      <<: *django-env
+      CELERY_STATE_DB: /var/lib/celery/worker_state_default
+    volumes:
+      - /mnt/data2tb/docker/volumes/nc_celery_data:/var/lib/celery
+    networks:
+      - nc_network
+      - nc_dbnet
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+    user: "1001:1001"
+    deploy:
+      resources:
+        limits: { memory: 1G, cpus: "1.0" }
+        reservations: { memory: 512M }
+
+  celery-import:
+    <<: *django-image
+    container_name: nc-celery-import
+    command:
+      - /bin/bash
+      - -c
+      - >
+        celery -A core.celery worker -Q import --loglevel=info --concurrency=1
+        --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+    env_file:
+      - ../.env.prod
+    environment:
+      <<: *django-env
+      CELERY_STATE_DB: /var/lib/celery/worker_state_import
+    volumes:
+      - /mnt/data2tb/docker/volumes/nc_celery_data:/var/lib/celery
+    networks:
+      - nc_network
+      - nc_dbnet
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+    user: "1001:1001"
+    deploy:
+      resources:
+        limits: { memory: 1G, cpus: "1.0" }
+        reservations: { memory: 512M }
+
+  celery-beat:
+    <<: *django-image
+    container_name: nc-celery-beat
+    command:
+      - /bin/bash
+      - -c
+      - celery -A core.celery beat --loglevel=info
+    env_file:
+      - ../.env.prod
+    environment:
+      <<: *django-env
+    networks:
+      - nc_network
+      - nc_dbnet
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+    user: "1001:1001"
+    deploy:
+      resources:
+        limits: { memory: 512M, cpus: "0.5" }
+
+  flower:
+    <<: *django-image
+    container_name: nc-flower
+    command:
+      - /bin/bash
+      - -c
+      - >
+        celery -A core.celery --broker=redis://:${REDIS_PASSWORD:-prod_password}@redis:6379/0
+        flower --port=5555 --basic_auth=${FLOWER_USER:-admin}:${FLOWER_PASSWORD:-flower}
+        --persistent=True --db=/var/lib/flower/flower.db --inspect_timeout=30
+    ports:
+      - "127.0.0.1:5555:5555"
+    env_file:
+      - ../.env.prod
+    environment:
+      <<: *django-env
+    volumes:
+      - /mnt/data2tb/docker/volumes/nc_flower_data:/var/lib/flower
+    networks:
+      - nc_network
+      - nc_dbnet
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+    user: "1001:1001"
+    deploy:
+      resources:
+        limits: { memory: 512M, cpus: "0.5" }
+
+  # ==========================================
+  # ⚠️ NIETYKALNY — Postgres z danymi produkcyjnymi. profile "shared" = NIE
+  # uruchamiany zwykłym `up`. Definicja tylko do `docker compose config`.
+  # Zarządzany osobno.
+  # ==========================================
+  postgres:
+    profiles: ["shared"]
+    image: postgres:18-alpine
+    container_name: nc-postgres-1
+    restart: unless-stopped
+    env_file:
+      - ../.env.prod
+    environment:
+      POSTGRES_USER: ${DEFAULT_DB_USER:-nc}
+      POSTGRES_PASSWORD: ${DEFAULT_DB_PASSWORD:-prod_password}
+      POSTGRES_DB: ${DEFAULT_DB_NAME:-zzz_default}
+      TZ: Europe/Warsaw
+    command: ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DEFAULT_DB_USER:-nc}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - /mnt/data2tb/docker/volumes/nc_postgres_data:/var/lib/postgresql/data
+      - ../deployments/docker/postgres/initdb.d:/docker-entrypoint-initdb.d:ro
+      - ../deployments/docker/postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+    networks:
+      - nc_network
+    labels:
+      - "nc.protected=true"
+
+networks:
+  nc_network:
+    name: nc_nc_network
+    external: true
+  nc_dbnet:
+    name: nc_dbnet
+    external: true
+  nginx_proxy_manager_network:
+    name: nginx_proxy_manager_network
+    external: true

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,78 @@
+# Deploy produkcji
+
+> Stan: **Faza 0** wdrożona (pliki gotowe), cutover z k3s jeszcze **nie
+> wykonany** — patrz [issue #259](https://github.com/pawlo884/nc/issues/259).
+> Do czasu cutoveru prod nadal działa: `web` na k3s + reszta na
+> `docker-compose.services.yml`.
+
+## Model docelowy
+
+Jeden stack **docker-compose** na VPS, bez k3s, bez blue-green.
+
+- Obraz `nc-django-app:latest` — kod + React SPA + `collectstatic` **wypalone**
+  w `Dockerfile.prod` (bez bind-mountów).
+- Wejście: **NPM** (Nginx Proxy Manager) → `web` (gunicorn + whitenoise dla
+  `/static/`). TLS na NPM. Media → MinIO/S3.
+- Deploy = `git reset --hard <ref>` → build → migracje → `up -d`. Kilka sekund
+  502 na `web` podczas recreate (akceptowalne dla huba katalogowego).
+
+Plik: [`docker-compose/docker-compose.prod.yml`](../docker-compose/docker-compose.prod.yml).
+Serwisy: `web`, `celery-default`, `celery-import`, `celery-beat`, `flower`,
+`redis`, `migrate` (profil). Postgres (`nc-postgres-1`) — **osobno**, profil
+`shared`, nietykalny.
+
+## Jak deployować
+
+### Z GitHub Actions (zalecane)
+
+`Actions → Deploy to VPS → Run workflow` → podaj tag lub branch (`ref`).
+Tylko ręczne uruchomienie (`workflow_dispatch`) — brak auto-deploy na tagu
+(świadome, #224).
+
+### Ręcznie na VPS
+
+```bash
+cd /home/pawel/apps/nc
+./scripts/deploy-prod.sh v1.44.20     # albo main
+```
+
+Skrypt: pobiera ref → `docker compose build` → `--profile migrate run --rm
+migrate` → `up -d --remove-orphans` → health check `http://127.0.0.1:8000/health/`.
+
+## Migracje
+
+Serwis `migrate` (profil `migrate`) robi po kolei:
+
+```
+migrate --database=default              # apps systemowe + celery beat/results + cache
+migrate matterhorn1 --database=matterhorn1
+migrate MPD --database=MPD
+migrate web_agent --database=web_agent
+migrate tabu --database=tabu
+migrate mada --database=mada            # było POMIJANE w k3s migrate-job
+createcachetable --database=default
+```
+
+Routery (`core/db_routers.py`) pilnują, żeby migracje aplikacji-luster nie
+trafiły do `default`. (Stary `migrate-job.yaml` miał dodatkowy hack
+`DELETE FROM django_migrations` — usunięty, to była jednorazowa naprawa
+historycznego bałaganu, nie rzecz na każdy deploy.)
+
+## Rollback
+
+```bash
+./scripts/deploy-prod.sh <poprzedni-tag>
+```
+
+Migracje wstecznie niezgodne → rollback wymaga też `migrate <app> <numer>` ręcznie.
+
+## Cutover z k3s (jednorazowo, Faza 1 #259)
+
+1. Na VPS: `git pull` (żeby był `docker-compose.prod.yml`) → `docker compose -f docker-compose/docker-compose.services.yml down web-blue web-green nginx-router` (usuń martwe blue-green).
+2. `./scripts/deploy-prod.sh main` — postawi `web` + zaadoptuje redis/celery/flower do stacka `prod`.
+3. **NPM:** przełącz `nc.sowa.ch` z `IP:80` (Traefik) na `IP:8000` (albo Forward Hostname `nc-web`, port `8000`).
+4. Weryfikacja end-to-end (admin, `/mpd-app/`, eksport XML, API).
+5. `kubectl scale deployment/nc-web -n nc-prod --replicas=0` (manifesty zostają na rollback).
+6. Obserwacja ~1 dzień → Faza 2: `kubectl delete namespace nc-prod`, `k3s-uninstall.sh`, usunięcie `deployments/k8s/`, `scripts/k8s-prod/`, `scripts/deploy/`.
+
+**Rollback cutoveru:** NPM z powrotem na `:80` + `kubectl scale ... --replicas=3`.

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Deploy produkcji — JEDEN stack docker-compose (zastępuje scripts/k8s-prod/ i
+# scripts/deploy/*blue-green*). Patrz docker-compose/docker-compose.prod.yml, #259.
+#
+# Użycie na VPS:
+#   ./scripts/deploy-prod.sh [<ref>]      # ref = tag / branch, domyślnie main
+#
+# Kroki: git reset --hard <ref> → build obrazu → migracje → up -d → health.
+# Kilka sekund 502 na `web` podczas recreate — akceptowalne (bez blue-green).
+set -euo pipefail
+
+REF="${1:-main}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CF="$REPO_ROOT/docker-compose/docker-compose.prod.yml"
+
+# Ta sama nazwa projektu co dotychczasowy stack (dir "docker-compose"), żeby
+# `up -d` adoptował istniejące kontenery/sieci/wolumeny zamiast tworzyć drugi komplet.
+export COMPOSE_PROJECT_NAME=docker-compose
+
+DC() { docker compose -f "$CF" "$@"; }
+
+cd "$REPO_ROOT"
+
+echo "📥 Pobieram $REF"
+git fetch origin --tags --prune
+if git rev-parse --verify "origin/$REF" >/dev/null 2>&1; then
+  git reset --hard "origin/$REF"
+elif git rev-parse --verify "$REF" >/dev/null 2>&1; then
+  git reset --hard "$REF"
+else
+  echo "❌ Ref '$REF' nie istnieje"; exit 1
+fi
+echo "📌 $(git rev-parse --short HEAD) — $(git log -1 --pretty=%s)"
+
+[[ -f "$REPO_ROOT/.env.prod" ]] || { echo "❌ Brak .env.prod na serwerze"; exit 1; }
+
+echo "🔨 Buduję obraz nc-django-app:latest"
+DC build
+
+echo "🗃️  Migracje (stary web nadal obsługuje ruch)"
+DC --profile migrate run --rm migrate
+
+echo "🚀 up -d (recreate)"
+DC up -d --remove-orphans
+
+echo "🩺 Health check web"
+for i in $(seq 1 30); do
+  if curl -sf http://127.0.0.1:8000/health/ >/dev/null; then
+    echo "✅ web zdrowy ($(git rev-parse --short HEAD))"
+    DC ps
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "❌ Health check nie przeszedł w 60 s"
+DC logs --tail=50 web
+exit 1


### PR DESCRIPTION
**Faza 0** z [#259](https://github.com/pawlo884/nc/issues/259). Same pliki — **prod nie jest ruszany**, cutover to Faza 1 (ręcznie na VPS).

## Co wchodzi

| Plik | |
|------|--|
| `docker-compose/docker-compose.prod.yml` | Jeden stack: `web` (gunicorn `--workers 4` + whitenoise `/static/`, **bez blue-green, bez fronting nginx** — NPM już jest nginxem z przodu), `celery-default/import/beat`, `flower`, `redis`. Obraz `nc-django-app:latest` **wypalany** z `Dockerfile.prod` (kod + React SPA + `collectstatic` w obrazie, **bez bind-mountów** — dokładnie jak działały pody k3s). Postgres za `profiles: ["shared"]`, nietykalny. Serwis `migrate` (profil `migrate`). `deploy.resources.limits` przeniesione z manifestów k8s. |
| `scripts/deploy-prod.sh` | `git reset --hard <ref>` → `docker compose build` → `--profile migrate run --rm migrate` → `up -d --remove-orphans` → health check `:8000/health/`. `COMPOSE_PROJECT_NAME=docker-compose` żeby przy cutoverze zaadoptować istniejące kontenery/sieci. |
| `.github/workflows/deploy-vps.yml` | przepisany: **tylko `workflow_dispatch`** (input `ref`) → SSH → `deploy-prod.sh`. Koniec z k3s (`build-image.sh`/`create-secret.sh`/`deploy.sh --migrate`). |
| `.github/workflows/deploy-test.yml` | auto-trigger na `src/**` **wyłączony** (klaster `nc-test` wygaszany, pełne usunięcie w Fazie 2). |
| `docs/DEPLOY.md` | nowy — model docelowy + procedura cutoveru krok po kroku. |

## Poprawki przy okazji

- **`migrate mada --database=mada`** — było **pomijane** w `deployments/k8s/nc-prod/migrate-job.yaml` (migrował tylko default/matterhorn1/MPD/web_agent/tabu). Tabele `mada` na prodzie mogły nie istnieć — do sprawdzenia przy cutoverze.
- Usunięty hack `DELETE FROM django_migrations WHERE app IN (...)` z kroku migracji — to była jednorazowa naprawa historycznego bałaganu multi-DB, nie rzecz na każdy deploy. Routery (`core/db_routers.py::allow_migrate`) i tak pilnują, że migracje aplikacji-luster nie trafią do `default`.

## Walidacja

`docker compose -f docker-compose.prod.yml --profile migrate config` — OK. `bash -n deploy-prod.sh` — OK. YAML workflowów — OK.

## Dalej (osobno, po Twoim „ok")

- **Faza 1** — cutover na VPS: `deploy-prod.sh` postawi `web` obok k3s → przełączenie NPM `:80` → `:8000` → `kubectl scale nc-web --replicas=0` → obserwacja.
- **Faza 2** — `kubectl delete namespace nc-prod` + `nc-test`, `k3s-uninstall.sh`, usunięcie `deployments/k8s/`, `scripts/k8s-prod/`, `scripts/k8s-test/`, `scripts/deploy/`, `docker-compose.services.yml`, przepisanie `PROJECT_OVERVIEW §9` / `ARCHITECTURE` / reszty docs, odwrócenie pamięci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)