### PR TITLE
fix(tabu): usuń sztywny queue='default' z PeriodicTask sync_tabu_products_update

### DIFF
--- a/docs/tabu/TABU.md
+++ b/docs/tabu/TABU.md
@@ -198,7 +198,14 @@ Schedule w bazie (`django_celery_beat`, `DatabaseScheduler`):
 | `tabu.tasks.sync_tabu_categories` | co 7 dni |
 | `tabu.tasks.watchdog_tabu_stock_lock` | co 5 min (no-op — advisory lock nie wymaga watchdoga) |
 
-Wszystkie taski działają na kolejce `default` (worker `celery-default`).
+**Routing kolejki** (`CELERY_TASK_ROUTES`, #263/#265): `sync_tabu_products_update`
+idzie na **`celery-heavy`** — długi task (do 3h, `time_limit=10800`) nie może
+blokować 3 slotów `celery-fast` zarezerwowanych pod 5-minutowe krytyczne
+taski. Reszta (`sync_tabu_stock`, `sync_tabu_categories`,
+`watchdog_tabu_stock_lock`) leci na `celery-fast`. `PeriodicTask`
+(`setup_tabu_sync_task`) **musi** mieć `queue=None` — jawny `queue` w
+`apply_async` wygrywa z `CELERY_TASK_ROUTES` i wysyła task na złego workera
+(ten sam bug co w mada, patrz #267).
 
 ---
 

--- a/docs/tabu/TABU.md
+++ b/docs/tabu/TABU.md
@@ -51,16 +51,16 @@ Kod: `src/apps/tabu/`.
 
 `src/apps/tabu/models.py`. Wszystkie tabele z prefiksem `tabu_`.
 
-| Model | Tabela | Rola | Klucz z API |
-| --- | --- | --- | --- |
-| `Brand` | `tabu_brand` | marka | `brand_id` = `str(producer_id)` (unique) |
-| `Category` | `tabu_category` | kategoria + `path`, `parent` | `category_id` = `str(api_category_id)` (unique) |
-| `TabuProduct` | `tabu_product_detail` | produkt, **`store_total`** (suma wariantów) | `api_id` (IntegerField, **unique**) |
-| `TabuProductImage` | `tabu_product_gallery` | gallery, `unique(product, api_image_id)` | `api_image_id` |
-| `TabuProductVariant` | `tabu_product_variant` | wariant, **`store`**, ceny | `api_id` (IntegerField, **unique**) |
-| `ApiSyncLog` | `tabu_apisynclog` | log syncu (`sync_type`, `status`, `raw_response`) | — |
-| `StockHistory` | `tabu_stock_history` | historia zmian stanu | — |
-| `Saga` / `SagaStep` | `tabu_saga_logs` / `tabu_saga_steps` | saga mapowania do MPD | — |
+| Model                | Tabela                               | Rola                                              | Klucz z API                                     |
+| -------------------- | ------------------------------------ | ------------------------------------------------- | ----------------------------------------------- |
+| `Brand`              | `tabu_brand`                         | marka                                             | `brand_id` = `str(producer_id)` (unique)        |
+| `Category`           | `tabu_category`                      | kategoria + `path`, `parent`                      | `category_id` = `str(api_category_id)` (unique) |
+| `TabuProduct`        | `tabu_product_detail`                | produkt, **`store_total`** (suma wariantów)       | `api_id` (IntegerField, **unique**)             |
+| `TabuProductImage`   | `tabu_product_gallery`               | gallery, `unique(product, api_image_id)`          | `api_image_id`                                  |
+| `TabuProductVariant` | `tabu_product_variant`               | wariant, **`store`**, ceny                        | `api_id` (IntegerField, **unique**)             |
+| `ApiSyncLog`         | `tabu_apisynclog`                    | log syncu (`sync_type`, `status`, `raw_response`) | —                                               |
+| `StockHistory`       | `tabu_stock_history`                 | historia zmian stanu                              | —                                               |
+| `Saga` / `SagaStep`  | `tabu_saga_logs` / `tabu_saga_steps` | saga mapowania do MPD                             | —                                               |
 
 Mapowanie do MPD: `TabuProduct.mapped_product_uid`, `TabuProductVariant.mapped_variant_uid`
 / `is_mapped`. Ustawiane ręcznie w adminie (`mpd_create` / `assign_mapping`,
@@ -92,12 +92,12 @@ factory tworzą obiekty bez `.using()` → też `default`. Spójnie.
 Taski Celery (`tabu/tasks.py`) to cienkie wrappery wokół management commands
 (`tabu/management/commands/`):
 
-| Task | Komenda | Endpoint | Częstość |
-| --- | --- | --- | --- |
-| `sync_tabu_stock` | `sync_tabu_stock` | `products/basic` | co 10 min |
-| `sync_tabu_products_update` | `sync_tabu_new_products` | `products/{id}` | co 240 min |
-| `sync_tabu_categories` | `sync_tabu_categories` | `products/categories` | co 7 dni |
-| `watchdog_tabu_stock_lock` | — (no-op) | — | co 5 min |
+| Task                        | Komenda                  | Endpoint              | Częstość   |
+| --------------------------- | ------------------------ | --------------------- | ---------- |
+| `sync_tabu_stock`           | `sync_tabu_stock`        | `products/basic`      | co 10 min  |
+| `sync_tabu_products_update` | `sync_tabu_new_products` | `products/{id}`       | co 240 min |
+| `sync_tabu_categories`      | `sync_tabu_categories`   | `products/categories` | co 7 dni   |
+| `watchdog_tabu_stock_lock`  | — (no-op)                | —                     | co 5 min   |
 
 Pozostałe komendy: `sync_tabu_products` (pełny import po ID),
 `import_tabu_by_id`, `find_common_eans`, `check_tabu_mpd_db`, `clear_tabu_data`,
@@ -126,7 +126,7 @@ Komenda `sync_tabu_stock`:
 
 1. Stronicowane `GET products/basic?update_from=…` → płaska lista rekordów.
 2. **Wczesny stop:** jeśli odcisk (`sha1` z posortowanych `(variant_id, store,
-   price_net, price_gross)`) == odcisk z poprzedniego zakończonego runu →
+price_net, price_gross)`) == odcisk z poprzedniego zakończonego runu →
    pomiń cały run (`skipped_reason: identical_fetch_as_previous_run`). To nie
    „ta sama liczba rekordów" — porównanie **danych** (poprawka #233).
 3. **`_apply_stock_updates(records)` — batch, bez N+1:**
@@ -191,12 +191,12 @@ Tabu (mapowanie per kolor hurtowni, v1.41).
 
 Schedule w bazie (`django_celery_beat`, `DatabaseScheduler`):
 
-| Zadanie | Częstość |
-| --- | --- |
-| `tabu.tasks.sync_tabu_stock` | co 10 min |
-| `tabu.tasks.sync_tabu_products_update` | co 240 min |
-| `tabu.tasks.sync_tabu_categories` | co 7 dni |
-| `tabu.tasks.watchdog_tabu_stock_lock` | co 5 min (no-op — advisory lock nie wymaga watchdoga) |
+| Zadanie                                | Częstość                                              |
+| -------------------------------------- | ----------------------------------------------------- |
+| `tabu.tasks.sync_tabu_stock`           | co 10 min                                             |
+| `tabu.tasks.sync_tabu_products_update` | co 240 min                                            |
+| `tabu.tasks.sync_tabu_categories`      | co 7 dni                                              |
+| `tabu.tasks.watchdog_tabu_stock_lock`  | co 5 min (no-op — advisory lock nie wymaga watchdoga) |
 
 **Routing kolejki** (`CELERY_TASK_ROUTES`, #263/#265): `sync_tabu_products_update`
 idzie na **`celery-heavy`** — długi task (do 3h, `time_limit=10800`) nie może
@@ -231,7 +231,7 @@ z `is_mapped=True` zmienione w oknie po `updated_at`). Dlatego
   (scoped), `last_update`; akcje mapowania do MPD.
 - `TabuProductVariantAdmin`, `TabuProductImageAdmin`, `BrandAdmin`, `CategoryAdmin`.
 - `StockHistoryAdmin` (`ReadOnlyLogAdminMixin`) — prosty: `list_filter =
-  ['change_type', 'timestamp']`. **Brak** buga z filtrem dużej kardynalności /
+['change_type', 'timestamp']`. **Brak** buga z filtrem dużej kardynalności /
   N+1 w linku (który dotknął matterhorn1 — #229).
 - `ApiSyncLogAdmin`, `SagaAdmin`, `SagaStepAdmin` — read-only.
 
@@ -239,14 +239,14 @@ z `is_mapped=True` zmienione w oknie po `updated_at`). Dlatego
 
 ## 12. Różnice względem matterhorn1
 
-| | matterhorn1 | tabu |
-| --- | --- | --- |
-| Blokada importu | Redis `cache.add` (TTL 1 h) — **ryzyko zawieszonego locka** po padzie workera (issue #238) | **PostgreSQL advisory lock** — auto-release, bez TTL, bez watchdoga |
-| Idempotencja stanów | warunkowy `UPDATE` (#230) | warunkowy `UPDATE` (analogicznie) |
-| `store_total` / `stock_total` | `@property` (suma na żądanie) | pole liczone z sumy przy syncu |
-| Pipeline pobierania stron | współbieżny (wątek launcher, #226/#227) | sekwencyjny (`products/basic` szybkie, mniejszy wolumen) |
-| Checkpoint/wznawianie ITEMS | tak (`current_page`) | nie ma (nowe produkty przez `check_range`) |
-| Admin StockHistory | wymagał optymalizacji (#229) | od początku prosty |
+|                               | matterhorn1                                                                                | tabu                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Blokada importu               | Redis `cache.add` (TTL 1 h) — **ryzyko zawieszonego locka** po padzie workera (issue #238) | **PostgreSQL advisory lock** — auto-release, bez TTL, bez watchdoga |
+| Idempotencja stanów           | warunkowy `UPDATE` (#230)                                                                  | warunkowy `UPDATE` (analogicznie)                                   |
+| `store_total` / `stock_total` | `@property` (suma na żądanie)                                                              | pole liczone z sumy przy syncu                                      |
+| Pipeline pobierania stron     | współbieżny (wątek launcher, #226/#227)                                                    | sekwencyjny (`products/basic` szybkie, mniejszy wolumen)            |
+| Checkpoint/wznawianie ITEMS   | tak (`current_page`)                                                                       | nie ma (nowe produkty przez `check_range`)                          |
+| Admin StockHistory            | wymagał optymalizacji (#229)                                                               | od początku prosty                                                  |
 
 **Wzorzec advisory lock z tabu jest rekomendowany dla matterhorn1** (issue #238).
 

--- a/src/apps/tabu/management/commands/setup_tabu_sync_task.py
+++ b/src/apps/tabu/management/commands/setup_tabu_sync_task.py
@@ -51,8 +51,12 @@ class Command(BaseCommand):
             )
             existing_task.interval = schedule
             existing_task.enabled = not options['disable']
-            if not existing_task.queue:
-                existing_task.queue = 'default'
+            # Bez sztywnego queue - decyduje CELERY_TASK_ROUTES (base.py), gdzie
+            # sync_tabu_products_update -> heavy. Jawny queue tutaj wygrywałby
+            # z routingiem (apply_async z queue= bije task_routes) i wysyłał ten
+            # task (do 3h - time_limit=10800) na celery-fast, zabierając jeden
+            # z 3 slotów krytycznym 5-minutowym taskom - patrz #263/#265/#267.
+            existing_task.queue = None
             existing_task.save()
 
             status = 'wyłączony' if options['disable'] else 'włączony'
@@ -60,7 +64,7 @@ class Command(BaseCommand):
                 self.style.SUCCESS(
                     f'✅ Zaktualizowano periodic task: {task_name}\n'
                     f'   - Interwał: co {interval_minutes} minut\n'
-                    f'   - Queue: {existing_task.queue or "default"}\n'
+                    f'   - Queue: {existing_task.queue or "(routing z CELERY_TASK_ROUTES)"}\n'
                     f'   - Status: {status}'
                 )
             )
@@ -80,7 +84,8 @@ class Command(BaseCommand):
                 interval=schedule,
                 name=task_name,
                 task=task_path,
-                queue='default',
+                # j.w. - bez sztywnego queue, CELERY_TASK_ROUTES kieruje ten task na heavy.
+                queue=None,
                 enabled=not options['disable'],
                 start_time=timezone.now(),
                 description='Sprawdza nowe produkty: max(api_id)+1, 404=brak',
@@ -112,7 +117,7 @@ class Command(BaseCommand):
                     if task.interval
                     else str(task.crontab or '')
                 )
-                queue_info = task.queue or '(pusta – używa default)'
+                queue_info = task.queue or '(routing z CELERY_TASK_ROUTES)'
                 self.stdout.write(
                     f'\n{icon} {task.name}\n'
                     f'   Task: {task.task}\n'

--- a/src/apps/tabu/tests/tests_unit_setup_tabu_sync_task.py
+++ b/src/apps/tabu/tests/tests_unit_setup_tabu_sync_task.py
@@ -1,0 +1,43 @@
+"""
+`setup_tabu_sync_task` — regresja na #267/#269: PeriodicTask dla
+`sync_tabu_products_update` nie może mieć jawnego `queue`, bo to wygrywa z
+`CELERY_TASK_ROUTES` (który kieruje ten task na `heavy`) i wysyła długi
+(do 3h) task na `celery-fast`.
+"""
+from __future__ import annotations
+
+import pytest
+from django.core.management import call_command
+from django_celery_beat.models import PeriodicTask
+
+pytestmark = pytest.mark.django_db
+
+TASK_NAME = "Synchronizacja produktów Tabu"
+
+
+def test_nowy_task_ma_puste_queue():
+    call_command("setup_tabu_sync_task")
+
+    task = PeriodicTask.objects.get(name=TASK_NAME)
+    assert task.queue in (None, "")
+    assert task.task == "tabu.tasks.sync_tabu_products_update"
+
+
+def test_istniejacy_task_ze_starym_queue_zostaje_wyczyszczony():
+    """Regresja na sam bug: stary wpis miał queue='default' na sztywno -
+    ponowne uruchomienie setup command musi to wyczyścić, nie tylko
+    ustawiać gdy puste."""
+    from django_celery_beat.models import IntervalSchedule
+
+    interval, _ = IntervalSchedule.objects.get_or_create(every=60, period="minutes")
+    PeriodicTask.objects.create(
+        name=TASK_NAME,
+        task="tabu.tasks.sync_tabu_products_update",
+        interval=interval,
+        queue="default",
+    )
+
+    call_command("setup_tabu_sync_task")
+
+    task = PeriodicTask.objects.get(name=TASK_NAME)
+    assert task.queue in (None, "")


### PR DESCRIPTION
Ten sam bug co w mada (#267): `setup_tabu_sync_task` tworzył/aktualizował
`PeriodicTask` dla `sync_tabu_products_update` z jawnym `queue='default'`.
Jawny `queue` w `apply_async` wygrywa z `CELERY_TASK_ROUTES`, który kieruje
ten task na `heavy` (#263/#265) — więc periodic beat wysyłał go na
`celery-fast` zamiast `celery-heavy`, zabierając jeden z tylko 3 slotów
fast-workera na potencjalnie do 3h (`time_limit=10800`).

Mniej groźne niż w mada — ten task ma własny hojny `time_limit` i nie wisi
w `running` w nieskończoność — ale to wciąż dokładnie ten starvation, przed
którym #263 miał chronić.

## Zmiany
- `setup_tabu_sync_task.py`: `queue=None` w obu gałęziach (create/update).
  Update-branch wcześniej ustawiał `'default'` tylko gdy puste
  (`if not existing_task.queue`) - to nie sprzątało już zapisanego złego
  wpisu przy ponownym uruchomieniu, więc teraz nadpisuje zawsze.
- `docs/tabu/TABU.md`: sprostowane błędne „wszystkie taski na kolejce
  default" (nieaktualne od #263) + opis routingu.
- Test: `tests_unit_setup_tabu_sync_task.py` (nowy wpis ma puste `queue`;
  istniejący z `queue='default'` zostaje wyczyszczony przy ponownym odpaleniu).

## Do zrobienia ręcznie po merge
Jak przy mada (#267/#268) - istniejący wpis w prod DB ma zapisane stare
`queue='default'`, migracja tego nie dotyka. Po deployu:
```
docker compose exec web python manage.py setup_tabu_sync_task
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)