### PR TITLE
perf(matterhorn1): backpressure w pipeline importu (fix OOM/SIGKILL)

### DIFF
--- a/deployments/k8s/nc-prod/celery.yaml
+++ b/deployments/k8s/nc-prod/celery.yaml
@@ -25,7 +25,7 @@ spec:
             - >
               sleep 20 &&
               celery -A core.celery worker -Q default --loglevel=info --concurrency=1
-              --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+              --max-memory-per-child=500000 --without-gossip --without-mingle --without-heartbeat
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: core.settings.prod
@@ -85,7 +85,7 @@ spec:
             - >
               sleep 20 &&
               celery -A core.celery worker -Q import --loglevel=info --concurrency=1
-              --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+              --max-memory-per-child=500000 --without-gossip --without-mingle --without-heartbeat
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: core.settings.prod

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -138,7 +138,7 @@ services:
       - -c
       - >
         celery -A core.celery worker -Q default --loglevel=info --concurrency=1
-        --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+        --max-memory-per-child=500000 --without-gossip --without-mingle --without-heartbeat
     env_file:
       - ../.env.prod
     environment:
@@ -167,7 +167,7 @@ services:
       - -c
       - >
         celery -A core.celery worker -Q import --loglevel=info --concurrency=1
-        --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+        --max-memory-per-child=500000 --without-gossip --without-mingle --without-heartbeat
     env_file:
       - ../.env.prod
     environment:

--- a/docker-compose/docker-compose.services.yml
+++ b/docker-compose/docker-compose.services.yml
@@ -242,7 +242,7 @@ services:
       - -c
       - >
         sleep 20 && celery -A core.celery worker -Q default --loglevel=info --concurrency=1
-        --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+        --max-memory-per-child=500000 --without-gossip --without-mingle --without-heartbeat
     volumes:
       - ../src:/app
       - /mnt/data2tb/docker/volumes/nc_celery_data:/var/lib/celery
@@ -266,6 +266,7 @@ services:
       - nc_network
       - nc_dbnet
     user: 1001:1001
+    mem_limit: 1g          # cgroup OOM zamiast OOM killera hosta (izolacja)
 
   celery-import:
     build:
@@ -278,7 +279,7 @@ services:
       - -c
       - >
         sleep 20 && celery -A core.celery worker -Q import --loglevel=info --concurrency=1
-        --max-memory-per-child=150000 --without-gossip --without-mingle --without-heartbeat
+        --max-memory-per-child=500000 --without-gossip --without-mingle --without-heartbeat
     volumes:
       - ../src:/app
       - /mnt/data2tb/docker/volumes/nc_celery_data:/var/lib/celery
@@ -298,6 +299,7 @@ services:
       - nc_network
       - nc_dbnet
     user: 1001:1001
+    mem_limit: 1g          # cgroup OOM zamiast OOM killera hosta (izolacja)
 
   celery-beat:
     build:

--- a/src/apps/matterhorn1/tasks.py
+++ b/src/apps/matterhorn1/tasks.py
@@ -51,14 +51,19 @@ def _capture_task_context():
 
 
 # Pipeline pobierania stron B2BAPI (ITEMS i ITEMS/INVENTORY): nowa strona co
-# tyle sekund, niezależnie od tego, ile poprzednich jeszcze nie odpowiedziało.
+# tyle sekund, dopóki bufor `pending` nie jest pełny (patrz MAX_INFLIGHT niżej).
 # Limit API Matterhorn to 2 requesty/sekundę (docs/matterhorn/MATTERHORN1_*.md),
 # więc to spory margines. MAX_PIPELINE_WORKERS to tylko górna granica liczby
-# wątków (nie throttling - o tempie decyduje wyłącznie interval powyżej),
-# zabezpieczenie przed nieograniczonym tworzeniem wątków, gdyby detekcja końca
-# danych z jakiegoś powodu zawiodła.
+# wątków (zabezpieczenie przed nieograniczonym tworzeniem wątków, gdyby
+# detekcja końca danych zawiodła).
 MATTERHORN_PAGE_LAUNCH_INTERVAL = 2.0
 MATTERHORN_PIPELINE_MAX_WORKERS = 50
