### PR TITLE
fix(mada): watchdog + self-heal dla zawieszonych 'running' + fix routingu kolejki

### DIFF
--- a/docs/mada/MADA.md
+++ b/docs/mada/MADA.md
@@ -212,11 +212,30 @@ Sprzątanie mapowań: `MPD/signals.py` (`post_delete` na `Products`) zeruje
 | `mada.tasks.sync_mada_full`         | `mada:sync_mada_full`         | codziennie 00:15                       |
 | `mada.tasks.sync_mada_partial`      | `mada:sync_mada_partial`      | co 15 min                              |
 | `mada.tasks.cleanup_empty_products` | `mada:cleanup_empty_products` | dziennie (osobny setup)                |
+| `mada.tasks.watchdog_import_healthcheck` | —                         | co 5 min (migracja `0002`)             |
 
 Lock nie zdobyty → `{'status': 'skipped', 'reason': 'already_running'}`.
 Błąd komendy → `self.retry`.
 
 **Uwaga:** full i partial mają **różne** nazwy locka — mogą lecieć równolegle.
+
+**Sprzątanie osieroconych `running` (#267):** jeśli worker padnie w trakcie
+(SIGKILL, hard time limit Celery) zanim komenda dojdzie do `except`/`finally`,
+`ApiSyncLog` zostaje w `status='running'` na zawsze — advisory lock zwalnia się
+sam (koniec sesji DB), ale log nie. Dwie warstwy sprzątania, jak w matterhorn1
+(#238):
+- **samoleczenie** — `sync_mada_full`/`sync_mada_partial`, zaraz po zdobyciu
+  locka, oznaczają jako `failed` każdy istniejący `running` tego samego
+  `sync_type` (skoro mamy wyłączny lock, to na pewno sierota);
+- **watchdog** (`watchdog_import_healthcheck`, co 5 min) — backstop gdyby
+  kolejny przebieg się nie odpalił: `running` starszy niż 60 min (partial) /
+  180 min (full) → `failed`.
+
+**Routing kolejki:** `sync_mada_full` idzie na `celery-heavy`
+(`CELERY_TASK_ROUTES`, #263/#265) — długi task nie może blokować 3 slotów
+`celery-fast` zarezerwowanych pod 5-minutowe krytyczne taski. `PeriodicTask`
+(`setup_mada_sync_task`) **musi** mieć `queue=None`, inaczej jawny `queue` w
+`apply_async` wygrywa z `CELERY_TASK_ROUTES` i task ucieka na złego workera.
 Bezpieczeństwo stanów zapewnia idempotentny `upsert_variants` (§8), nie lock.
 Ewentualne ujednolicenie locka → osobna decyzja (#243).
 

--- a/docs/mada/MADA.md
+++ b/docs/mada/MADA.md
@@ -207,12 +207,12 @@ Sprzątanie mapowań: `MPD/signals.py` (`post_delete` na `Products`) zeruje
 
 `mada/tasks.py` — cienkie wrappery na komendy, każdy z advisory lockiem:
 
-| Task                                | Lock                          | Domyślny cykl (`setup_mada_sync_task`) |
-| ----------------------------------- | ----------------------------- | -------------------------------------- |
-| `mada.tasks.sync_mada_full`         | `mada:sync_mada_full`         | codziennie 00:15                       |
-| `mada.tasks.sync_mada_partial`      | `mada:sync_mada_partial`      | co 15 min                              |
-| `mada.tasks.cleanup_empty_products` | `mada:cleanup_empty_products` | dziennie (osobny setup)                |
-| `mada.tasks.watchdog_import_healthcheck` | —                         | co 5 min (migracja `0002`)             |
+| Task                                     | Lock                          | Domyślny cykl (`setup_mada_sync_task`) |
+| ---------------------------------------- | ----------------------------- | -------------------------------------- |
+| `mada.tasks.sync_mada_full`              | `mada:sync_mada_full`         | codziennie 00:15                       |
+| `mada.tasks.sync_mada_partial`           | `mada:sync_mada_partial`      | co 15 min                              |
+| `mada.tasks.cleanup_empty_products`      | `mada:cleanup_empty_products` | dziennie (osobny setup)                |
+| `mada.tasks.watchdog_import_healthcheck` | —                             | co 5 min (migracja `0002`)             |
 
 Lock nie zdobyty → `{'status': 'skipped', 'reason': 'already_running'}`.
 Błąd komendy → `self.retry`.
@@ -224,6 +224,7 @@ Błąd komendy → `self.retry`.
 `ApiSyncLog` zostaje w `status='running'` na zawsze — advisory lock zwalnia się
 sam (koniec sesji DB), ale log nie. Dwie warstwy sprzątania, jak w matterhorn1
 (#238):
+
 - **samoleczenie** — `sync_mada_full`/`sync_mada_partial`, zaraz po zdobyciu
   locka, oznaczają jako `failed` każdy istniejący `running` tego samego
   `sync_type` (skoro mamy wyłączny lock, to na pewno sierota);

--- a/src/apps/mada/management/commands/setup_mada_sync_task.py
+++ b/src/apps/mada/management/commands/setup_mada_sync_task.py
@@ -54,7 +54,12 @@ class Command(BaseCommand):
                 'crontab': crontab,
                 'interval': None,
                 'task': 'mada.tasks.sync_mada_full',
-                'queue': 'default',
+                # Bez sztywnego queue - decyduje CELERY_TASK_ROUTES (base.py),
+                # gdzie sync_mada_full -> heavy. Jawny queue tutaj nadpisywałby
+                # routing (apply_async z queue= wygrywa z task_routes) i wysyłał
+                # ten długi task na celery-fast, zabierając jeden z 3 slotów
+                # krytycznym 5-minutowym taskom - patrz #263/#265.
+                'queue': None,
                 'enabled': enabled,
                 'start_time': timezone.now(),
                 'description': 'Pełny import katalogu Mada (najnowszy plik TYPE=full).',
@@ -72,7 +77,9 @@ class Command(BaseCommand):
                 'interval': interval,
                 'crontab': None,
                 'task': 'mada.tasks.sync_mada_partial',
-                'queue': 'default',
+                # j.w. - bez sztywnego queue, mada.tasks.* i tak trafia domyślnie
+                # na 'default' z CELERY_TASK_ROUTES.
+                'queue': None,
                 'enabled': enabled,
                 'start_time': timezone.now(),
                 'description': 'Import przyrostowy Mada (pliki TYPE=partial nowsze niż ostatni przetworzony).',

--- a/src/apps/mada/migrations/0002_watchdog_periodic_task.py
+++ b/src/apps/mada/migrations/0002_watchdog_periodic_task.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+def create_watchdog_periodic_task(apps, schema_editor):
+    IntervalSchedule = apps.get_model('django_celery_beat', 'IntervalSchedule')
+    PeriodicTask = apps.get_model('django_celery_beat', 'PeriodicTask')
+
+    interval, _ = IntervalSchedule.objects.get_or_create(
+        every=5,
+        period='minutes',
+    )
+
+    PeriodicTask.objects.update_or_create(
+        name='mada: watchdog import healthcheck (co 5 min)',
+        defaults={
+            'interval': interval,
+            'task': 'mada.tasks.watchdog_import_healthcheck',
+            'enabled': True,
+            'description': 'Sprząta wpisy ApiSyncLog utknięte w running (#267)',
+        }
+    )
+
+
+def remove_watchdog_periodic_task(apps, schema_editor):
+    PeriodicTask = apps.get_model('django_celery_beat', 'PeriodicTask')
+    PeriodicTask.objects.filter(
+        name='mada: watchdog import healthcheck (co 5 min)'
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mada', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_watchdog_periodic_task,
+                             remove_watchdog_periodic_task),
+    ]

--- a/src/apps/mada/tasks.py
+++ b/src/apps/mada/tasks.py
@@ -10,6 +10,29 @@ from core.pg_locks import advisory_lock
 logger = get_task_logger(__name__)
 
 
+def _fail_orphaned_running(sync_type, reason):
+    """Oznacza wpisy ApiSyncLog danego sync_type utknięte w 'running' jako
+    'failed'. Wołane po zdobyciu advisory locka - skoro trzymamy wyłączny
+    lock, żaden inny run nie działa, więc każdy 'running' to sierota po
+    workerze ubitym w poprzednim przebiegu (SIGKILL, hard time limit Celery -
+    ten ostatni nie daje procesowi dojść nawet do except/finally w komendzie).
+    Bez tego log wisi w 'running' w nieskończoność (brak widoczności - #267).
+    """
+    from django.utils import timezone
+    from mada.models import ApiSyncLog
+
+    n = ApiSyncLog.objects.filter(sync_type=sync_type, status='running').update(
+        status='failed',
+        completed_at=timezone.now(),
+        error_message=reason,
+    )
+    if n:
+        logger.warning(
+            '🧹 mada %s: sprzątnięto %s osierocony(ch) wpis(ów) running przed nowym przebiegiem',
+            sync_type, n,
+        )
+
+
 @shared_task(bind=True, name='mada.tasks.sync_mada_full', max_retries=2, default_retry_delay=600)
 def sync_mada_full(self):
     """Pełny import katalogu Mada. Wywoływany raz dziennie przez Celery Beat."""
@@ -17,6 +40,10 @@ def sync_mada_full(self):
         if not acquired:
             logger.warning('Pomijam sync_mada_full: poprzedni task nadal trwa (lock aktywny).')
             return {'status': 'skipped', 'reason': 'already_running'}
+        _fail_orphaned_running(
+            'full_import',
+            'Osierocony wpis running - poprzedni worker padł w trakcie (lock zwolniony, log nie zaktualizowany)',
+        )
         try:
             call_command('sync_mada_full')
             return {'status': 'ok'}
@@ -32,12 +59,62 @@ def sync_mada_partial(self):
         if not acquired:
             logger.warning('Pomijam sync_mada_partial: poprzedni task nadal trwa (lock aktywny).')
             return {'status': 'skipped', 'reason': 'already_running'}
+        _fail_orphaned_running(
+            'partial_import',
+            'Osierocony wpis running - poprzedni worker padł w trakcie (lock zwolniony, log nie zaktualizowany)',
+        )
         try:
             call_command('sync_mada_partial')
             return {'status': 'ok'}
         except Exception as exc:
             logger.exception('Błąd importu przyrostowego Mada: %s', exc)
             raise self.retry(exc=exc)
+
+
+@shared_task(bind=True, name='mada.tasks.watchdog_import_healthcheck')
+def watchdog_import_healthcheck(self):
+    """
+    Watchdog - siatka bezpieczeństwa dla importów Mada utkniętych w 'running'.
+    Uzupełnia sprzątanie w _fail_orphaned_running (które działa tylko na
+    starcie KOLEJNEGO przebiegu): gdyby beat przestał odpalać dany task,
+    stary wpis 'running' wisiałby bez końca i bez widoczności (#267).
+    Uruchamiany co 5 minut przez Celery Beat (migracja 0002).
+    """
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from mada.models import ApiSyncLog
+
+    # Konserwatywne progi - jak w matterhorn1 (#238): import przyrostowy
+    # (interwał 15 min) powinien kończyć się w kilka minut, pełny w granicach
+    # godziny.
+    thresholds_minutes = {
+        'partial_import': 60,
+        'full_import': 180,
+    }
+    cleaned = 0
+    for sync_type, minutes in thresholds_minutes.items():
+        cutoff = timezone.now() - timedelta(minutes=minutes)
+        stale = ApiSyncLog.objects.filter(
+            sync_type=sync_type, status='running', started_at__lt=cutoff,
+        )
+        for log in stale:
+            age_minutes = int((timezone.now() - log.started_at).total_seconds() / 60)
+            log.status = 'failed'
+            log.completed_at = timezone.now()
+            log.error_message = (
+                f'Watchdog: brak zakończenia po {age_minutes} min '
+                '(prawdopodobnie ubity worker / hard time limit Celery)'
+            )
+            log.save()
+            logger.warning(
+                '🧹 Watchdog mada: log #%s (%s) oznaczony jako failed po %s min',
+                log.id, sync_type, age_minutes,
+            )
+            cleaned += 1
+
+    return {'status': 'success', 'cleaned': cleaned}
 
 
 @shared_task(bind=True, name='mada.tasks.cleanup_empty_products', max_retries=2, default_retry_delay=600)

--- a/src/apps/mada/tests/tests_integration_tasks.py
+++ b/src/apps/mada/tests/tests_integration_tasks.py
@@ -11,6 +11,7 @@ import pytest
 from celery.exceptions import Retry
 
 from mada import tasks
+from mada.models import ApiSyncLog
 
 pytestmark = pytest.mark.django_db
 
@@ -47,6 +48,38 @@ class TestLockedTasks:
                 patch.object(tasks, "call_command", side_effect=RuntimeError("boom")), \
                 pytest.raises(Retry):
             task_fn.apply(throw=True)
+
+
+@pytest.mark.parametrize("task_fn, sync_type", [
+    (tasks.sync_mada_full, "full_import"),
+    (tasks.sync_mada_partial, "partial_import"),
+])
+def test_osierocony_running_sprzatany_przed_nowym_przebiegiem(task_fn, sync_type):
+    """#267: log z poprzedniego runu, ubitego bez aktualizacji statusu (SIGKILL,
+    hard time limit Celery), nie może wisieć w 'running' bez końca - skoro
+    zdobyliśmy wyłączny lock, to na pewno sierota."""
+    orphan = ApiSyncLog.objects.create(sync_type=sync_type, status="running")
+
+    with patch.object(tasks, "advisory_lock", lambda name: _lock(True)), \
+            patch.object(tasks, "call_command"):
+        task_fn.apply().get()
+
+    orphan.refresh_from_db()
+    assert orphan.status == "failed"
+    assert orphan.completed_at is not None
+    assert "Osierocony" in orphan.error_message
+
+
+def test_running_innego_typu_nie_jest_ruszany():
+    """sync_mada_full nie powinien sprzątać running z partial_import i odwrotnie."""
+    other = ApiSyncLog.objects.create(sync_type="partial_import", status="running")
+
+    with patch.object(tasks, "advisory_lock", lambda name: _lock(True)), \
+            patch.object(tasks, "call_command"):
+        tasks.sync_mada_full.apply().get()
+
+    other.refresh_from_db()
+    assert other.status == "running"
 
 
 def test_full_i_partial_uzywaja_roznych_lockow():

--- a/src/apps/mada/tests/tests_integration_watchdog.py
+++ b/src/apps/mada/tests/tests_integration_watchdog.py
@@ -1,0 +1,65 @@
+"""
+Integration: `mada.tasks.watchdog_import_healthcheck` — siatka bezpieczeństwa
+sprzątająca ApiSyncLog utknięte w `running` (#267), niezależna od tego czy
+kolejny przebieg w ogóle się odpali (samo-leczenie w sync_mada_full/partial
+działa dopiero na starcie następnego runu).
+
+Celery Beat woła to co 5 min.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from mada.models import ApiSyncLog
+from mada.tasks import watchdog_import_healthcheck
+
+pytestmark = pytest.mark.django_db
+
+
+def _running(sync_type: str, minutes_ago: int) -> ApiSyncLog:
+    row = ApiSyncLog.objects.create(sync_type=sync_type, status="running")
+    ApiSyncLog.objects.filter(pk=row.pk).update(
+        started_at=timezone.now() - timedelta(minutes=minutes_ago))
+    row.refresh_from_db()
+    return row
+
+
+@pytest.mark.parametrize("sync_type, stale_minutes", [
+    ("partial_import", 61),
+    ("full_import", 181),
+])
+def test_stary_running_oznaczany_jako_failed(sync_type, stale_minutes):
+    stale = _running(sync_type, stale_minutes)
+
+    watchdog_import_healthcheck.apply()
+
+    stale.refresh_from_db()
+    assert stale.status == "failed"
+    assert stale.completed_at is not None
+    assert "Watchdog" in stale.error_message
+
+
+@pytest.mark.parametrize("sync_type, fresh_minutes", [
+    ("partial_import", 30),
+    ("full_import", 60),
+])
+def test_swiezy_running_nie_jest_ruszany(sync_type, fresh_minutes):
+    fresh = _running(sync_type, fresh_minutes)
+
+    watchdog_import_healthcheck.apply()
+
+    fresh.refresh_from_db()
+    assert fresh.status == "running"
+
+
+def test_zwraca_liczbe_posprzatanych():
+    _running("partial_import", 61)
+    _running("full_import", 181)
+    _running("full_import", 10)  # świeży - nie liczy się
+
+    result = watchdog_import_healthcheck.apply().get()
+
+    assert result == {"status": "success", "cleaned": 2}


### PR DESCRIPTION
Closes #267.

## Problem
Import pełny mady potrafi wisieć w `status='running'` bez końca, jeśli
worker padnie w trakcie (hard time limit Celery, SIGKILL) - komenda nie
dochodzi do `except`/`finally`, więc `ApiSyncLog` nigdy się nie aktualizuje.
Advisory lock zwalnia się sam, ale sam log nie - stąd zero widoczności czy
coś faktycznie się liczy.

Po drodze znalazłem prawdopodobną przyczynę TEGO konkretnego zawieszenia:
`setup_mada_sync_task.py` tworzył `PeriodicTask` dla `sync_mada_full` z
jawnym `queue='default'`. Jawny `queue` w `apply_async` **wygrywa** z
`CELERY_TASK_ROUTES` (gdzie `sync_mada_full` → `heavy`, #263/#265) - więc
periodic beat mógł wysyłać ten długi task na `celery-fast` (concurrency 3,
pod krótkie 5-min taski) zamiast `celery-heavy`, i po przekroczeniu
`CELERY_TASK_TIME_LIMIT` (70 min) worker zabijał go twardo.

## Zmiany
- `mada/tasks.py`: self-heal - `sync_mada_full`/`sync_mada_partial` sprzątają
  osierocone `running` tego samego `sync_type` zaraz po zdobyciu locka
  (skoro mamy wyłączny lock, to na pewno sierota po poprzednim padzie).
- Nowy `watchdog_import_healthcheck` (co 5 min, migracja `0002`) jako
  backstop niezależny od kolejnego przebiegu, wzorem matterhorn1 (#238):
  `running` > 60 min (partial) / 180 min (full) → `failed`.
- `setup_mada_sync_task.py`: `queue=None` zamiast `queue='default'` dla obu
  tasków - `CELERY_TASK_ROUTES` jako jedyne źródło prawdy.
- `docs/mada/MADA.md`: §11 opisuje obie warstwy sprzątania + gotchę z routingiem.
- Testy: `tests_integration_tasks.py` (self-heal), nowy
  `tests_integration_watchdog.py` (progi/no-op na świeżych).

## Do zrobienia ręcznie po merge (opisane w #267)
Istniejący wpis `PeriodicTask` w prod DB ma zapisane stare `queue='default'`
- migracja tego nie nadpisze. Na VPS raz:
```
docker compose exec web python manage.py setup_mada_sync_task
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)