### PR TITLE
feat(MPD): most stanów tabu/mada -> MPD.StockAndPrices

### DIFF
--- a/docs/MPD_STOCK_SYNC_CHANGELOG.md
+++ b/docs/MPD_STOCK_SYNC_CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog - Synchronizacja stanów magazynowych MPD
 
+## 2026-09-10 - Wersja 3.0 - Most dla tabu i mada (#270)
+
+### 🐛 Problem
+
+Eksport do IdoSell/PrestaShop czyta stan wyłącznie z `MPD.StockAndPrices`.
+Dla tabu i mada ten cache powstawał **raz**, przy linkowaniu wariantu — nic
+go później nie odświeżało (`MadaAdapter`/`TabuAdapter` są używane tylko przy
+linkowaniu, nie przy eksporcie — dokumentacja wcześniej twierdziła inaczej).
+Efekt: stan tabu/mada w eksporcie zamrożony na moment linkowania.
+
+### ✨ Nowe funkcje
+
+- Nowy współdzielony moduł `MPD/stock_bridge.py::sync_stock_bridge` — ta sama
+  logika co `update_stock_from_matterhorn1`, ale bez okna czasowego
+  (`TabuProductVariant` nie ma pola `updated_at`, więc bierze wszystkie
+  warianty `is_mapped=True`; warunkowy zapis i tak nic nie robi, gdy stan się
+  nie zmienił).
+- Nowe taski: `MPD.tasks.update_stock_from_tabu`, `MPD.tasks.update_stock_from_mada`.
+- `setup_stock_sync_task` rozszerzony o `--source {matterhorn1,tabu,mada}`
+  (domyślnie `matterhorn1` — zachowanie sprzed #270 bez zmian).
+
+### Bez zmian
+
+`update_stock_from_matterhorn1` (poniżej) **zostaje nietknięty** — działa na
+produkcji bez pokrycia testami, nie było powodu ryzykować regresji przy
+okazji dokładania tabu/mada.
+
 ## 2024-10-09 - Wersja 2.0 - Time Window Optimization 🚀
 
 ### ✨ Nowe funkcje

--- a/docs/MPD_STOCK_SYNC_CHANGELOG.md
+++ b/docs/MPD_STOCK_SYNC_CHANGELOG.md
@@ -32,12 +32,14 @@ okazji dokładania tabu/mada.
 ### ✨ Nowe funkcje
 
 #### Time Window Filtering
+
 - **Ogromna optymalizacja:** Task sprawdza tylko warianty zaktualizowane w ostatnich X minutach
 - **Domyślnie:** 15 minut wstecz od momentu uruchomienia
 - **Parametr:** `time_window_minutes` w wywołaniu taska
 - **Wzrost wydajności:** ~1000x dla dużych baz danych!
 
 #### Nowe ustawienia domyślne
+
 - **Interval:** Co 5 minut (wcześniej: 15 minut)
 - **Time window:** 15 minut (nowe!)
 - **Bufor:** 3x - nie przegapisz zmian nawet jeśli task się opóźni
@@ -45,12 +47,13 @@ okazji dokładania tabu/mada.
 ### 🔧 Zmiany w implementacji
 
 #### MPD/tasks.py
+
 ```python
 @shared_task(bind=True, name='MPD.tasks.update_stock_from_matterhorn1')
 def update_stock_from_matterhorn1(self, time_window_minutes=15):
     # Oblicz czas od którego sprawdzamy zmiany
     time_threshold = start_time - timedelta(minutes=time_window_minutes)
-    
+
     # Filtruj po updated_at
     mapped_variants = Matterhorn1Variant.objects.using(matterhorn1_db).filter(
         is_mapped=True,
@@ -60,6 +63,7 @@ def update_stock_from_matterhorn1(self, time_window_minutes=15):
 ```
 
 #### MPD/management/commands/setup_stock_sync_task.py
+
 - Nowy parametr: `--time-window` (domyślnie: 15)
 - Zmieniony domyślny interval: 5 minut (wcześniej: 15)
 - Automatyczne przekazywanie `time_window_minutes` do taska przez `kwargs`
@@ -68,20 +72,20 @@ def update_stock_from_matterhorn1(self, time_window_minutes=15):
 
 #### Przykład: sklep z 10 000 wariantów
 
-| Scenariusz | Przed | Po | Przyspieszenie |
-|------------|-------|-----|----------------|
-| Typowe użycie | ~5-10 minut | ~1-5 sekund | ~1000x |
-| Duże zmiany | ~5-10 minut | ~10-30 sekund | ~100x |
-| Pierwsze uruchomienie | ~5-10 minut | (użyj dużego time_window) | N/A |
+| Scenariusz            | Przed       | Po                        | Przyspieszenie |
+| --------------------- | ----------- | ------------------------- | -------------- |
+| Typowe użycie         | ~5-10 minut | ~1-5 sekund               | ~1000x         |
+| Duże zmiany           | ~5-10 minut | ~10-30 sekund             | ~100x          |
+| Pierwsze uruchomienie | ~5-10 minut | (użyj dużego time_window) | N/A            |
 
 #### Zużycie zasobów
 
-| Metryka | Przed | Po | Redukcja |
-|---------|-------|-----|----------|
-| Warianty sprawdzane | 10 000 | ~12 | 99.9% |
-| Czas CPU | ~300s | ~1s | 99.7% |
-| DB queries | ~10 000 | ~12 | 99.9% |
-| Obciążenie DB | Wysokie | Minimalne | 99% |
+| Metryka             | Przed   | Po        | Redukcja |
+| ------------------- | ------- | --------- | -------- |
+| Warianty sprawdzane | 10 000  | ~12       | 99.9%    |
+| Czas CPU            | ~300s   | ~1s       | 99.7%    |
+| DB queries          | ~10 000 | ~12       | 99.9%    |
+| Obciążenie DB       | Wysokie | Minimalne | 99%      |
 
 ### 🎯 Rekomendowane ustawienia
 
@@ -90,15 +94,16 @@ def update_stock_from_matterhorn1(self, time_window_minutes=15):
 python manage.py setup_stock_sync_task --interval 5 --time-window 15 --settings=nc.settings.dev
 ```
 
-| Wielkość | Interval | Time Window | Opis |
-|----------|----------|-------------|------|
+| Wielkość | Interval | Time Window | Opis            |
+| -------- | -------- | ----------- | --------------- |
 | Mały     | 5 min    | 15 min      | Szybkie reakcje |
-| Średni   | 5 min    | 15 min      | Balans |
-| Duży     | 10 min   | 20 min      | Wydajność |
+| Średni   | 5 min    | 15 min      | Balans          |
+| Duży     | 10 min   | 20 min      | Wydajność       |
 
 ### 📝 Użycie
 
 #### Uruchomienie ręczne
+
 ```python
 # Domyślnie: ostatnie 15 minut
 result = update_stock_from_matterhorn1.delay()
@@ -111,6 +116,7 @@ result = update_stock_from_matterhorn1.delay(time_window_minutes=999999)
 ```
 
 #### Periodic task
+
 ```bash
 # Management command (REKOMENDOWANE)
 python manage.py setup_stock_sync_task --interval 5 --time-window 15
@@ -122,6 +128,7 @@ python manage.py setup_stock_sync_task --interval 5 --time-window 15
 ### 🔍 Monitoring
 
 #### Logi
+
 ```
 INFO: 🚀 Rozpoczynam task update_stock_from_matterhorn1 (ID: abc) o 2024-10-09 10:30:00 (okno czasowe: 15 min)
 INFO: 📊 Znaleziono 12 zmapowanych wariantów zaktualizowanych od 2024-10-09 10:15:00
@@ -133,13 +140,14 @@ INFO: 📊 Statystyki: Sprawdzono: 12, Zaktualizowano: 3, Utworzono: 0, Bez zmia
 ### ⚙️ Wymagania
 
 #### Index na updated_at (WAŻNE!)
+
 Dla optymalnej wydajności, upewnij się że masz index na kolumnie `updated_at`:
 
 ```sql
 -- Sprawdź czy index istnieje
-SELECT indexname, indexdef 
-FROM pg_indexes 
-WHERE tablename = 'productvariant' 
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'productvariant'
 AND schemaname = 'public';
 
 -- Jeśli nie ma, utwórz:
@@ -157,6 +165,7 @@ CREATE INDEX idx_productvariant_mapped ON productvariant(is_mapped, updated_at) 
 ### 📚 Dokumentacja
 
 Zaktualizowane pliki:
+
 - `MPD_STOCK_SYNC_README.md` - pełna dokumentacja
 - `MPD/QUICK_START_STOCK_SYNC.md` - szybki start
 - `MPD_STOCK_SYNC_CHANGELOG.md` - ten plik
@@ -164,6 +173,7 @@ Zaktualizowane pliki:
 ### 🚀 Migration Guide
 
 #### Dla nowych instalacji
+
 ```bash
 python manage.py setup_stock_sync_task --settings=nc.settings.dev
 ```
@@ -171,6 +181,7 @@ python manage.py setup_stock_sync_task --settings=nc.settings.dev
 #### Dla istniejących instalacji
 
 1. **Aktualizuj periodic task:**
+
 ```bash
 python manage.py setup_stock_sync_task --interval 5 --time-window 15 --settings=nc.settings.dev
 ```
@@ -183,6 +194,7 @@ python manage.py setup_stock_sync_task --interval 5 --time-window 15 --settings=
    - Zapisz
 
 3. **Sprawdź index (opcjonalnie, ale rekomendowane):**
+
 ```sql
 CREATE INDEX IF NOT EXISTS idx_productvariant_updated_at ON productvariant(updated_at);
 ```
@@ -192,7 +204,7 @@ CREATE INDEX IF NOT EXISTS idx_productvariant_updated_at ON productvariant(updat
 Ta aktualizacja wprowadza **ogromną optymalizację** dla synchronizacji stanów magazynowych:
 
 - ⚡ **~1000x szybciej** dla typowego użycia
-- 💾 **99.9% mniej zapytań** do bazy danych  
+- 💾 **99.9% mniej zapytań** do bazy danych
 - 🔋 **Minimalne obciążenie** systemu
 - ⏱️ **Częstsze uruchomienia** (co 5 minut zamiast 15)
 - 🛡️ **Bufor bezpieczeństwa** (3x overlap)
@@ -211,6 +223,3 @@ Ta aktualizacja wprowadza **ogromną optymalizację** dla synchronizacji stanów
 - Historia zmian w `StockHistory`
 - Management command `setup_stock_sync_task`
 - Dokumentacja i quick start guide
-
-
-

--- a/docs/MPD_STOCK_SYNC_README.md
+++ b/docs/MPD_STOCK_SYNC_README.md
@@ -1,5 +1,12 @@
 # Synchronizacja stanów magazynowych MPD z Matterhorn1
 
+> **#270:** ten dokument opisuje `update_stock_from_matterhorn1` (jedyny most
+> z oknem czasowym). Dla **tabu** i **mada** jest analogiczny most bez okna
+> (`update_stock_from_tabu` / `update_stock_from_mada`,
+> `MPD/stock_bridge.py`, rejestracja `setup_stock_sync_task --source tabu`/
+> `mada`) — patrz `MPD_STOCK_SYNC_CHANGELOG.md` wersja 3.0. Reszta poniżej
+> (Flower, format wyniku, troubleshooting) dotyczy tylko matterhorn1.
+
 ## Opis
 
 Task Celery `update_stock_from_matterhorn1` synchronizuje stany magazynowe z bazy danych Matterhorn1 do bazy MPD. 

--- a/docs/MPD_STOCK_SYNC_README.md
+++ b/docs/MPD_STOCK_SYNC_README.md
@@ -9,14 +9,14 @@
 
 ## Opis
 
-Task Celery `update_stock_from_matterhorn1` synchronizuje stany magazynowe z bazy danych Matterhorn1 do bazy MPD. 
+Task Celery `update_stock_from_matterhorn1` synchronizuje stany magazynowe z bazy danych Matterhorn1 do bazy MPD.
 
 **Kluczowa optymalizacja:** Task sprawdza tylko warianty zaktualizowane w określonym oknie czasowym (domyślnie ostatnie 15 minut), co znacznie zwiększa wydajność.
 
 ## Proces synchronizacji
 
 1. **Pobiera zmapowane warianty** z `matterhorn1.ProductVariant` gdzie:
-   - `is_mapped=True` 
+   - `is_mapped=True`
    - `mapped_variant_uid` jest ustawione
    - `updated_at >= (current_time - time_window_minutes)` - tylko ostatnie X minut
 2. **Znajduje odpowiednie warianty** w MPD używając `mapped_variant_uid` jako klucza
@@ -138,13 +138,14 @@ PeriodicTask.objects.create(
 
 ### Rekomendowane ustawienia
 
-| Wielkość sklepu | Interval | Time Window | Opis |
-|----------------|----------|-------------|------|
-| Mały (<1000)   | 5 min    | 15 min      | Szybkie reakcje na zmiany |
-| Średni (1k-5k) | 5 min    | 15 min      | Balans między wydajnością a aktualnością |
-| Duży (>5k)     | 10 min   | 20 min      | Mniej częste, ale bardziej wydajne |
+| Wielkość sklepu | Interval | Time Window | Opis                                     |
+| --------------- | -------- | ----------- | ---------------------------------------- |
+| Mały (<1000)    | 5 min    | 15 min      | Szybkie reakcje na zmiany                |
+| Średni (1k-5k)  | 5 min    | 15 min      | Balans między wydajnością a aktualnością |
+| Duży (>5k)      | 10 min   | 20 min      | Mniej częste, ale bardziej wydajne       |
 
 **Dlaczego time_window > interval?**
+
 - Bufor bezpieczeństwa (np. 3x)
 - Nie przegapisz zmian jeśli task się opóźni
 - Pokrycie dla overlapping updates
@@ -208,6 +209,7 @@ INFO:    - Błędy: 5
 ```
 
 **Rozwiązanie**: Upewnij się, że warianty w Matterhorn1 mają:
+
 - `is_mapped = True`
 - `mapped_variant_uid` ustawiony na prawidłowy `variant_id` z MPD
 
@@ -217,7 +219,8 @@ INFO:    - Błędy: 5
 ⚠️ Nie znaleziono wariantu MPD dla mapped_variant_uid=123
 ```
 
-**Rozwiązanie**: 
+**Rozwiązanie**:
+
 - Sprawdź czy wariant o ID 123 istnieje w `MPD.ProductVariants`
 - Sprawdź czy istnieje rekord w `MPD.ProductvariantsSources` dla źródła Matterhorn
 
@@ -244,6 +247,7 @@ Sources.objects.create(
 ### Flower (Celery monitoring)
 
 Otwórz http://localhost:5555 aby:
+
 - Zobaczyć status tasków
 - Sprawdzić historię wykonań
 - Zobaczyć szczegóły błędów
@@ -269,7 +273,7 @@ docker-compose logs -f celery_worker
 Wszystkie zmiany stanów są zapisywane w `MPD.StockHistory`:
 
 ```sql
-SELECT 
+SELECT
     sh.*,
     pv.producer_code,
     p.name as product_name
@@ -293,14 +297,14 @@ from MPD.models import StockAndPrices, Sources
 
 class StockSyncTestCase(TransactionTestCase):
     databases = ['zzz_matterhorn1', 'zzz_MPD']
-    
+
     def test_update_stock(self):
         # Przygotuj dane testowe
         # ... (stwórz warianty z mapowaniem)
-        
+
         # Uruchom task
         result = update_stock_from_matterhorn1()
-        
+
         # Sprawdź wynik
         self.assertEqual(result['status'], 'success')
         self.assertGreater(result['stats']['checked'], 0)
@@ -311,6 +315,7 @@ class StockSyncTestCase(TransactionTestCase):
 ### Optymalizacja
 
 Task używa:
+
 - **Time window filtering** - sprawdza tylko ostatnie X minut (ogromny wzrost wydajności!)
 - `select_related('product')` dla matterhorn1 variants
 - `select_related('variant')` dla MPD variant sources
@@ -320,10 +325,12 @@ Task używa:
 ### Szacowany czas wykonania
 
 #### Z time window (15 minut):
+
 - Typowe obciążenie: ~1-5 sekund (tylko zmienione warianty)
 - Duże obciążenie: ~10-30 sekund (wiele zmian jednocześnie)
 
 #### Bez time window (wszystkie warianty):
+
 - 100 wariantów: ~5-10 sekund
 - 1000 wariantów: ~30-60 sekund
 - 10000 wariantów: ~5-10 minut
@@ -333,11 +340,11 @@ Task używa:
 Przykład: sklep z 10 000 wariantów, typowo 50 zmian na godzinę:
 
 | Time window | Warianty do sprawdzenia | Czas wykonania |
-|-------------|------------------------|----------------|
-| 5 minut     | ~4 warianty            | <1 sekunda     |
-| 15 minut    | ~12 wariantów          | ~1 sekunda     |
-| 60 minut    | ~50 wariantów          | ~5 sekund      |
-| Bez limitu  | 10 000 wariantów       | ~5-10 minut    |
+| ----------- | ----------------------- | -------------- |
+| 5 minut     | ~4 warianty             | <1 sekunda     |
+| 15 minut    | ~12 wariantów           | ~1 sekunda     |
+| 60 minut    | ~50 wariantów           | ~5 sekund      |
+| Bez limitu  | 10 000 wariantów        | ~5-10 minut    |
 
 **Wniosek:** Time window daje ~1000x przyspieszenie! 🚀
 
@@ -361,4 +368,3 @@ Przykład: sklep z 10 000 wariantów, typowo 50 zmian na godzinę:
 - [ ] Delta updates (tylko zmienione warianty)
 - [ ] Compression dla dużych synchronizacji
 - [ ] Parallel processing dla bardzo dużych zbiorów danych
-

--- a/docs/mada/MADA.md
+++ b/docs/mada/MADA.md
@@ -262,16 +262,16 @@ Ewentualne ujednolicenie locka → osobna decyzja (#243).
 
 ## 13. Różnice względem matterhorn1 / tabu
 
-| Aspekt             | Mada                                            | matterhorn1 / tabu                                        |
-| ------------------ | ----------------------------------------------- | --------------------------------------------------------- |
-| Transport          | feed XML w ZIP (manifest + pliki)               | REST JSON                                                 |
-| Auth               | login/hasło w query stringu (redakcja w logach) | token w nagłówku                                          |
-| Id wariantu        | brak — `variant_key` = EAN \| `"color\|size"`   | numeryczne `variant_uid` / `api_id`                       |
-| Cena               | na produkcie                                    | na wariancie                                              |
-| Przyrostowość      | kursor po `file_name` plików partial            | `update_from` / `last_update` z `ApiSyncLog`              |
-| Wygaszanie         | `is_active=False` dla nieobecnych w `full`      | brak / miękkie                                            |
+| Aspekt             | Mada                                            | matterhorn1 / tabu                                           |
+| ------------------ | ----------------------------------------------- | ------------------------------------------------------------ |
+| Transport          | feed XML w ZIP (manifest + pliki)               | REST JSON                                                    |
+| Auth               | login/hasło w query stringu (redakcja w logach) | token w nagłówku                                             |
+| Id wariantu        | brak — `variant_key` = EAN \| `"color\|size"`   | numeryczne `variant_uid` / `api_id`                          |
+| Cena               | na produkcie                                    | na wariancie                                                 |
+| Przyrostowość      | kursor po `file_name` plików partial            | `update_from` / `last_update` z `ApiSyncLog`                 |
+| Wygaszanie         | `is_active=False` dla nieobecnych w `full`      | brak / miękkie                                               |
 | Most stanów do MPD | push `update_stock_from_mada` (#270, bez okna)  | matterhorn1: push z oknem 15 min; tabu: push bez okna (#270) |
-| Lock importu       | pg advisory lock, **osobny full vs partial**    | pg advisory lock (oba)                                     |
+| Lock importu       | pg advisory lock, **osobny full vs partial**    | pg advisory lock (oba)                                       |
 
 Wspólne: idempotentny warunkowy UPDATE stanów + `bulk_create` historii,
 wzorzec saga `core.saga`, `ApiSyncLog`, `StockHistory`.

--- a/docs/mada/MADA.md
+++ b/docs/mada/MADA.md
@@ -30,9 +30,9 @@ Sąsiednie dokumenty: [`matterhorn/MATTERHORN1.md`](../matterhorn/MATTERHORN1.md
 ## 1. Przegląd
 
 ```
-Mada feed XML ──(import)──▶ baza mada ──(adapter źródłowy / saga)──▶ MPD ──▶ eksport ──▶ IdoSell / PrestaShop
-  get_xml.php (manifest)          MadaProduct / MadaProductVariant       MadaAdapter czyta .stock po EAN
-  get_xml.php?file=… (ZIP)        StockHistory (audyt zmian stanu)       (model pull, nie push)
+Mada feed XML ──(import)──▶ baza mada ──(saga, linkowanie)──▶ MPD ──▶ eksport ──▶ IdoSell / PrestaShop
+  get_xml.php (manifest)          MadaProduct / MadaProductVariant   StockAndPrices (cache)
+  get_xml.php?file=… (ZIP)        StockHistory (audyt zmian stanu)   ↑ update_stock_from_mada (push, #270)
 ```
 
 - **`full`** — pełny katalog (~24 MB `products.xml`), generowany raz dziennie
@@ -191,13 +191,20 @@ Różnice modelu Mada w sadze:
 
 ## 10. Most stanów do MPD
 
-**Model pull, nie push.** Nie ma taska „wypchnij stany Mada do MPD".
-`MPD/source_adapters/mada.py::MadaAdapter` czyta `MadaProductVariant.stock`
-**na żywo po EAN** (`get_variants_by_eans`, `get_all_variants_for_product`,
-`get_unmapped_variants_for_mpd_product`) podczas linkowania / eksportu MPD.
+**Sprostowanie (#270):** poniższe „model pull, na żywo" było mylące —
+`MadaAdapter` (`get_variants_by_eans` itd.) jest używany **tylko przy
+linkowaniu** (dopinanie wariantu do MPD), **NIE przy eksporcie**. Eksport do
+IdoSell/PrestaShop czyta wyłącznie `MPD.StockAndPrices` — bez osobnego mostu
+ten cache byłby więc zamrożony na stan z chwili linkowania.
 
-`mada.StockHistory` jest **tylko audytem** — nic z niego nie odczytuje MPD
-(inaczej niż `MPD.tasks.update_stock_from_matterhorn1` dla matterhorn1).
+Most: **`MPD.tasks.update_stock_from_mada`** (`MPD/stock_bridge.py`,
+współdzielony z tabu) — bierze **wszystkie** warianty z `is_mapped=True` i
+odświeża `StockAndPrices` + `MPD.StockHistory`. Bez okna czasowego (jak
+matterhorn1) — warunkowy zapis i tak nic nie robi, gdy stan się nie zmienił.
+Rejestracja: `setup_stock_sync_task --source mada` (`MPD` app).
+
+`mada.StockHistory` (ta w bazie mada, nie MPD) jest tylko audytem
+przyrostowego/pełnego importu — osobna tabela od `MPD.StockHistory` powyżej.
 
 Sprzątanie mapowań: `MPD/signals.py` (`post_delete` na `Products`) zeruje
 `mapped_product_uid` / `mapped_variant_uid` w Mada; historyczne sieroty czyści
@@ -263,8 +270,8 @@ Ewentualne ujednolicenie locka → osobna decyzja (#243).
 | Cena               | na produkcie                                    | na wariancie                                              |
 | Przyrostowość      | kursor po `file_name` plików partial            | `update_from` / `last_update` z `ApiSyncLog`              |
 | Wygaszanie         | `is_active=False` dla nieobecnych w `full`      | brak / miękkie                                            |
-| Most stanów do MPD | pull przez `MadaAdapter` (na żywo)              | push (`update_stock_from_matterhorn1`) + adapter          |
-| Lock importu       | pg advisory lock, **osobny full vs partial**    | matterhorn1: Redis `cache.add`; tabu: pg advisory (jeden) |
+| Most stanów do MPD | push `update_stock_from_mada` (#270, bez okna)  | matterhorn1: push z oknem 15 min; tabu: push bez okna (#270) |
+| Lock importu       | pg advisory lock, **osobny full vs partial**    | pg advisory lock (oba)                                     |
 
 Wspólne: idempotentny warunkowy UPDATE stanów + `bulk_create` historii,
 wzorzec saga `core.saga`, `ApiSyncLog`, `StockHistory`.

--- a/docs/matterhorn/MATTERHORN1.md
+++ b/docs/matterhorn/MATTERHORN1.md
@@ -264,7 +264,10 @@ Schedule w bazie (`django_celery_beat`, `DatabaseScheduler`), nie w kodzie:
 | ----------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `matterhorn1.tasks.full_import_and_update`      | crontab `2,12,22,32,42,52 * * * *` (Europe/Warsaw) | co 10 min                                                                                                                                                        |
 | `matterhorn1.tasks.watchdog_import_healthcheck` | co 5 min                                           | siatka bezpieczeństwa: `running` bez postępu > 15 min → `error`, bardzo stare (> 3 h) → `error`. Blokada = advisory lock, więc nie ma ghost-locków do sprzątania |
-| `MPD.tasks.update_stock_from_matterhorn1`       | co 5 min                                           | most stanów matterhorn1 → MPD                                                                                                                                    |
+| `MPD.tasks.update_stock_from_matterhorn1`       | co 5 min                                           | most stanów matterhorn1 → MPD (jedyny most z oknem czasowym — patrz `MPD_STOCK_SYNC_README.md`)                                                                  |
+
+Tabu i mada mają analogiczne mosty (`update_stock_from_tabu`/`_mada`, bez
+okna czasowego) — #270, `docs/MPD_STOCK_SYNC_CHANGELOG.md` wersja 3.0.
 
 Pozostałe taski (bez harmonogramu / punktowe):
 `clean_old_stock_history` (kasuje wpisy `StockHistory` starsze niż N dni —

--- a/docs/tabu/TABU.md
+++ b/docs/tabu/TABU.md
@@ -216,10 +216,14 @@ taski. Reszta (`sync_tabu_stock`, `sync_tabu_categories`,
 przez `_apply_stock_updates` (bulk_create) — `tabu.stock_tracker.track_stock_change`
 istnieje (tested), ale nie jest już wołany przez sync.
 
-Most do MPD: **`MPD.tasks.update_stock_from_matterhorn1`** — nazwa historyczna,
-ale obsługuje **wszystkie** hurtownie po `mapped_variant_uid` (bierze warianty
-z `is_mapped=True` zmienione w oknie po `updated_at`). Dlatego
-`_apply_stock_updates` ustawia `updated_at` wariantu przez warunkowy `UPDATE`.
+**Most do MPD (#270 — sprostowanie):** `MPD.tasks.update_stock_from_matterhorn1`
+obsługuje **tylko matterhorn1** (mimo nazwy sugerującej ogólność — importuje
+wprost `matterhorn1.models.ProductVariant`). Dla tabu jest osobny task:
+**`MPD.tasks.update_stock_from_tabu`** (`MPD/stock_bridge.py`, współdzielony
+z mada) — bierze **wszystkie** warianty z `is_mapped=True` (bez okna
+czasowego: `TabuProductVariant` **nie ma** pola `updated_at`, więc nie ma po
+czym filtrować "co się zmieniło"; warunkowy zapis i tak nic nie robi, gdy
+stan się nie zmienił). Rejestracja: `setup_stock_sync_task --source tabu`.
 
 ---
 

--- a/src/apps/MPD/QUICK_START_STOCK_SYNC.md
+++ b/src/apps/MPD/QUICK_START_STOCK_SYNC.md
@@ -1,5 +1,11 @@
 # Quick Start - Synchronizacja stanów magazynowych
 
+> Ten quick start opisuje `update_stock_from_matterhorn1`. Dla **tabu** i
+> **mada** jest analogiczny most bez okna czasowego — `update_stock_from_tabu`
+> / `update_stock_from_mada` (`MPD/stock_bridge.py`, #270), rejestracja
+> `setup_stock_sync_task --source tabu` / `--source mada`. Reszta (Flower,
+> `/admin/django_celery_beat/periodictask/`, format wyniku) identyczna.
+
 ## 1. Szybki start - Uruchom task ręcznie
 
 ```bash

--- a/src/apps/MPD/QUICK_START_STOCK_SYNC.md
+++ b/src/apps/MPD/QUICK_START_STOCK_SYNC.md
@@ -43,6 +43,7 @@ python manage.py setup_stock_sync_task --interval 5 --time-window 15 --settings=
 ```
 
 Opcje:
+
 - `--interval 5` - jak często uruchamiać task (domyślnie: 5 minut)
 - `--time-window 15` - ile minut wstecz sprawdzać (domyślnie: 15 minut)
 - `--disable` - wyłącz task
@@ -53,12 +54,15 @@ Opcje:
 ## 3. Monitoring
 
 ### Flower (Celery monitoring)
+
 Otwórz: http://localhost:5555
 
 ### Django Admin
+
 Przejdź do: http://localhost:8000/admin/django_celery_beat/periodictask/
 
 ### Logi
+
 ```bash
 # Development
 tail -f logs/matterhorn/import_all_by_one.log
@@ -67,11 +71,12 @@ tail -f logs/matterhorn/import_all_by_one.log
 ## 4. Wymagania przed uruchomieniem
 
 ### Mapowanie wariantów
+
 Warianty w Matterhorn1 muszą być zmapowane:
 
 ```sql
 -- Sprawdź zmapowane warianty
-SELECT 
+SELECT
     pv.variant_uid,
     pv.product_id,
     pv.name as size,
@@ -99,6 +104,7 @@ mh1_variant.save(using='zzz_matterhorn1')
 ```
 
 ### Źródło w MPD
+
 Task automatycznie utworzy źródło "Matterhorn API" jeśli nie istnieje.
 
 ## 5. Przykładowy wynik
@@ -124,19 +130,25 @@ Task automatycznie utworzy źródło "Matterhorn API" jeśli nie istnieje.
 ## 6. Troubleshooting
 
 ### Brak zmapowanych wariantów
+
 ```
 ℹ️ Brak zmapowanych wariantów do synchronizacji
 ```
+
 **Rozwiązanie**: Zmapuj warianty (patrz punkt 4)
 
 ### Nie znaleziono wariantu MPD
+
 ```
 ⚠️ Nie znaleziono wariantu MPD dla mapped_variant_uid=123
 ```
+
 **Rozwiązanie**: Sprawdź czy wariant istnieje w MPD i czy ma rekord w ProductvariantsSources
 
 ### Błąd połączenia z bazą
+
 **Rozwiązanie**: Sprawdź czy:
+
 - PostgreSQL działa
 - Settings.dev ma poprawną konfigurację baz danych
 - Masz dostęp do obu baz (zzz_matterhorn1 i zzz_MPD)
@@ -144,4 +156,3 @@ Task automatycznie utworzy źródło "Matterhorn API" jeśli nie istnieje.
 ## 7. Pełna dokumentacja
 
 Zobacz `MPD_STOCK_SYNC_README.md` dla pełnej dokumentacji.
-

--- a/src/apps/MPD/management/commands/setup_stock_sync_task.py
+++ b/src/apps/MPD/management/commands/setup_stock_sync_task.py
@@ -1,15 +1,49 @@
 """
-Management command do konfiguracji periodic task dla synchronizacji stanów magazynowych
+Management command do konfiguracji periodic task dla mostu stanów magazynowych
+hurtownia -> MPD.StockAndPrices (#270: rozszerzone o tabu/mada, wcześniej
+tylko matterhorn1).
 """
+import json
+
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django_celery_beat.models import PeriodicTask, IntervalSchedule
 
+# Nazwa/task_path per źródło. Nazwa dla matterhorn1 zostaje jak była (żeby
+# `PeriodicTask.objects.get(name=...)` trafiał w istniejący wpis w prod DB,
+# a nie tworzył duplikatu) - tabu/mada dostają analogiczne nowe wpisy.
+SOURCES = {
+    'matterhorn1': {
+        'task_name': 'Synchronizacja stanów MPD z Matterhorn1',
+        'task_path': 'MPD.tasks.update_stock_from_matterhorn1',
+        'description': 'Synchronizuje stany magazynowe z bazy Matterhorn1 do MPD',
+        'takes_time_window': True,
+    },
+    'tabu': {
+        'task_name': 'Synchronizacja stanów MPD z Tabu',
+        'task_path': 'MPD.tasks.update_stock_from_tabu',
+        'description': 'Synchronizuje stany magazynowe z bazy Tabu do MPD (#270)',
+        'takes_time_window': False,
+    },
+    'mada': {
+        'task_name': 'Synchronizacja stanów MPD z Mada',
+        'task_path': 'MPD.tasks.update_stock_from_mada',
+        'description': 'Synchronizuje stany magazynowe z bazy Mada do MPD (#270)',
+        'takes_time_window': False,
+    },
+}
+
 
 class Command(BaseCommand):
-    help = 'Konfiguruje periodic task dla synchronizacji stanów magazynowych MPD z Matterhorn1'
+    help = 'Konfiguruje periodic task dla mostu stanów magazynowych hurtownia -> MPD'
 
     def add_arguments(self, parser):
+        parser.add_argument(
+            '--source',
+            choices=sorted(SOURCES.keys()),
+            default='matterhorn1',
+            help='Która hurtownia (domyślnie: matterhorn1, zachowanie sprzed #270)',
+        )
         parser.add_argument(
             '--interval',
             type=int,
@@ -20,7 +54,7 @@ class Command(BaseCommand):
             '--time-window',
             type=int,
             default=15,
-            help='Ile minut wstecz sprawdzać zmiany (domyślnie: 15)'
+            help='Ile minut wstecz sprawdzać zmiany - tylko matterhorn1 (domyślnie: 15)'
         )
         parser.add_argument(
             '--disable',
@@ -34,14 +68,15 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        source = SOURCES[options['source']]
         interval_minutes = options['interval']
         time_window_minutes = options['time_window']
-        task_name = 'Synchronizacja stanów MPD z Matterhorn1'
-        task_path = 'MPD.tasks.update_stock_from_matterhorn1'
+        task_name = source['task_name']
+        task_path = source['task_path']
 
-        # Argumenty dla taska (okno czasowe)
-        import json
-        task_kwargs = json.dumps({'time_window_minutes': time_window_minutes})
+        task_kwargs = ''
+        if source['takes_time_window']:
+            task_kwargs = json.dumps({'time_window_minutes': time_window_minutes})
 
         # Sprawdź czy task już istnieje
         try:
@@ -63,15 +98,17 @@ class Command(BaseCommand):
 
             existing_task.interval = schedule
             existing_task.enabled = not options['disable']
-            existing_task.kwargs = task_kwargs
+            if source['takes_time_window']:
+                existing_task.kwargs = task_kwargs
             existing_task.save()
 
             status = 'wyłączony' if options['disable'] else 'włączony'
+            extra = f'\n   - Okno czasowe: {time_window_minutes} minut' if source['takes_time_window'] else ''
             self.stdout.write(
                 self.style.SUCCESS(
                     f'✅ Zaktualizowano periodic task: {task_name}\n'
-                    f'   - Interval: co {interval_minutes} minut\n'
-                    f'   - Okno czasowe: {time_window_minutes} minut\n'
+                    f'   - Interval: co {interval_minutes} minut'
+                    f'{extra}\n'
                     f'   - Status: {status}'
                 )
             )
@@ -102,15 +139,16 @@ class Command(BaseCommand):
                 kwargs=task_kwargs,
                 enabled=not options['disable'],
                 start_time=timezone.now(),
-                description='Synchronizuje stany magazynowe z bazy Matterhorn1 do MPD'
+                description=source['description'],
             )
 
             status = 'wyłączony' if options['disable'] else 'włączony'
+            extra = f'\n   - Okno czasowe: {time_window_minutes} minut' if source['takes_time_window'] else ''
             self.stdout.write(
                 self.style.SUCCESS(
                     f'✅ Utworzono periodic task: {task_name}\n'
-                    f'   - Interval: co {interval_minutes} minut\n'
-                    f'   - Okno czasowe: {time_window_minutes} minut\n'
+                    f'   - Interval: co {interval_minutes} minut'
+                    f'{extra}\n'
                     f'   - Status: {status}\n'
                     f'   - Task ID: {task.id}'
                 )
@@ -146,11 +184,12 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.HTTP_INFO(
                 '\n💡 Wskazówki:\n'
-                '   - Domyślnie: uruchomienie co 5 minut, sprawdza ostatnie 15 minut\n'
-                '   - Aby zmienić interval: python manage.py setup_stock_sync_task --interval 10\n'
-                '   - Aby zmienić okno czasowe: python manage.py setup_stock_sync_task --time-window 30\n'
-                '   - Aby wyłączyć: python manage.py setup_stock_sync_task --disable\n'
-                '   - Aby usunąć: python manage.py setup_stock_sync_task --delete\n'
+                '   - Domyślnie: matterhorn1, co 5 minut, okno 15 minut\n'
+                '   - Inna hurtownia: python manage.py setup_stock_sync_task --source tabu\n'
+                '   - Zmiana intervalu: python manage.py setup_stock_sync_task --interval 10\n'
+                '   - Zmiana okna czasowego (tylko matterhorn1): --time-window 30\n'
+                '   - Aby wyłączyć: python manage.py setup_stock_sync_task --source tabu --disable\n'
+                '   - Aby usunąć: python manage.py setup_stock_sync_task --source tabu --delete\n'
                 '   - Monitoring: http://localhost:5555 (Flower)\n'
                 '   - Admin: /admin/django_celery_beat/periodictask/\n'
             )

--- a/src/apps/MPD/stock_bridge.py
+++ b/src/apps/MPD/stock_bridge.py
@@ -1,0 +1,107 @@
+"""
+Most stanów magazynowych: hurtownia (warianty `is_mapped=True`) -> MPD.StockAndPrices.
+
+Współdzielone przez `MPD.tasks.update_stock_from_tabu` / `update_stock_from_mada`
+(#270). `update_stock_from_matterhorn1` ma własną, starszą, nietestowaną
+implementację wprost w `MPD/tasks.py` - zostawiona bez zmian, żeby nie
+ryzykować regresji czegoś co już działa na produkcji bez siatki testów.
+
+Dlaczego bez okna czasowego (inaczej niż matterhorn1): TabuProductVariant nie
+ma pola `updated_at`, więc nie ma po czym filtrować "co się zmieniło od X".
+Zamiast okna bierzemy WSZYSTKIE zmapowane (`is_mapped=True`) warianty przy
+każdym uruchomieniu - `sync_stock_bridge` i tak nie zapisuje nic (ani do
+StockAndPrices, ani do StockHistory) gdy stan się nie zmienił, więc dla
+zbioru ograniczonego do już-zlinkowanych wariantów to tanie.
+"""
+import logging
+from decimal import Decimal
+from typing import Iterable, Tuple
+
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+def sync_stock_bridge(
+    mapped_stock_pairs: Iterable[Tuple[int, int]],
+    *,
+    source_name: str,
+    source_type_default: str,
+    source_location_default: str,
+    mpd_db: str,
+) -> dict:
+    """
+    mapped_stock_pairs: (mapped_variant_uid, current_stock) dla wariantów
+    hurtowni z is_mapped=True - mapped_variant_uid odpowiada
+    ProductvariantsSources.variant_id w MPD.
+
+    Źródło (`Sources`) dopasowane po dokładnej nazwie `source_name` (ten sam
+    rekord co przy linkowaniu w `tabu/services.py` / `mada/services.py`),
+    tworzone przy braku. Cena nie jest tu ruszana (price=0.00 przy tworzeniu -
+    jak w matterhorn1 - idzie innym torem); tylko stock + StockHistory.
+
+    Zwraca stats: {'checked', 'updated', 'created', 'unchanged', 'errors', 'error_details'}.
+    """
+    from MPD.models import ProductvariantsSources, StockAndPrices, StockHistory, Sources
+
+    stats = {
+        'checked': 0, 'updated': 0, 'created': 0, 'unchanged': 0,
+        'errors': 0, 'error_details': [],
+    }
+
+    source, source_created = Sources.objects.using(mpd_db).get_or_create(
+        name=source_name,
+        defaults={'type': source_type_default, 'location': source_location_default},
+    )
+    if source_created:
+        logger.info("📦 Utworzono nowe źródło: %s (ID: %s)", source.name, source.id)
+
+    now = timezone.now()
+    for mapped_variant_uid, current_stock in mapped_stock_pairs:
+        stats['checked'] += 1
+        try:
+            pvs = ProductvariantsSources.objects.using(mpd_db).filter(
+                variant_id=mapped_variant_uid, source=source,
+            ).select_related('variant').first()
+            if not pvs:
+                stats['errors'] += 1
+                stats['error_details'].append(
+                    f'Brak ProductvariantsSources dla variant_id={mapped_variant_uid} '
+                    f'(source={source_name})'
+                )
+                continue
+
+            sap, created = StockAndPrices.objects.using(mpd_db).get_or_create(
+                variant=pvs.variant, source=source,
+                defaults={
+                    'stock': current_stock, 'price': Decimal('0.00'),
+                    'currency': 'PLN', 'last_updated': now,
+                },
+            )
+            if created:
+                stats['created'] += 1
+                StockHistory.objects.using(mpd_db).create(
+                    stock_id=sap.id, source_id=source.id,
+                    previous_stock=0, new_stock=current_stock,
+                    previous_price=Decimal('0.00'), new_price=sap.price,
+                )
+            elif sap.stock != current_stock:
+                # Warunkowy UPDATE (idempotentny wzorzec jak w tabu/mada mirror-sync) -
+                # zapisujemy historię PRZED update'em, na starym sap.stock.
+                StockHistory.objects.using(mpd_db).create(
+                    stock_id=sap.id, source_id=source.id,
+                    previous_stock=sap.stock, new_stock=current_stock,
+                    previous_price=sap.price, new_price=sap.price,
+                )
+                StockAndPrices.objects.using(mpd_db).filter(pk=sap.pk).update(
+                    stock=current_stock, last_updated=now,
+                )
+                stats['updated'] += 1
+            else:
+                stats['unchanged'] += 1
+        except Exception as exc:
+            stats['errors'] += 1
+            stats['error_details'].append(f'variant_id={mapped_variant_uid}: {exc}')
+            logger.exception("Błąd sync_stock_bridge (%s) dla variant_id=%s", source_name, mapped_variant_uid)
+
+    return stats

--- a/src/apps/MPD/tasks.py
+++ b/src/apps/MPD/tasks.py
@@ -221,6 +221,89 @@ def track_recent_stock_changes(self):
         }
 
 
+def _mpd_db():
+    from core.db_routers import _get_mpd_db
+    return _get_mpd_db()
+
+
+@shared_task(bind=True, name='MPD.tasks.update_stock_from_tabu')
+def update_stock_from_tabu(self):
+    """
+    Most stanów magazynowych Tabu -> MPD (#270).
+
+    Bierze WSZYSTKIE warianty Tabu z is_mapped=True (TabuProductVariant nie ma
+    pola updated_at, więc nie ma jak filtrować oknem czasowym jak w
+    matterhorn1) i przekazuje do sync_stock_bridge - warunkowy zapis i tak nic
+    nie robi, gdy stan się nie zmienił.
+
+    Uruchamiany okresowo przez periodic task (np. co 5 minut,
+    `setup_stock_sync_task --source tabu`).
+    """
+    from core.db_routers import _get_tabu_db
+    from tabu.models import TabuProductVariant
+    from MPD.stock_bridge import sync_stock_bridge
+
+    start_time = timezone.now()
+    pairs = TabuProductVariant.objects.using(_get_tabu_db()).filter(
+        is_mapped=True, mapped_variant_uid__isnull=False,
+    ).values_list('mapped_variant_uid', 'store')
+
+    stats = sync_stock_bridge(
+        pairs,
+        source_name='Tabu API',
+        source_type_default='api',
+        source_location_default='https://b2b.tabu.com.pl',
+        mpd_db=_mpd_db(),
+    )
+    duration = (timezone.now() - start_time).total_seconds()
+    logger.info(
+        "✅ update_stock_from_tabu: sprawdzono=%s zaktualizowano=%s utworzono=%s błędy=%s (%.2fs)",
+        stats['checked'], stats['updated'], stats['created'], stats['errors'], duration,
+    )
+    return {
+        'status': 'success' if stats['errors'] == 0 else 'partial',
+        'stats': stats,
+        'duration_seconds': duration,
+    }
+
+
+@shared_task(bind=True, name='MPD.tasks.update_stock_from_mada')
+def update_stock_from_mada(self):
+    """
+    Most stanów magazynowych Mada -> MPD (#270). Jak update_stock_from_tabu -
+    bez okna czasowego, bierze wszystkie is_mapped=True warianty Mada.
+
+    Uruchamiany okresowo przez periodic task (np. co 5 minut,
+    `setup_stock_sync_task --source mada`).
+    """
+    from core.db_routers import _get_mada_db
+    from mada.models import MadaProductVariant
+    from MPD.stock_bridge import sync_stock_bridge
+
+    start_time = timezone.now()
+    pairs = MadaProductVariant.objects.using(_get_mada_db()).filter(
+        is_mapped=True, mapped_variant_uid__isnull=False,
+    ).values_list('mapped_variant_uid', 'stock')
+
+    stats = sync_stock_bridge(
+        pairs,
+        source_name='Mada API',
+        source_type_default='api',
+        source_location_default='https://www.mada.pl',
+        mpd_db=_mpd_db(),
+    )
+    duration = (timezone.now() - start_time).total_seconds()
+    logger.info(
+        "✅ update_stock_from_mada: sprawdzono=%s zaktualizowano=%s utworzono=%s błędy=%s (%.2fs)",
+        stats['checked'], stats['updated'], stats['created'], stats['errors'], duration,
+    )
+    return {
+        'status': 'success' if stats['errors'] == 0 else 'partial',
+        'stats': stats,
+        'duration_seconds': duration,
+    }
+
+
 @shared_task(bind=True, name='MPD.tasks.update_stock_from_matterhorn1')
 def update_stock_from_matterhorn1(self, time_window_minutes=15):
     """

--- a/src/apps/MPD/tests_setup_stock_sync_task.py
+++ b/src/apps/MPD/tests_setup_stock_sync_task.py
@@ -1,0 +1,73 @@
+"""
+`setup_stock_sync_task` - regresja na #270: rozszerzenie o --source nie może
+zmienić domyślnego (matterhorn1) zachowania (nazwa/task_path/kwargs muszą
+zostać identyczne, inaczej ponowne uruchomienie na prod stworzy DUPLIKAT
+zamiast zaktualizować istniejący wpis).
+"""
+import json
+
+import pytest
+from django.core.management import call_command
+from django_celery_beat.models import PeriodicTask
+
+pytestmark = pytest.mark.django_db
+
+
+def test_domyslne_zrodlo_to_matterhorn1_ze_starą_nazwą():
+    call_command("setup_stock_sync_task")
+
+    task = PeriodicTask.objects.get(name="Synchronizacja stanów MPD z Matterhorn1")
+    assert task.task == "MPD.tasks.update_stock_from_matterhorn1"
+    assert json.loads(task.kwargs) == {"time_window_minutes": 15}
+    assert task.interval.every == 5
+
+
+def test_source_tabu_tworzy_osobny_task_bez_kwargs():
+    call_command("setup_stock_sync_task", "--source", "tabu")
+
+    task = PeriodicTask.objects.get(name="Synchronizacja stanów MPD z Tabu")
+    assert task.task == "MPD.tasks.update_stock_from_tabu"
+    assert task.kwargs in ("", "{}", None)
+    assert not PeriodicTask.objects.filter(name="Synchronizacja stanów MPD z Matterhorn1").exists()
+
+
+def test_source_mada_tworzy_osobny_task():
+    call_command("setup_stock_sync_task", "--source", "mada")
+
+    task = PeriodicTask.objects.get(name="Synchronizacja stanów MPD z Mada")
+    assert task.task == "MPD.tasks.update_stock_from_mada"
+
+
+def test_trzy_zrodla_wspolistnieja_niezaleznie():
+    call_command("setup_stock_sync_task", "--source", "matterhorn1")
+    call_command("setup_stock_sync_task", "--source", "tabu")
+    call_command("setup_stock_sync_task", "--source", "mada")
+
+    names = set(
+        PeriodicTask.objects.filter(task__startswith="MPD.tasks.").values_list("name", flat=True)
+    )
+    assert names == {
+        "Synchronizacja stanów MPD z Matterhorn1",
+        "Synchronizacja stanów MPD z Tabu",
+        "Synchronizacja stanów MPD z Mada",
+    }
+
+
+def test_disable_tabu_nie_rusza_matterhorn1():
+    call_command("setup_stock_sync_task")  # matterhorn1, enabled
+    call_command("setup_stock_sync_task", "--source", "tabu", "--disable")
+
+    mh = PeriodicTask.objects.get(name="Synchronizacja stanów MPD z Matterhorn1")
+    tabu = PeriodicTask.objects.get(name="Synchronizacja stanów MPD z Tabu")
+    assert mh.enabled is True
+    assert tabu.enabled is False
+
+
+def test_delete_tabu_nie_rusza_mada():
+    call_command("setup_stock_sync_task", "--source", "tabu")
+    call_command("setup_stock_sync_task", "--source", "mada")
+
+    call_command("setup_stock_sync_task", "--source", "tabu", "--delete")
+
+    assert not PeriodicTask.objects.filter(name="Synchronizacja stanów MPD z Tabu").exists()
+    assert PeriodicTask.objects.filter(name="Synchronizacja stanów MPD z Mada").exists()

--- a/src/apps/MPD/tests_stock_bridge.py
+++ b/src/apps/MPD/tests_stock_bridge.py
@@ -1,0 +1,221 @@
+"""
+Most stanów magazynowych hurtownia -> MPD (#270): `stock_bridge.sync_stock_bridge`
++ taski `update_stock_from_tabu` / `update_stock_from_mada`.
+
+`update_stock_from_matterhorn1` NIE jest tu testowany - to celowo nietknięta,
+starsza implementacja (patrz komentarz w MPD/tasks.py).
+"""
+from datetime import datetime
+from decimal import Decimal
+
+from django.conf import settings
+from django.test import TestCase
+
+from mada.models import Brand as MadaBrand, MadaProduct, MadaProductVariant
+from MPD.models import (
+    Brands,
+    Colors,
+    ProductVariants,
+    Products,
+    ProductvariantsSources,
+    Sizes,
+    Sources,
+    StockAndPrices,
+    StockHistory,
+)
+from MPD.stock_bridge import sync_stock_bridge
+from MPD.tasks import update_stock_from_mada, update_stock_from_tabu
+from tabu.models import Brand as TabuBrand, TabuProduct, TabuProductVariant
+
+
+def _mpd_db():
+    return 'zzz_MPD' if 'zzz_MPD' in settings.DATABASES else 'MPD'
+
+
+def _tabu_db():
+    return 'zzz_tabu' if 'zzz_tabu' in settings.DATABASES else 'tabu'
+
+
+def _mada_db():
+    return 'zzz_mada' if 'zzz_mada' in settings.DATABASES else 'mada'
+
+
+class _MPDVariantMixin:
+    """Tworzy minimalny produkt MPD z jednym wariantem + wpisem ProductvariantsSources."""
+
+    def _make_mpd_variant(self, source, variant_uid):
+        mpd_db = _mpd_db()
+        brand = Brands.objects.using(mpd_db).create(name='Test Brand')
+        color = Colors.objects.using(mpd_db).create(name='Czerwony')
+        size = Sizes.objects.using(mpd_db).create(name='M')
+        product = Products.objects.using(mpd_db).create(name='Produkt testowy', brand=brand)
+        variant = ProductVariants.objects.using(mpd_db).create(
+            product=product, color=color, size=size,
+        )
+        ProductvariantsSources.objects.using(mpd_db).create(
+            variant=variant, source=source, variant_uid=variant_uid,
+        )
+        return variant
+
+
+class SyncStockBridgeTest(_MPDVariantMixin, TestCase):
+    databases = '__all__'
+
+    def setUp(self):
+        self.mpd_db = _mpd_db()
+        self.source = Sources.objects.using(self.mpd_db).create(
+            name='Test API', type='api', location='https://test.example',
+        )
+        self.variant = self._make_mpd_variant(self.source, variant_uid=1001)
+
+    def test_nowy_wpis_tworzy_stock_and_prices_i_historie(self):
+        stats = sync_stock_bridge(
+            [(self.variant.variant_id, 7)],
+            source_name='Test API', source_type_default='api',
+            source_location_default='https://test.example', mpd_db=self.mpd_db,
+        )
+
+        sap = StockAndPrices.objects.using(self.mpd_db).get(variant=self.variant, source=self.source)
+        self.assertEqual(sap.stock, 7)
+        self.assertEqual(stats['created'], 1)
+        self.assertEqual(stats['checked'], 1)
+        history = StockHistory.objects.using(self.mpd_db).get(stock_id=sap.id)
+        self.assertEqual(history.previous_stock, 0)
+        self.assertEqual(history.new_stock, 7)
+
+    def test_zmieniony_stan_aktualizuje_i_loguje_historie(self):
+        StockAndPrices.objects.using(self.mpd_db).create(
+            variant=self.variant, source=self.source, stock=5,
+            price=Decimal('0.00'), currency='PLN', last_updated=datetime.now(),
+        )
+
+        stats = sync_stock_bridge(
+            [(self.variant.variant_id, 12)],
+            source_name='Test API', source_type_default='api',
+            source_location_default='https://test.example', mpd_db=self.mpd_db,
+        )
+
+        sap = StockAndPrices.objects.using(self.mpd_db).get(variant=self.variant, source=self.source)
+        self.assertEqual(sap.stock, 12)
+        self.assertEqual(stats['updated'], 1)
+        history = StockHistory.objects.using(self.mpd_db).get(stock_id=sap.id)
+        self.assertEqual(history.previous_stock, 5)
+        self.assertEqual(history.new_stock, 12)
+
+    def test_niezmieniony_stan_nic_nie_zapisuje(self):
+        """Idempotencja: re-run z tym samym stanem nie tworzy nowego wpisu StockHistory."""
+        StockAndPrices.objects.using(self.mpd_db).create(
+            variant=self.variant, source=self.source, stock=9,
+            price=Decimal('0.00'), currency='PLN', last_updated=datetime.now(),
+        )
+
+        stats = sync_stock_bridge(
+            [(self.variant.variant_id, 9)],
+            source_name='Test API', source_type_default='api',
+            source_location_default='https://test.example', mpd_db=self.mpd_db,
+        )
+
+        self.assertEqual(stats['unchanged'], 1)
+        self.assertEqual(stats['updated'], 0)
+        self.assertFalse(StockHistory.objects.using(self.mpd_db).exists())
+
+    def test_brak_productvariantssources_liczony_jako_blad(self):
+        stats = sync_stock_bridge(
+            [(999999, 3)],
+            source_name='Test API', source_type_default='api',
+            source_location_default='https://test.example', mpd_db=self.mpd_db,
+        )
+
+        self.assertEqual(stats['errors'], 1)
+        self.assertIn('999999', stats['error_details'][0])
+
+    def test_brak_zrodla_tworzy_je(self):
+        Sources.objects.using(self.mpd_db).filter(name='Nowe API').delete()
+
+        stats = sync_stock_bridge(
+            [], source_name='Nowe API', source_type_default='api',
+            source_location_default='https://nowe.example', mpd_db=self.mpd_db,
+        )
+
+        self.assertEqual(stats['checked'], 0)
+        self.assertTrue(
+            Sources.objects.using(self.mpd_db).filter(name='Nowe API').exists()
+        )
+
+
+class UpdateStockFromTabuTaskTest(_MPDVariantMixin, TestCase):
+    databases = '__all__'
+
+    def setUp(self):
+        self.mpd_db = _mpd_db()
+        self.tabu_db = _tabu_db()
+        self.source = Sources.objects.using(self.mpd_db).create(
+            name='Tabu API', type='api', location='https://b2b.tabu.com.pl',
+        )
+        self.variant = self._make_mpd_variant(self.source, variant_uid=555)
+
+        brand = TabuBrand.objects.using(self.tabu_db).create(brand_id='1', name='Marka Tabu')
+        product = TabuProduct.objects.using(self.tabu_db).create(
+            api_id=555, symbol='SYM', name='Produkt Tabu', brand=brand, last_update=datetime.now(),
+        )
+        self.tabu_variant = TabuProductVariant.objects.using(self.tabu_db).create(
+            api_id=555, product=product, symbol='SYM-1', store=42,
+            mapped_variant_uid=self.variant.variant_id, is_mapped=True,
+        )
+
+    def test_zmapowany_wariant_aktualizuje_stock_and_prices(self):
+        result = update_stock_from_tabu.apply().get()
+
+        sap = StockAndPrices.objects.using(self.mpd_db).get(variant=self.variant, source=self.source)
+        self.assertEqual(sap.stock, 42)
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['stats']['checked'], 1)
+
+    def test_niezmapowany_wariant_pomijany(self):
+        self.tabu_variant.is_mapped = False
+        self.tabu_variant.mapped_variant_uid = None
+        self.tabu_variant.save()
+
+        result = update_stock_from_tabu.apply().get()
+
+        self.assertEqual(result['stats']['checked'], 0)
+        self.assertFalse(
+            StockAndPrices.objects.using(self.mpd_db).filter(variant=self.variant, source=self.source).exists()
+        )
+
+
+class UpdateStockFromMadaTaskTest(_MPDVariantMixin, TestCase):
+    databases = '__all__'
+
+    def setUp(self):
+        self.mpd_db = _mpd_db()
+        self.mada_db = _mada_db()
+        self.source = Sources.objects.using(self.mpd_db).create(
+            name='Mada API', type='api', location='https://www.mada.pl',
+        )
+        self.variant = self._make_mpd_variant(self.source, variant_uid=777)
+
+        brand = MadaBrand.objects.using(self.mada_db).create(producer_id='1', name='Marka Mada')
+        product = MadaProduct.objects.using(self.mada_db).create(
+            api_id=777, name='Produkt Mada', brand=brand,
+        )
+        self.mada_variant = MadaProductVariant.objects.using(self.mada_db).create(
+            product=product, variant_key='EAN777', stock=17,
+            mapped_variant_uid=self.variant.variant_id, is_mapped=True,
+        )
+
+    def test_zmapowany_wariant_aktualizuje_stock_and_prices(self):
+        result = update_stock_from_mada.apply().get()
+
+        sap = StockAndPrices.objects.using(self.mpd_db).get(variant=self.variant, source=self.source)
+        self.assertEqual(sap.stock, 17)
+        self.assertEqual(result['status'], 'success')
+
+    def test_niezmapowany_wariant_pomijany(self):
+        self.mada_variant.is_mapped = False
+        self.mada_variant.mapped_variant_uid = None
+        self.mada_variant.save()
+
+        result = update_stock_from_mada.apply().get()
+
+        self.assertEqual(result['stats']['checked'], 0)


### PR DESCRIPTION
Closes #270.

## Problem
Eksport do IdoSell/PrestaShop czyta stan wyłącznie z `MPD.StockAndPrices`.
Ten cache dla tabu/mada powstawał **raz**, przy linkowaniu wariantu — nic go
później nie odświeżało. `TabuAdapter`/`MadaAdapter` są używane tylko przy
linkowaniu, **nie** przy eksporcie (dokumentacja wcześniej twierdziła
inaczej — sprostowane w tym samym PR). Dla matterhorn1 istnieje periodic
task `update_stock_from_matterhorn1` (co 5 min, okno 15 min) — dla tabu/mada
nic takiego nie było.

## Zmiany
- Nowy współdzielony `MPD/stock_bridge.py::sync_stock_bridge` — ta sama
  logika co matterhorn1 (warunkowy zapis do `StockAndPrices` + `StockHistory`
  tylko gdy stan się zmienił), ale **bez okna czasowego**: `TabuProductVariant`
  nie ma pola `updated_at`, więc bierze wszystkie `is_mapped=True` warianty
  za każdym razem — warunkowy zapis i tak nic nie robi, gdy stan się nie
  zmienił.
- Nowe taski: `MPD.tasks.update_stock_from_tabu` / `update_stock_from_mada`.
- `setup_stock_sync_task` rozszerzony o `--source {matterhorn1,tabu,mada}`
  (domyślnie `matterhorn1` — identyczna nazwa/task_path/kwargs co przed tym
  PR, żeby ponowne uruchomienie na prod zaktualizowało istniejący wpis, a
  nie stworzyło duplikatu).
- `update_stock_from_matterhorn1` **nietknięty** — działa na produkcji bez
  pokrycia testami, brak powodu ryzykować regresję przy okazji.
- Sprostowanie `docs/tabu/TABU.md` i `docs/mada/MADA.md` — błędnie
  twierdziły, że most matterhorn1 "obsługuje wszystkie hurtownie" / że
  `MadaAdapter` jest używany "przy eksporcie". Update też
  `MPD_STOCK_SYNC_{README,CHANGELOG}.md`, `QUICK_START_STOCK_SYNC.md`,
  `docs/matterhorn/MATTERHORN1.md`.

## Testy
- `tests_stock_bridge.py` — `sync_stock_bridge` (tworzenie/aktualizacja/
  idempotencja — re-run bez zmiany stanu nie tworzy nowego `StockHistory`/
  brak `ProductvariantsSources`/auto-tworzenie źródła) + oba nowe taski
  (zmapowany wariant aktualizuje, niezmapowany pomijany).
- `tests_setup_stock_sync_task.py` — regresja: domyślne (`matterhorn1`)
  zachowanie identyczne jak przed zmianą (ta sama nazwa/task_path/kwargs),
  trzy źródła współistnieją niezależnie (disable/delete jednego nie rusza
  pozostałych).

## Do zrobienia ręcznie po merge
```
docker compose exec web python manage.py setup_stock_sync_task --source tabu
docker compose exec web python manage.py setup_stock_sync_task --source mada
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)