+# Backpressure: maksymalna liczba stron w buforze `pending` (pobrane/pobierane,
+# jeszcze nie zapisane do bazy). Bez tego przy zatorze na zapisie (burst do DB,
+# kontencja locka) bufor puchnie o stronę co MATTERHORN_PAGE_LAUNCH_INTERVAL
+# sekund — kilkadziesiąt stron × ~1,5 MB JSON = worker dostaje OOM (SIGKILL).
+# Launcher wstrzymuje wystrzeliwanie, aż writer nadgoni.
+MATTERHORN_PIPELINE_MAX_INFLIGHT = 8
 
 
 @shared_task(bind=True, name='matterhorn1.tasks.full_import_and_update', queue='import',
@@ -523,11 +528,16 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
         def _launcher(start_page):
             p = start_page
             while not stop_launching.is_set():
+                launched = False
                 with pending_lock:
-                    pending[p] = executor.submit(
-                        _run_with_task_context, task_ctx, _fetch_items_page,
-                        p, api_url, headers, limit, last_update)
-                    p += 1
+                    # Backpressure - nie wystrzeliwuj nowej strony, gdy bufor pełny
+                    # (writer nie nadąża z zapisem). Chroni przed OOM.
+                    if len(pending) < MATTERHORN_PIPELINE_MAX_INFLIGHT:
+                        pending[p] = executor.submit(
+                            _run_with_task_context, task_ctx, _fetch_items_page,
+                            p, api_url, headers, limit, last_update)
+                        p += 1
+                        launched = True
                     # Wczesny stop - patrz komentarz wyżej. Skanujemy pod tym
                     # samym lockiem co wstawianie/zdejmowanie z `pending`.
                     for fut in list(pending.values()):
@@ -535,7 +545,7 @@ def _import_products_from_items(start_id, max_products, api_url, username, passw
                             stop_launching.set()
                             break
                 if not stop_launching.is_set():
-                    time.sleep(MATTERHORN_PAGE_LAUNCH_INTERVAL)
+                    time.sleep(MATTERHORN_PAGE_LAUNCH_INTERVAL if launched else 0.5)
 
         launcher_thread = threading.Thread(
             target=_run_with_task_context, args=(task_ctx, _launcher, page),
@@ -1595,18 +1605,22 @@ def _update_inventory_from_api(api_url, username, password, batch_size, dry_run)
         def _launcher(start_page):
             p = start_page
             while not stop_launching.is_set():
+                launched = False
                 with pending_lock:
-                    pending[p] = executor.submit(
-                        _run_with_task_context, task_ctx, _fetch_inventory_page,
-                        p, api_url, headers, limit, last_update)
-                    p += 1
+                    # Backpressure - patrz _import_products_from_items.
+                    if len(pending) < MATTERHORN_PIPELINE_MAX_INFLIGHT:
+                        pending[p] = executor.submit(
+                            _run_with_task_context, task_ctx, _fetch_inventory_page,
+                            p, api_url, headers, limit, last_update)
+                        p += 1
+                        launched = True
                     # Wczesny stop - patrz _import_products_from_items.
                     for fut in list(pending.values()):
                         if fut.done() and fut.result()['outcome'] != 'ok':
                             stop_launching.set()
                             break
                 if not stop_launching.is_set():
-                    time.sleep(MATTERHORN_PAGE_LAUNCH_INTERVAL)
+                    time.sleep(MATTERHORN_PAGE_LAUNCH_INTERVAL if launched else 0.5)
 
         launcher_thread = threading.Thread(
             target=_run_with_task_context, args=(task_ctx, _launcher, 1),

--- a/src/apps/matterhorn1/tests/tests_unit_items_pipeline.py
+++ b/src/apps/matterhorn1/tests/tests_unit_items_pipeline.py
@@ -10,13 +10,66 @@ weryfikacja logiki orkiestratora, bez DB/HTTP.
 from __future__ import annotations
 
 import threading
+import time
 from unittest.mock import patch
 
 import pytest
 
+from matterhorn1 import tasks
 from matterhorn1.tasks import _import_products_from_items
 
 pytestmark = pytest.mark.unit
+
+
+def _run_import_in_thread(fake_fetch, fake_bulk_import):
+    def run():
+        with patch("matterhorn1.tasks._fetch_items_page", side_effect=fake_fetch), \
+                patch("matterhorn1.tasks._bulk_import_products", side_effect=fake_bulk_import), \
+                patch("matterhorn1.tasks._get_last_items_update_time", return_value="2026-01-01 00:00:00"), \
+                patch("matterhorn1.tasks._get_last_items_page", return_value=1), \
+                patch("matterhorn1.tasks._save_items_import_start_time"), \
+                patch("matterhorn1.tasks._update_items_import_status"):
+            _import_products_from_items(
+                start_id=None, max_products=200000, api_url="https://matterhorn.example",
+                username="u", password="p", batch_size=100, dry_run=False,
+            )
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    return t
+
+
+def test_launcher_nie_przekracza_limitu_bufora_gdy_writer_utknie(monkeypatch):
+    """#238/OOM: gdy zapis do bazy utyka, launcher przestaje wystrzeliwać nowe
+    strony po MATTERHORN_PIPELINE_MAX_INFLIGHT — inaczej bufor puchnie o stronę
+    co 2 s i worker dostaje SIGKILL (OOM)."""
+    monkeypatch.setattr(tasks.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(tasks, "MATTERHORN_PAGE_LAUNCH_INTERVAL", 0)
+
+    fetched = []
+    first_write = threading.Event()
+    release_writer = threading.Event()
+
+    def fake_fetch(page, *a):
+        fetched.append(page)
+        if page > 40:
+            return {"outcome": "end_of_data", "reason": "no_more_products"}
+        return {"outcome": "ok", "items": [{"id": page, "creation_date": "2026-01-01"}]}
+
+    def fake_bulk_import(items):
+        first_write.set()
+        release_writer.wait(5)           # writer stoi na pierwszej stronie
+        return {"status": "success", "imported_count": len(items), "updated_count": 0}
+
+    t = _run_import_in_thread(fake_fetch, fake_bulk_import)
+    try:
+        assert first_write.wait(5), "import nie doszedł do pierwszego zapisu"
+        time.sleep(0.5)                  # launcher miałby czas wystrzelić ~dziesiątki stron bez capa
+        assert max(fetched) <= tasks.MATTERHORN_PIPELINE_MAX_INFLIGHT + 2, (
+            f"launcher wystrzelił do strony {max(fetched)} mimo zablokowanego writera")
+    finally:
+        release_writer.set()
+        t.join(10)
 
 
 def test_strony_przetwarzane_w_kolejnosci_mimo_odwroconej_kolejnosci_odpowiedzi(monkeypatch):


### PR DESCRIPTION
## Objaw

```
WorkerLostError('Worker exited prematurely: signal 9 (SIGKILL) Job: 68.')
```
na `celery-import` — worker OOM-owany.

## Przyczyna

Launcher pipeline'u (`_import_products_from_items` i `_update_inventory_from_api`) wystrzeliwał stronę co `MATTERHORN_PAGE_LAUNCH_INTERVAL` s **bez żadnego limitu bufora**. Gdy writer utknie na zapisie do bazy (burst, kontencja locka advisory z #238), `pending` puchnie o stronę co 2 s — kilkadziesiąt stron × ~1,5 MB JSON (`content_length=1566227` w logach) × 3–4 (obiekty Pythona) = setki MB → SIGKILL.

`--max-memory-per-child=150000` (KB = **146 MB**) był i tak absurdalnie niski dla tego workloadu — a to i tak retire graceful, nie SIGKILL, więc OOM leciał z cgroup / hosta.

## Fix

| | |
|---|---|
| `MATTERHORN_PIPELINE_MAX_INFLIGHT = 8` | launcher wstrzymuje wystrzeliwanie, gdy `len(pending) >= 8` (czeka 0.5 s, sprawdza ponownie). Bounduje RAM **i** liczbę równoległych requestów. Oba pipeline'y. |
| `--max-memory-per-child` 150000 → **500000** (~488 MB) | `docker-compose.prod.yml`, `docker-compose.services.yml`, `k8s/celery.yaml` |
| `mem_limit: 1g` na `services.yml` celery-default/import | cgroup OOM zamiast OOM killera **hosta** (dotąd brak jakiegokolwiek limitu — OOM mógł ubić inne rzeczy na VPS) |

Po #238 (`acks_late=False` + advisory lock) SIGKILL `full_import_and_update` **nie powoduje** już redeliveru po 1 h — beat wznawia od `current_page`. Ten PR usuwa samą przyczynę OOM.

## Zastosowanie na prod

- `services.yml` (obecny prod): `docker compose -f docker-compose/docker-compose.services.yml up -d --force-recreate celery-default celery-import` — bierze `mem_limit` + nowy `--max-memory-per-child`. Kod (backpressure) łapie się z bind-mountu `../src` po `git pull` + restart celery.
- `prod.yml` (po cutoverze) — już zawiera.

## Testy

`test_launcher_nie_przekracza_limitu_bufora_gdy_writer_utknie` — writer zablokowany na pierwszym zapisie → launcher nie wychodzi poza `MAX_INFLIGHT`. `pytest src/apps/matterhorn1` = 246 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)